### PR TITLE
SDK-614 LATD correction

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -952,9 +952,21 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 
 #pragma mark - Query methods
 
+/**
+ Branch includes SDK methods to allow retrieval of our Cross Platform ID (CPID) from the client. This results in an asynchronous call being made to Branch’s servers with CPID data returned when possible.
+ 
+ @param completion callback with cross platform id data
+ */
 - (void)crossPlatformIdDataWithCompletion:(void(^) (BranchCrossPlatformID * _Nullable cpid))completion;
 
-- (void)lastTouchAttributedDataWithCompletion:(void(^) (BranchLastAttributedTouchData * _Nullable ltad))completion;
+/**
+ Branch includes SDK methods to allow retrieval of our last attributed touch data (LATD) from the client. This results in an asynchronous call being made to Branch's servers with LATD data returned when possible.
+ Last attributed touch data contains the information associated with that user's last viewed impression or clicked link.
+ 
+ @param window attribution window in days.  If the window is outside the server supported range, it will default to 30 days.
+ @param completion callback with attribution data
+ */
+- (void)lastAttributedTouchDataWithAttributionWindow:(NSInteger)window completion:(void(^) (BranchLastAttributedTouchData * _Nullable latd))completion;
 
 #pragma mark - Short Url Sync methods
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1199,14 +1199,16 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
 #pragma mark - Query methods
 
 - (void)crossPlatformIdDataWithCompletion:(void(^) (BranchCrossPlatformID * _Nullable cpid))completion {
+    [self initSafetyCheck];
     dispatch_async(self.isolationQueue, ^(){
         [BranchCrossPlatformID requestCrossPlatformIdData:self.serverInterface key:self.class.branchKey completion:completion];
     });
 }
 
-- (void)lastTouchAttributedDataWithCompletion:(void(^) (BranchLastAttributedTouchData * _Nullable ltad))completion {
+- (void)lastAttributedTouchDataWithAttributionWindow:(NSInteger)window completion:(void(^) (BranchLastAttributedTouchData * _Nullable latd))completion {
+    [self initSafetyCheck];
     dispatch_async(self.isolationQueue, ^(){
-        [BranchLastAttributedTouchData requestLastTouchAttributedData:self.serverInterface key:self.class.branchKey completion:completion];
+        [BranchLastAttributedTouchData requestLastTouchAttributedData:self.serverInterface key:self.class.branchKey attributionWindow:window completion:completion];
     });
 }
 

--- a/Branch-SDK/Branch-SDK/BranchLastAttributedTouchData.h
+++ b/Branch-SDK/Branch-SDK/BranchLastAttributedTouchData.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BranchLastAttributedTouchData *)buildFromJSON:(NSDictionary *)json;
 
-+ (void)requestLastTouchAttributedData:(BNCServerInterface *)serverInterface key:(NSString *)key completion:(void(^) (BranchLastAttributedTouchData *latd))completion;
++ (void)requestLastTouchAttributedData:(BNCServerInterface *)serverInterface key:(NSString *)key attributionWindow:(NSInteger)window completion:(void(^) (BranchLastAttributedTouchData *latd))completion;
 
 @end
 

--- a/Branch-SDK/Branch-SDK/BranchLastAttributedTouchData.m
+++ b/Branch-SDK/Branch-SDK/BranchLastAttributedTouchData.m
@@ -9,6 +9,7 @@
 #import "BranchLastAttributedTouchData.h"
 #import "BranchLATDRequest.h"
 #import "BNCJSONUtility.h"
+#import "BNCLog.h"
 
 @implementation BranchLastAttributedTouchData
 
@@ -25,8 +26,16 @@
     return nil;
 }
 
-+ (void)requestLastTouchAttributedData:(BNCServerInterface *)serverInterface key:(NSString *)key completion:(void(^) (BranchLastAttributedTouchData *ltad))completion {
++ (void)requestLastTouchAttributedData:(BNCServerInterface *)serverInterface key:(NSString *)key attributionWindow:(NSInteger)window completion:(void(^) (BranchLastAttributedTouchData *latd))completion {
     BranchLATDRequest *request = [BranchLATDRequest new];
+    
+    // Limit attribution range to about a year.  Although the server only supports up to 90 days as of Nov. 2019, it will fail gracefully for higher values.
+    if (window > -1 && window < 365) {
+        request.attributionWindow = window;
+    } else {
+        BNCLogWarning(@"Attribution window is outside the expected range, using 30 days.");
+    }
+    
     [request makeRequest:serverInterface key:key callback:^(BNCServerResponse *response, NSError *error) {
         
         // error is logged by the network service, skip parsing on error

--- a/Branch-SDK/Branch-SDK/Networking/Requests/BranchLATDRequest.h
+++ b/Branch-SDK/Branch-SDK/Networking/Requests/BranchLATDRequest.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BranchLATDRequest : BNCServerRequest
 
+@property (nonatomic, assign, readwrite) NSInteger attributionWindow;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Branch-SDK/Branch-SDK/Networking/Requests/BranchLATDRequest.m
+++ b/Branch-SDK/Branch-SDK/Networking/Requests/BranchLATDRequest.m
@@ -12,13 +12,21 @@
 
 @implementation BranchLATDRequest
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.attributionWindow = 30;
+    }
+    return self;
+}
+
 - (NSString *)serverURL {
     return [[BNCPreferenceHelper preferenceHelper] getAPIURL:BRANCH_REQUEST_ENDPOINT_LATD];
 }
 
-// all required fields for this request is added by BNCServerInterface
 - (NSMutableDictionary *)buildRequestParams {
     NSMutableDictionary *params = [NSMutableDictionary new];
+    [params setObject:@(self.attributionWindow) forKey:@"attribution_window"];
     return params;
 }
 


### PR DESCRIPTION
Allow attribution window.  

Apparently the server will handle 0, so allow that through.  Block negative numbers and any value greater than a year.
