### PR TITLE
SDK-96 disable certificate pinning, bare min requirement

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCConfig.m
+++ b/Branch-SDK/Branch-SDK/BNCConfig.m
@@ -9,7 +9,7 @@
 #include "BNCConfig.h"
 
 NSString * const BNC_API_BASE_URL    = @"https://api2.branch.io";
-BOOL       const BNC_API_PINNED      = YES;
+BOOL       const BNC_API_PINNED      = NO;
 NSString * const BNC_API_VERSION     = @"v1";
 NSString * const BNC_LINK_URL        = @"https://bnc.lt";
 NSString * const BNC_SDK_VERSION     = @"0.25.10";


### PR DESCRIPTION
Please submit your PR against the `staging` branch.

Disable certificate pinning by default.

This can be tested by checking proxying.  With certificate pinning proxying calls will not work.  