### PR TITLE
SDK-603 use new build system in swift test project

### DIFF
--- a/Branch-TestBed-Swift/TestBed-Swift.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Branch-TestBed-Swift/TestBed-Swift.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
+	<key>PreviewsEnabled</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Source integration of Carthage requires the swift project to build successfully.  Forgot to commit the project settings with the switch to the new build system.

Binary integration works without this change.

