### PR TITLE
Ensure query parameter parsing passes for url's that contain empy key values

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -551,9 +551,11 @@ static Branch *currInstance;
     NSMutableDictionary *params = [[NSMutableDictionary alloc] init];
     for (NSString *pair in pairs) {
         NSArray *kv = [pair componentsSeparatedByString:@"="];
-        NSString *val = [[kv objectAtIndex:1]
-                         stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        [params setObject:val forKey:[kv objectAtIndex:0]];
+        if (kv.count > 1) {
+            NSString *val = [[kv objectAtIndex:1]
+                             stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+            [params setObject:val forKey:[kv objectAtIndex:0]];
+        }
     }
     return params;
 }


### PR DESCRIPTION
We're using branch in our application (imojiapp) and noticed some crashes handling URL's created from within our application. It looks like the branch code for parsing query string parameters is assuming there will be a valid key/value pair, however some URLS's, like ours, don't always send proper paris. 

Example URL:
imojiapp://c?b

The proposed fix is to omit incomplete key value pairs.
