### PR TITLE
SDK-594 fix tune data check only works once

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCTuneUtility.m
+++ b/Branch-SDK/Branch-SDK/BNCTuneUtility.m
@@ -12,7 +12,7 @@
 
 // INTENG-7695 Tune data indicates an app upgrading from Tune SDK to Branch SDK
 + (BOOL)isTuneDataPresent {
-    __block BOOL isPresent = NO;
+    static BOOL isPresent = NO;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         NSString *tuneMatIdKey = @"_TUNE_mat_id";


### PR DESCRIPTION
Silly error.  Missed cause the flag only matters on first install.  But for consistency lets fix this.
