### PR TITLE
SDK-301 remove search ads debug.  Apple provides a sample payload on …

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -628,14 +628,6 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 - (void)delayInitToCheckForSearchAds;
 
 /**
- Set the SDK into Apple Search Ad debug mode where it passes fake campaign params back 100%
-
- @warning This should not be used in production.
- */
-- (void)setAppleSearchAdsDebugMode;
-
-
-/**
  Specify the time to wait in seconds between retries in the case of a Branch server error
 
  @param retryInterval Number of seconds to wait between retries.

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -144,7 +144,6 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 @property (assign, nonatomic) BOOL accountForFacebookSDK;
 @property (strong, nonatomic) id FBSDKAppLinkUtility;
 @property (assign, nonatomic) BOOL delayForAppleAds;
-@property (assign, nonatomic) BOOL searchAdsDebugMode;
 @property (strong, nonatomic) NSMutableArray *whiteListedSchemeList;
 @property (strong, nonatomic) BNCURLBlackList *URLBlackList;
 @end
@@ -950,10 +949,6 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
     self.delayForAppleAds = YES;
 }
 
-- (void)setAppleSearchAdsDebugMode {
-    self.searchAdsDebugMode = YES;
-}
-
 - (BOOL)checkAppleSearchAdsAttribution {
     if (!self.delayForAppleAds)
         return NO;
@@ -1000,29 +995,6 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
             if (attrDetails.count > 0 && !error) {
                 [self.preferenceHelper addInstrumentationDictionaryKey:@"apple_search_ad"
                     value:[[NSNumber numberWithInteger:elapsedSeconds*1000] stringValue]];
-            }
-            if (self.searchAdsDebugMode) {
-                // If searchAdsDebugMode is on then force the result to a set value for testing.
-                NSTimeInterval const kOneHour = (60.0*60.0*1.0); // Round down to one day for testing.
-                NSTimeInterval t = trunc([[NSDate date] timeIntervalSince1970] / kOneHour) * kOneHour;
-                NSDate *date = [NSDate dateWithTimeIntervalSince1970:t];
-                attrDetails = @{
-                    @"Version3.1": @{
-                        @"iad-adgroup-id":      @1234567890,
-                        @"iad-adgroup-name":    @"AdGroupName",
-                        @"iad-attribution":     (id)kCFBooleanTrue,
-                        @"iad-campaign-id":     @1234567890,
-                        @"iad-campaign-name":   @"CampaignName",
-                        @"iad-click-date":      date,
-                        @"iad-conversion-date": date,
-                        @"iad-creative-id":     @1234567890,
-                        @"iad-creative-name":   @"CreativeName",
-                        @"iad-keyword":         @"Keyword",
-                        @"iad-lineitem-id":     @1234567890,
-                        @"iad-lineitem-name":   @"LineName",
-                        @"iad-org-name":        @"OrgName"
-                    }
-                };
             }
             if (!error) {
                 if (attrDetails == nil)

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -48,9 +48,6 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Check for Apple Search Ad attribution (trade-off: slows down app startup):
     // [branch delayInitToCheckForSearchAds];
     
-    // Turn this on to debug Apple Search Ads.  Should not be included for production.
-    // [branch setAppleSearchAdsDebugMode];
-    
     // Optional. Use if presenting SFSafariViewController as part of onboarding. Cannot use with setDebug.
     // [self onboardUserOnInstall];
 


### PR DESCRIPTION
Remove redundant Apple Search Ads debug mode.  Apple provides the same type of placeholder data on all debug and simulator builds.  This feature should never be used in production.

