### PR TITLE
SDK-605 add optional config to set the blacklist url

### DIFF
--- a/Branch-SDK-Tests/BNCPreferenceHelperTests.m
+++ b/Branch-SDK-Tests/BNCPreferenceHelperTests.m
@@ -12,30 +12,41 @@
 #import "BNCTestCase.h"
 
 @interface BNCPreferenceHelperTests : BNCTestCase
+@property (nonatomic, strong, readwrite) BNCPreferenceHelper *prefHelper;
 @end
 
 @implementation BNCPreferenceHelperTests
 
-#pragma mark - Default storage tests
+- (void)setUp {
+    self.prefHelper = [BNCPreferenceHelper new];
+}
+
+- (void)tearDown {
+
+}
+
 - (void)testPreferenceDefaults {
-    BNCPreferenceHelper *prefHelper = [[BNCPreferenceHelper alloc] init];
-    
-    // Defaults
-    XCTAssertEqual(prefHelper.timeout, 5.5);
-    XCTAssertEqual(prefHelper.retryInterval, 0);
-    XCTAssertEqual(prefHelper.retryCount, 3);
+    XCTAssertEqual(self.prefHelper.timeout, 5.5);
+    XCTAssertEqual(self.prefHelper.retryInterval, 0);
+    XCTAssertEqual(self.prefHelper.retryCount, 3);
 }
 
 - (void)testPreferenceSets {
-    BNCPreferenceHelper *prefHelper = [[BNCPreferenceHelper alloc] init];
+    self.prefHelper.retryCount = NSIntegerMax;
+    self.prefHelper.retryInterval = NSIntegerMax;
+    self.prefHelper.timeout = NSIntegerMax;
     
-    prefHelper.retryCount = NSIntegerMax;
-    prefHelper.retryInterval = NSIntegerMax;
-    prefHelper.timeout = NSIntegerMax;
+    XCTAssertEqual(self.prefHelper.retryCount, NSIntegerMax);
+    XCTAssertEqual(self.prefHelper.retryInterval, NSIntegerMax);
+    XCTAssertEqual(self.prefHelper.timeout, NSIntegerMax);
+}
+
+- (void)testBlacklistURL {
+    XCTAssertTrue([@"https://cdn.branch.io" isEqualToString:self.prefHelper.branchBlacklistURL]);
     
-    XCTAssertEqual(prefHelper.retryCount, NSIntegerMax);
-    XCTAssertEqual(prefHelper.retryInterval, NSIntegerMax);
-    XCTAssertEqual(prefHelper.timeout, NSIntegerMax);
+    NSString *customBlacklistURL = @"https://blacklist.branch.io";
+    self.prefHelper.branchBlacklistURL = customBlacklistURL;
+    XCTAssertTrue([customBlacklistURL isEqualToString:self.prefHelper.branchBlacklistURL]);
 }
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.h
@@ -46,6 +46,7 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 @property (strong, nonatomic) NSString *browserUserAgentString;
 @property (strong, atomic) NSString *referringURL;
 @property (strong, atomic) NSString *branchAPIURL;
+@property (nonatomic, strong, readwrite) NSString *branchBlacklistURL;
 @property (assign, atomic) BOOL      limitFacebookTracking;
 @property (strong, atomic) NSDate   *previousAppBuildDate;
 

--- a/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/Branch-SDK/BNCPreferenceHelper.m
@@ -108,6 +108,8 @@ static NSString * const BRANCH_PREFS_KEY_ANALYTICS_MANIFEST = @"bnc_branch_analy
     _persistPrefsQueue = [[NSOperationQueue alloc] init];
     _persistPrefsQueue.maxConcurrentOperationCount = 1;
 
+    self.branchBlacklistURL = @"https://cdn.branch.io";
+    
     return self;
 }
 

--- a/Branch-SDK/Branch-SDK/BNCURLBlackList.m
+++ b/Branch-SDK/Branch-SDK/BNCURLBlackList.m
@@ -123,8 +123,7 @@
     self.error = nil;
     NSString *urlString = [self.blackListJSONURL absoluteString];
     if (!urlString) {
-        urlString = [NSString stringWithFormat:@"https://cdn.branch.io/sdk/uriskiplist_v%ld.json",
-            (long) self.blackListVersion+1];
+        urlString = [NSString stringWithFormat:@"%@/sdk/uriskiplist_v%ld.json", [BNCPreferenceHelper preferenceHelper].branchBlacklistURL, (long) self.blackListVersion+1];
     }
     NSMutableURLRequest *request =
         [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]


### PR DESCRIPTION
Example usage:

`[BNCPreferenceHelper preferenceHelper].branchBlacklistURL = @"https://example.com";`

This must be before Branch init.