### PR TITLE
SDK-513 search ads update

### DIFF
--- a/Branch-SDK-Tests/BNCAppleAdClientTests.m
+++ b/Branch-SDK-Tests/BNCAppleAdClientTests.m
@@ -1,0 +1,39 @@
+//
+//  BNCAppleAdClientTests.m
+//  Branch-SDK-Tests
+//
+//  Created by Ernest Cho on 11/7/19.
+//  Copyright © 2019 Branch, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <iAd/iAd.h>
+#import "BNCAppleAdClient.h"
+
+// expose private property for testing
+@interface BNCAppleAdClient()
+
+@property (nonatomic, strong, readwrite) id adClient;
+
+@end
+
+@interface BNCAppleAdClientTests : XCTestCase
+
+@end
+
+@implementation BNCAppleAdClientTests
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+// verifies AdClient loaded via reflection is the sharedClient
+- (void)testReflection {
+    XCTAssertTrue([ADClient sharedClient] == [BNCAppleAdClient new].adClient);
+}
+
+@end

--- a/Branch-SDK-Tests/BNCAppleAdClientTests.m
+++ b/Branch-SDK-Tests/BNCAppleAdClientTests.m
@@ -32,8 +32,27 @@
 }
 
 // verifies AdClient loaded via reflection is the sharedClient
-- (void)testReflection {
+- (void)testAdClientLoadsViaReflection {
     XCTAssertTrue([ADClient sharedClient] == [BNCAppleAdClient new].adClient);
+}
+
+- (void)testErrorOnFailureToLoad {
+    // simulate failure to load by setting adClient to nil
+    BNCAppleAdClient *adClient = [BNCAppleAdClient new];
+    adClient.adClient = nil;
+    
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@""];
+    
+    [adClient requestAttributionDetailsWithBlock:^(NSDictionary<NSString *,NSObject *> * _Nonnull attributionDetails, NSError * _Nonnull error) {
+        XCTAssertNotNil(error);
+        XCTAssertTrue([error.localizedFailureReason containsString:@"ADClient is not available"]);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5 handler:^(NSError * _Nullable error) {
+        NSLog(@"%@", error);
+    }];
 }
 
 @end

--- a/Branch-SDK-Tests/BNCAppleAdClientTests.m
+++ b/Branch-SDK-Tests/BNCAppleAdClientTests.m
@@ -36,12 +36,44 @@
     XCTAssertTrue([ADClient sharedClient] == [BNCAppleAdClient new].adClient);
 }
 
-- (void)testErrorOnFailureToLoad {
+/*
+Expected payload varies by simulator or test device.  In general, there is a payload of some sort.
+
+This test fails on iOS 10 simulators.  Some iPad simulators never respond.  Some iPhone simulators return an error.
+*/
+- (void)testRequestAttribution {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"BNCAppleAdClient"];
+    
+    BNCAppleAdClient *adClient = [BNCAppleAdClient new];
+    [adClient requestAttributionDetailsWithBlock:^(NSDictionary<NSString *,NSObject *> * _Nonnull attributionDetails, NSError * _Nonnull error) {
+        XCTAssertNil(error);
+        
+        id tmp = [attributionDetails objectForKey:@"Version3.1"];
+        if ([tmp isKindOfClass:NSDictionary.class]) {
+            NSDictionary *tmpDict = (NSDictionary *)tmp;
+            XCTAssertNotNil(tmpDict);
+                   
+            NSNumber *tmpBool = [tmpDict objectForKey:@"iad-attribution"];
+            XCTAssertNotNil(tmpBool);
+        } else {
+            XCTFail(@"Did not find Search Ads attribution");
+        }
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5 handler:^(NSError * _Nullable error) {
+        NSLog(@"%@", error);
+    }];
+}
+
+- (void)testRequestAttribution_Error {
+    
     // simulate failure to load by setting adClient to nil
     BNCAppleAdClient *adClient = [BNCAppleAdClient new];
     adClient.adClient = nil;
     
-    __block XCTestExpectation *expectation = [self expectationWithDescription:@""];
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"BNCAppleAdClient"];
     
     [adClient requestAttributionDetailsWithBlock:^(NSDictionary<NSString *,NSObject *> * _Nonnull attributionDetails, NSError * _Nonnull error) {
         XCTAssertNotNil(error);

--- a/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
+++ b/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
@@ -38,6 +38,7 @@
         return;
     }
     
+    // Search Ads requires iOS 10+ but the API is iOS 9+
     if (@available(iOS 9, *)) {
         [[ADClient sharedClient] requestAttributionDetailsWithBlock:completionHandler];
     }

--- a/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
+++ b/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
@@ -7,6 +7,8 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <UIKit/UIKit.h>
+#import <iAd/iAd.h>
 #import "BNCAppleSearchAds.h"
 
 // expose private methods for unit testing
@@ -16,6 +18,7 @@
 - (BOOL)isDateWithinWindow:(NSDate *)installDate;
 - (BOOL)isAdClientAvailable;
 - (BOOL)isAppleTestData:(NSDictionary *)appleSearchAdDetails;
+- (BOOL)isSearchAdsErrorRetryable:(nullable NSError *)error;
 
 - (void)requestAttributionWithCompletion:(void (^_Nullable)(NSDictionary *__nullable attributionDetails, NSError *__nullable error, NSTimeInterval elapsedSeconds))completion;
 
@@ -124,10 +127,38 @@
     XCTAssertFalse([self.appleSearchAds isAppleTestData:testDataIndicators]);
 }
 
+- (void)testIsSearchAdsErrorRetryable_Nil {
+    XCTAssertFalse([self.appleSearchAds isSearchAdsErrorRetryable:nil]);
+}
+
+// ADClientErrorUnknown
+- (void)testIsSearchAdsErrorRetryable_0 {
+    NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorUnknown userInfo:nil];
+    XCTAssertTrue([self.appleSearchAds isSearchAdsErrorRetryable:error]);
+}
+
+// ADClientErrorLimitAdTracking
+- (void)testIsSearchAdsErrorRetryable_1 {
+    NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorLimitAdTracking userInfo:nil];
+    XCTAssertFalse([self.appleSearchAds isSearchAdsErrorRetryable:error]);
+}
+
+// ADClientErrorMissingData
+- (void)testIsSearchAdsErrorRetryable_2 {
+    NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorMissingData userInfo:nil];
+    XCTAssertTrue([self.appleSearchAds isSearchAdsErrorRetryable:error]);
+}
+
+// ADClientErrorCorruptResponse
+- (void)testIsSearchAdsErrorRetryable_3 {
+    NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorCorruptResponse userInfo:nil];
+    XCTAssertTrue([self.appleSearchAds isSearchAdsErrorRetryable:error]);
+}
+
 /*
  Expected payload varies by simulator or test device.  In general, there is a payload of some sort.
  
- This test fails on iOS 10 simulators.  iPad simulators never respond.  iPhone simulators return an error.
+ This test fails on iOS 10 simulators.  Some iPad simulators never respond.  Some iPhone simulators return an error.
  */
 - (void)testRequestAppleSearchAds {
     __block XCTestExpectation *expectation = [self expectationWithDescription:@"AppleSearchAds"];

--- a/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
+++ b/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
@@ -167,25 +167,25 @@
 }
 
 // ADClientErrorUnknown
-- (void)testIsSearchAdsErrorRetryable_0 {
+- (void)testIsSearchAdsErrorRetryable_ADClientErrorUnknown {
     NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorUnknown userInfo:nil];
     XCTAssertTrue([self.appleSearchAds isSearchAdsErrorRetryable:error]);
 }
 
 // ADClientErrorLimitAdTracking
-- (void)testIsSearchAdsErrorRetryable_1 {
+- (void)testIsSearchAdsErrorRetryable_ADClientErrorLimitAdTracking {
     NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorLimitAdTracking userInfo:nil];
     XCTAssertFalse([self.appleSearchAds isSearchAdsErrorRetryable:error]);
 }
 
 // ADClientErrorMissingData
-- (void)testIsSearchAdsErrorRetryable_2 {
+- (void)testIsSearchAdsErrorRetryable_ADClientErrorMissingData {
     NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorMissingData userInfo:nil];
     XCTAssertTrue([self.appleSearchAds isSearchAdsErrorRetryable:error]);
 }
 
 // ADClientErrorCorruptResponse
-- (void)testIsSearchAdsErrorRetryable_3 {
+- (void)testIsSearchAdsErrorRetryable_ADClientErrorCorruptResponse {
     NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorCorruptResponse userInfo:nil];
     XCTAssertTrue([self.appleSearchAds isSearchAdsErrorRetryable:error]);
 }

--- a/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
+++ b/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
@@ -166,25 +166,21 @@
     XCTAssertFalse([self.appleSearchAds isSearchAdsErrorRetryable:nil]);
 }
 
-// ADClientErrorUnknown
 - (void)testIsSearchAdsErrorRetryable_ADClientErrorUnknown {
     NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorUnknown userInfo:nil];
     XCTAssertTrue([self.appleSearchAds isSearchAdsErrorRetryable:error]);
 }
 
-// ADClientErrorLimitAdTracking
 - (void)testIsSearchAdsErrorRetryable_ADClientErrorLimitAdTracking {
     NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorLimitAdTracking userInfo:nil];
     XCTAssertFalse([self.appleSearchAds isSearchAdsErrorRetryable:error]);
 }
 
-// ADClientErrorMissingData
 - (void)testIsSearchAdsErrorRetryable_ADClientErrorMissingData {
     NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorMissingData userInfo:nil];
     XCTAssertTrue([self.appleSearchAds isSearchAdsErrorRetryable:error]);
 }
 
-// ADClientErrorCorruptResponse
 - (void)testIsSearchAdsErrorRetryable_ADClientErrorCorruptResponse {
     NSError *error = [NSError errorWithDomain:@"" code:ADClientErrorCorruptResponse userInfo:nil];
     XCTAssertTrue([self.appleSearchAds isSearchAdsErrorRetryable:error]);

--- a/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
+++ b/Branch-SDK-Tests/BNCAppleSearchAdsTests.m
@@ -10,15 +10,53 @@
 #import <UIKit/UIKit.h>
 #import <iAd/iAd.h>
 #import "BNCAppleSearchAds.h"
+#import "BNCAppleAdClient.h"
 
-// expose private methods for unit testing
+@interface BNCAppleAdClientMock : NSObject <BNCAppleAdClientProtocol>
+
+@property (nonatomic, assign, readwrite) NSInteger ignoreCount;
+@property (nonatomic, assign, readwrite) NSInteger numIgnores;
+
+- (void)requestAttributionDetailsWithBlock:(void (^)(NSDictionary<NSString *,NSObject *> * _Nonnull, NSError * _Nonnull))completionHandler;
+
+@end
+
+@implementation BNCAppleAdClientMock
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.numIgnores = 0;
+        self.ignoreCount = 0;
+    }
+    return self;
+}
+
+- (void)requestAttributionDetailsWithBlock:(void (^)(NSDictionary<NSString *,NSObject *> * _Nonnull, NSError * _Nonnull))completionHandler {
+    if (self.ignoreCount < self.numIgnores) {
+        self.ignoreCount++;
+        return;
+    }
+    
+    if (@available(iOS 9, *)) {
+        [[ADClient sharedClient] requestAttributionDetailsWithBlock:completionHandler];
+    }
+}
+
+@end
+
 @interface BNCAppleSearchAds()
+
+// Expose private methods for testing
+@property (nonatomic, strong, readwrite) id <BNCAppleAdClientProtocol> adClient;
 
 - (BOOL)isAppleSearchAdSavedToDictionary:(NSDictionary *)appleSearchAdDetails;
 - (BOOL)isDateWithinWindow:(NSDate *)installDate;
 - (BOOL)isAdClientAvailable;
 - (BOOL)isAppleTestData:(NSDictionary *)appleSearchAdDetails;
 - (BOOL)isSearchAdsErrorRetryable:(nullable NSError *)error;
+
+- (void)requestAttributionWithMaxAttempts:(NSInteger)maxAttempts completion:(void (^_Nullable)(NSDictionary *__nullable attributionDetails, NSError *__nullable error, NSTimeInterval elapsedSeconds))completion;
 
 - (void)requestAttributionWithCompletion:(void (^_Nullable)(NSDictionary *__nullable attributionDetails, NSError *__nullable error, NSTimeInterval elapsedSeconds))completion;
 
@@ -38,10 +76,6 @@
 
 - (void)tearDown {
 
-}
-
-- (void)testAdClientIsAvailable {
-    XCTAssertTrue([self.appleSearchAds isAdClientAvailable]);
 }
 
 - (void)testDateIsWithinWindow_DistantPast {
@@ -173,6 +207,98 @@
         NSNumber *tmpBool = [tmpDict objectForKey:@"iad-attribution"];
         XCTAssertNotNil(tmpBool);
         
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5 handler:^(NSError * _Nullable error) {
+        NSLog(@"%@", error);
+    }];
+}
+
+// min attempts = 1, so this should ignore the max attempts
+- (void)testRequestAppleSearchAdsWithRetry_0 {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"AppleSearchAds"];
+    
+    [self.appleSearchAds requestAttributionWithMaxAttempts:0 completion:^(NSDictionary * _Nullable attributionDetails, NSError * _Nullable error, NSTimeInterval elapsedSeconds) {
+        XCTAssertNil(error);
+        XCTAssertTrue(elapsedSeconds > 0);
+        
+        NSDictionary *tmpDict = [attributionDetails objectForKey:@"Version3.1"];
+        XCTAssertNotNil(tmpDict);
+        
+        NSNumber *tmpBool = [tmpDict objectForKey:@"iad-attribution"];
+        XCTAssertNotNil(tmpBool);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5 handler:^(NSError * _Nullable error) {
+        NSLog(@"%@", error);
+    }];
+}
+
+// should work as a basic pass through
+- (void)testRequestAppleSearchAdsWithRetry_1 {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"AppleSearchAds"];
+    
+    [self.appleSearchAds requestAttributionWithMaxAttempts:1 completion:^(NSDictionary * _Nullable attributionDetails, NSError * _Nullable error, NSTimeInterval elapsedSeconds) {
+        XCTAssertNil(error);
+        XCTAssertTrue(elapsedSeconds > 0);
+        
+        NSDictionary *tmpDict = [attributionDetails objectForKey:@"Version3.1"];
+        XCTAssertNotNil(tmpDict);
+        
+        NSNumber *tmpBool = [tmpDict objectForKey:@"iad-attribution"];
+        XCTAssertNotNil(tmpBool);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5 handler:^(NSError * _Nullable error) {
+        NSLog(@"%@", error);
+    }];
+}
+
+- (void)testRequestAppleSearchAdsWithRetry_NoResponse {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"AppleSearchAds"];
+
+    // Mock the adClient to never respond
+    self.appleSearchAds.adClient = nil;
+    
+    [self.appleSearchAds requestAttributionWithMaxAttempts:1 completion:^(NSDictionary * _Nullable attributionDetails, NSError * _Nullable error, NSTimeInterval elapsedSeconds) {
+        XCTAssertNotNil(error);
+        XCTAssertTrue(elapsedSeconds > 0);
+        XCTAssertNil(attributionDetails);
+                
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5 handler:^(NSError * _Nullable error) {
+        NSLog(@"%@", error);
+    }];
+}
+
+- (void)testRequestAppleSearchAdsWithRetry_3 {
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"AppleSearchAds"];
+
+    // Mock the adClient to ignore 2 times
+    __block BNCAppleAdClientMock *mock = [BNCAppleAdClientMock new];
+    mock.ignoreCount = 2;
+    self.appleSearchAds.adClient = mock;
+    
+    [self.appleSearchAds requestAttributionWithMaxAttempts:3 completion:^(NSDictionary * _Nullable attributionDetails, NSError * _Nullable error, NSTimeInterval elapsedSeconds) {
+        XCTAssertNil(error);
+        XCTAssertTrue(elapsedSeconds > 0);
+        
+        NSDictionary *tmpDict = [attributionDetails objectForKey:@"Version3.1"];
+        XCTAssertNotNil(tmpDict);
+        
+        NSNumber *tmpBool = [tmpDict objectForKey:@"iad-attribution"];
+        XCTAssertNotNil(tmpBool);
+        
+        // verifies things were ignored
+        XCTAssert(mock.ignoreCount == 2);
+                
         [expectation fulfill];
     }];
     

--- a/Branch-SDK/Branch-SDK/BNCAppleAdClient.h
+++ b/Branch-SDK/Branch-SDK/BNCAppleAdClient.h
@@ -1,0 +1,27 @@
+//
+//  BNCAppleAdClient.h
+//  Branch
+//
+//  Created by Ernest Cho on 11/7/19.
+//  Copyright © 2019 Branch, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// protocol for easier mocking of ADClient behavior in tests
+@protocol BNCAppleAdClientProtocol <NSObject>
+
+@required
+- (void)requestAttributionDetailsWithBlock:(void (^)(NSDictionary<NSString *,NSObject *> *attributionDetails, NSError *error))completionHandler;
+
+@end
+
+@interface BNCAppleAdClient : NSObject <BNCAppleAdClientProtocol>
+
+- (void)requestAttributionDetailsWithBlock:(void (^)(NSDictionary<NSString *,NSObject *> *attributionDetails, NSError *error))completionHandler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Branch-SDK/Branch-SDK/BNCAppleAdClient.m
+++ b/Branch-SDK/Branch-SDK/BNCAppleAdClient.m
@@ -1,0 +1,62 @@
+//
+//  BNCAppleAdClient.m
+//  Branch
+//
+//  Created by Ernest Cho on 11/7/19.
+//  Copyright © 2019 Branch, Inc. All rights reserved.
+//
+
+#import "BNCAppleAdClient.h"
+
+@interface BNCAppleAdClient()
+
+@property (nonatomic, strong, readwrite) Class adClientClass;
+@property (nonatomic, assign, readwrite) SEL adClientSharedClient;
+@property (nonatomic, assign, readwrite) SEL adClientRequestAttribution;
+
+@property (nonatomic, strong, readwrite) id adClient;
+
+@end
+
+// ADClient facade that uses reflection to detect and make it available
+@implementation BNCAppleAdClient
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.adClientClass = NSClassFromString(@"ADClient");
+        self.adClientSharedClient = NSSelectorFromString(@"sharedClient");
+        self.adClientRequestAttribution = NSSelectorFromString(@"requestAttributionDetailsWithBlock:");
+        
+        self.adClient = [self loadAdClient];
+    }
+    return self;
+}
+
+- (id)loadAdClient {
+    if ([self isAdClientAvailable]) {
+        return ((id (*)(id, SEL))[self.adClientClass methodForSelector:self.adClientSharedClient])(self.adClientClass, self.adClientSharedClient);
+    }
+    return nil;
+}
+
+- (BOOL)isAdClientAvailable {
+    BOOL ADClientIsAvailable = self.adClientClass &&
+        [self.adClientClass instancesRespondToSelector:self.adClientRequestAttribution] &&
+        [self.adClientClass methodForSelector:self.adClientSharedClient];
+
+    if (ADClientIsAvailable) {
+        return YES;
+    }
+    return NO;
+}
+
+- (void)requestAttributionDetailsWithBlock:(void (^)(NSDictionary<NSString *,NSObject *> *attributionDetails, NSError *error))completionHandler {
+    if (self.adClient) {
+        ((void (*)(id, SEL, void (^ __nullable)(NSDictionary *__nullable attrDetails, NSError * __nullable error)))
+        [self.adClient methodForSelector:self.adClientRequestAttribution])
+        (self.adClient, self.adClientRequestAttribution, completionHandler);
+    }
+}
+
+@end

--- a/Branch-SDK/Branch-SDK/BNCAppleAdClient.m
+++ b/Branch-SDK/Branch-SDK/BNCAppleAdClient.m
@@ -7,6 +7,7 @@
 //
 
 #import "BNCAppleAdClient.h"
+#import "NSError+Branch.h"
 
 @interface BNCAppleAdClient()
 
@@ -56,6 +57,10 @@
         ((void (*)(id, SEL, void (^ __nullable)(NSDictionary *__nullable attrDetails, NSError * __nullable error)))
         [self.adClient methodForSelector:self.adClientRequestAttribution])
         (self.adClient, self.adClientRequestAttribution, completionHandler);
+    } else {
+        if (completionHandler) {
+            completionHandler(nil, [NSError branchErrorWithCode:BNCGeneralError localizedMessage:@"ADClient is not available. Requires iAD.framework and iOS 10+"]);
+        }
     }
 }
 

--- a/Branch-SDK/Branch-SDK/BNCAppleReceipt.m
+++ b/Branch-SDK/Branch-SDK/BNCAppleReceipt.m
@@ -46,11 +46,11 @@
     NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
     if (receiptURL) {
         self.isSandboxReceipt = [receiptURL.lastPathComponent isEqualToString:@"sandboxReceipt"];
-    }
-    
-    NSData *receiptData = [NSData dataWithContentsOfURL:receiptURL];
-    if (receiptData) {
-        self.receipt = [receiptData base64EncodedStringWithOptions:0];
+        
+        NSData *receiptData = [NSData dataWithContentsOfURL:receiptURL];
+        if (receiptData) {
+            self.receipt = [receiptData base64EncodedStringWithOptions:0];
+        }
     }
 }
 

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
@@ -18,9 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BNCAppleSearchAds *)sharedInstance;
 
-// Apple suggests a longer delay, however this is detrimental to app launch times
-- (void)useAppleRecommendedDelay;
-
 // Checks Apple Search Ads and updates preferences
 // This method blocks the thread, it should only be called on a background thread.
 - (void)checkAppleSearchAdsSaveTo:(BNCPreferenceHelper *)preferenceHelper installDate:(NSDate *)installDate completion:(void (^_Nullable)(void))completion;

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
@@ -14,10 +14,15 @@ NS_ASSUME_NONNULL_BEGIN
 @interface BNCAppleSearchAds : NSObject
 
 @property (nonatomic, assign, readwrite) BOOL enableAppleSearchAdsCheck;
+@property (nonatomic, assign, readwrite) BOOL ignoreAppleTestData;
 
 + (BNCAppleSearchAds *)sharedInstance;
 
-// checks Apple Search Ads and updates preferences.  This acquires a lock on BNCPreferenceHelper.
+// Apple suggests a longer delay, however this is detrimental to app launch times
+- (void)useAppleRecommendedDelay;
+
+// Checks Apple Search Ads and updates preferences
+// This method blocks the thread, it should only be called on a background thread.
 - (void)checkAppleSearchAdsSaveTo:(BNCPreferenceHelper *)preferenceHelper installDate:(NSDate *)installDate completion:(void (^_Nullable)(void))completion;
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
@@ -18,6 +18,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BNCAppleSearchAds *)sharedInstance;
 
+// Default delay and retry configuration.  ~p95
+// typically less than 1s delay, up to 3.5s delay on first app start
+- (void)useBranchConfig;
+
+// Apple suggests a longer delay, however this is detrimental to app launch times
+// typically less than 1s delay, up to 14s delay on first app start
+- (void)useAppleConfig;
+
 // Checks Apple Search Ads and updates preferences
 // This method blocks the thread, it should only be called on a background thread.
 - (void)checkAppleSearchAdsSaveTo:(BNCPreferenceHelper *)preferenceHelper installDate:(NSDate *)installDate completion:(void (^_Nullable)(void))completion;

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BNCAppleSearchAds *)sharedInstance;
 
-// Default delay and retry configuration.  ~p95
+// Default delay and retry configuration.  ~p90
 // typically less than 1s delay, up to 3.5s delay on first app start
 - (void)useBranchConfig;
 

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.h
@@ -20,11 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Default delay and retry configuration.  ~p90
 // typically less than 1s delay, up to 3.5s delay on first app start
-- (void)useBranchConfig;
+- (void)useDefaultAppleSearchAdsConfig;
 
 // Apple suggests a longer delay, however this is detrimental to app launch times
 // typically less than 1s delay, up to 14s delay on first app start
-- (void)useAppleConfig;
+- (void)useLongWaitAppleSearchAdsConfig;
 
 // Checks Apple Search Ads and updates preferences
 // This method blocks the thread, it should only be called on a background thread.

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
@@ -11,9 +11,20 @@
 #import <UIKit/UIKit.h>
 
 @interface BNCAppleSearchAds()
+
 @property (nonatomic, strong, readwrite) Class adClientClass;
 @property (nonatomic, assign, readwrite) SEL adClientSharedClient;
 @property (nonatomic, assign, readwrite) SEL adClientRequestAttribution;
+
+// Maximum number of tries
+@property (nonatomic, assign, readwrite) NSInteger maxAttempts;
+
+// Apple recommends waiting a bit before checking search ads and waiting between retries.
+@property (nonatomic, assign, readwrite) NSTimeInterval delay;
+
+// Apple recommends implementing our own timeout per request to Apple Search Ads
+@property (nonatomic, assign, readwrite) NSTimeInterval timeOut;
+
 @end
 
 @implementation BNCAppleSearchAds
@@ -34,64 +45,112 @@
         self.adClientClass = NSClassFromString(@"ADClient");
         self.adClientSharedClient = NSSelectorFromString(@"sharedClient");
         self.adClientRequestAttribution = NSSelectorFromString(@"requestAttributionDetailsWithBlock:");
+        
+        self.ignoreAppleTestData = NO;
+        [self useBranchRecommendedDelay];
     }
     return self;
 }
 
+// Based on discussions with Apple, our default values are p95
+- (void)useBranchRecommendedDelay {
+    self.delay = 0.5;
+    self.maxAttempts = 1;
+    self.timeOut = 3.0;
+}
+
+// Apple suggests a longer delay, however this is detrimental to app launch times
+- (void)useAppleRecommendedDelay {
+    self.delay = 2.0;
+    self.maxAttempts = 2;
+    self.timeOut = 5.0;
+}
+
 // business logic around checking and storing Apple Search Ads attribution
 - (void)checkAppleSearchAdsSaveTo:(BNCPreferenceHelper *)preferenceHelper installDate:(NSDate *)installDate completion:(void (^_Nullable)(void))completion {
-    if (!self.enableAppleSearchAdsCheck) {
-        if (completion) {
-            completion();
-        }
-        return;
-    }
     
-    if ([self isAppleSearchAdSavedToDictionary:preferenceHelper.appleSearchAdDetails]) {
-        if (completion) {
-            completion();
-        }
-        return;
-    }
-    
-    if (![self isDateWithinWindow:installDate]) {
-        if (completion) {
-            completion();
-        }
-        return;
-    }
-    
-    if (![self isAdClientAvailable]) {
-        if (completion) {
-            completion();
-        }
-        return;
-    }
-    
-    [self requestAttributionWithCompletion:^(NSDictionary * _Nullable attributionDetails, NSError * _Nullable error, NSTimeInterval elapsedSeconds) {
-        // BNCPreferenceHelper should be responsible for correctly storing and resetting this
-        @synchronized (preferenceHelper) {
-            if (attributionDetails.count > 0 && !error) {
-                [preferenceHelper addInstrumentationDictionaryKey:@"apple_search_ad" value:[[NSNumber numberWithInteger:elapsedSeconds*1000] stringValue]];
-            }
-            if (!error) {
-                if (attributionDetails == nil) {
-                    attributionDetails = @{};
-                }
-                if (preferenceHelper.appleSearchAdDetails == nil) {
-                    preferenceHelper.appleSearchAdDetails = @{};
-                }
-                if (![preferenceHelper.appleSearchAdDetails isEqualToDictionary:attributionDetails]) {
-                    preferenceHelper.appleSearchAdDetails = attributionDetails;
-                    preferenceHelper.appleSearchAdNeedsSend = YES;
-                }
-            }
-        }
+    // several conditions where we do not check apple search ads
+    if (!self.enableAppleSearchAdsCheck ||
+        [self isAppleSearchAdSavedToDictionary:preferenceHelper.appleSearchAdDetails] ||
+        ![self isDateWithinWindow:installDate]) {
         
         if (completion) {
             completion();
         }
-    }];
+        return;
+    }
+    
+    // recursive retry using blocks.  maybe I should have tried to rework this into a loop.
+    __block NSInteger attempts = 1;
+    
+    // define the retry block
+    __block void (^retryBlock)(NSDictionary *attrDetails, NSError *error, NSTimeInterval elapsedSeconds);
+    
+    // define a weak version of the retry block
+    __unsafe_unretained __block void (^weakRetryBlock)(NSDictionary *attrDetails, NSError *error, NSTimeInterval elapsedSeconds);
+    
+    // retry block will retry the call to Apple Search Ads using the weak retry block on retryable error
+    retryBlock = ^ void(NSDictionary * _Nullable attributionDetails, NSError * _Nullable error, NSTimeInterval elapsedSeconds) {
+        if ([self isSearchAdsErrorRetryable:error] && attempts < self.maxAttempts) {
+            attempts++;
+            [self requestAttributionWithCompletion:weakRetryBlock];
+            
+        } else {
+            
+            if (self.ignoreAppleTestData && [self isAppleTestData:attributionDetails]) {
+                [self saveToPreferences:preferenceHelper attributionDetails:@{} error:error elapsedSeconds:elapsedSeconds];
+
+            } else {
+            
+                // save search ads data for future use and callback
+                [self saveToPreferences:preferenceHelper attributionDetails:attributionDetails error:error elapsedSeconds:elapsedSeconds];
+            }
+            
+            if (completion) {
+                completion();
+            }
+        }
+    };
+    
+    // set the weak retryblock as the retryblock
+    weakRetryBlock = retryBlock;
+    
+    [self requestAttributionWithCompletion:retryBlock];
+}
+
+/*
+ Apple recommends retrying the following error codes
+
+ ADClientErrorUnknown = 0
+ ADClientErrorMissingData = 2
+ ADClientErrorCorruptResponse = 3
+ */
+- (BOOL)isSearchAdsErrorRetryable:(nullable NSError *)error {
+    if (error && (error.code == 0 || error.code == 2 || error.code == 3)) {
+        return YES;
+    }
+    return NO;
+}
+
+// Eventually BNCPreferenceHelper should be responsible for correctly storing data
+- (void)saveToPreferences:(BNCPreferenceHelper *)preferenceHelper attributionDetails:(nullable NSDictionary *)attributionDetails error:(nullable NSError *)error elapsedSeconds:(NSTimeInterval)elapsedSeconds {
+    @synchronized (preferenceHelper) {
+        if (attributionDetails.count > 0 && !error) {
+            [preferenceHelper addInstrumentationDictionaryKey:@"apple_search_ad" value:[[NSNumber numberWithInteger:elapsedSeconds*1000] stringValue]];
+        }
+        if (!error) {
+            if (attributionDetails == nil) {
+                attributionDetails = @{};
+            }
+            if (preferenceHelper.appleSearchAdDetails == nil) {
+                preferenceHelper.appleSearchAdDetails = @{};
+            }
+            if (![preferenceHelper.appleSearchAdDetails isEqualToDictionary:attributionDetails]) {
+                preferenceHelper.appleSearchAdDetails = attributionDetails;
+                preferenceHelper.appleSearchAdNeedsSend = YES;
+            }
+        }
+    }
 }
 
 - (BOOL)isAppleSearchAdSavedToDictionary:(NSDictionary *)appleSearchAdDetails {
@@ -168,51 +227,65 @@ Printing description of attributionDetails:
         [@"OrgName" isEqualToString:[tmp objectForKey:@"iad-org-name"]]) {
         return YES;
     }
-    
     return NO;
 }
 
-// iOS 10, iPad simulators never respond.
-- (BOOL)isBrokenSimulator {
-    #if TARGET_OS_SIMULATOR
-    UIDevice *currentDevice = [UIDevice currentDevice];
-    double version = [currentDevice.systemVersion doubleValue];
-    if ([currentDevice.model rangeOfString:@"iPad"].location != NSNotFound && version < 11.0) {
-        return YES;
-    }
-    #endif
-    return NO;
-}
-
+// This method blocks the thread, it should only be called on a background thread.
 - (void)requestAttributionWithCompletion:(void (^_Nullable)(NSDictionary *__nullable attributionDetails, NSError *__nullable error, NSTimeInterval elapsedSeconds))completion {
-    if (![self isAdClientAvailable]) {
-        if (completion) {
-            completion(nil, [NSError branchErrorWithCode:BNCGeneralError localizedMessage:@"ADClient is not available. Requires iAD.framework and iOS 10+"], 0);
-        }
-        return;
-    }
     
-    if ([self isBrokenSimulator]) {
-        if (completion) {
-            completion(nil, [NSError branchErrorWithCode:BNCGeneralError localizedMessage:@"AdClient does not callback on the iOS 10, iPad Simulators"], 0);
-        }
-        return;
-    }
+    // Apple recommends waiting for a short delay between requests for Search Ads, even the very first request to Apple Search Ads
+    [NSThread sleepForTimeInterval:self.delay];
     
+    // track timeout
+    __block BOOL searchAdsResponded = NO;
+    __block BOOL timedOut = NO;
+    __block NSObject *timedOutLock = [NSObject new];
+    
+    // track apple search ads API performance
+    __block NSDate *startDate = [NSDate date];
+    
+    // get ADClint using reflection
     id adClient = ((id (*)(id, SEL))[self.adClientClass methodForSelector:self.adClientSharedClient])(self.adClientClass, self.adClientSharedClient);
     
-    __block NSDate *startDate = [NSDate date];
-    void (^__nullable completionBlock)(NSDictionary *attrDetails, NSError *error) = ^ void(NSDictionary *__nullable attributionDetails, NSError *__nullable error) {        
-        NSTimeInterval elapsedSeconds = - [startDate timeIntervalSinceNow];
+    // block to handle ADClient response
+    void (^__nullable completionBlock)(NSDictionary *attrDetails, NSError *error) = ^ void(NSDictionary *__nullable attributionDetails, NSError *__nullable error) {
+
+        // skip callback if request already timed out
+        @synchronized (timedOutLock) {
+            if (timedOut) {
+                return;
+            } else {
+                searchAdsResponded = YES;
+            }
+        }
         
+        // callback with Apple Search Ads data
+        NSTimeInterval elapsedSeconds = -[startDate timeIntervalSinceNow];
         if (completion) {
             completion(attributionDetails, error, elapsedSeconds);
         }
     };
 
+    // call Apple Search Ads via reflection
     ((void (*)(id, SEL, void (^ __nullable)(NSDictionary *__nullable attrDetails, NSError * __nullable error)))
     [adClient methodForSelector:self.adClientRequestAttribution])
     (adClient, self.adClientRequestAttribution, completionBlock);
+    
+    // timer for timeout, this is racing the call to Apple Search Ads
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.timeOut * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        @synchronized (timedOutLock) {
+            if (searchAdsResponded) {
+                return;
+            } else {
+                timedOut = YES;
+            }
+        }
+        
+        NSTimeInterval elapsedSeconds = -[startDate timeIntervalSinceNow];
+        if (completion) {
+            completion(nil, [NSError branchErrorWithCode:BNCGeneralError localizedMessage:@"AdClient timed out"], elapsedSeconds);
+        }
+    });
 }
 
 @end

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
@@ -237,8 +237,7 @@ Printing description of attributionDetails:
     [NSThread sleepForTimeInterval:self.delay];
     
     // track timeout
-    __block BOOL searchAdsResponded = NO;
-    __block BOOL timedOut = NO;
+    __block BOOL raceIsOver = NO;
     __block NSObject *timedOutLock = [NSObject new];
     
     // track apple search ads API performance
@@ -252,10 +251,10 @@ Printing description of attributionDetails:
 
         // skip callback if request already timed out
         @synchronized (timedOutLock) {
-            if (timedOut) {
+            if (raceIsOver) {
                 return;
             } else {
-                searchAdsResponded = YES;
+                raceIsOver = YES;
             }
         }
         
@@ -274,10 +273,10 @@ Printing description of attributionDetails:
     // timer for timeout, this is racing the call to Apple Search Ads
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.timeOut * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         @synchronized (timedOutLock) {
-            if (searchAdsResponded) {
+            if (raceIsOver) {
                 return;
             } else {
-                timedOut = YES;
+                raceIsOver = YES;
             }
         }
         

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
@@ -44,14 +44,14 @@
         
         self.enableAppleSearchAdsCheck = NO;
         self.ignoreAppleTestData = NO;
-        [self useBranchConfig];
+        [self useDefaultAppleSearchAdsConfig];
     }
     return self;
 }
 
 // Default delay and retry configuration.  ~p90
 // typically less than 1s delay, up to 3.5s delay on first app start
-- (void)useBranchConfig {
+- (void)useDefaultAppleSearchAdsConfig {
     self.delay = 0.5;
     self.maxAttempts = 1;
     self.timeOut = 3.0;
@@ -59,7 +59,7 @@
 
 // Apple suggests a longer delay, however this is detrimental to app launch times
 // typically less than 1s delay, up to 14s delay on first app start
-- (void)useAppleConfig {
+- (void)useLongWaitAppleSearchAdsConfig {
     self.delay = 2.0;
     self.maxAttempts = 2;
     self.timeOut = 5.0;

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
@@ -49,7 +49,7 @@
     return self;
 }
 
-// Default delay and retry configuration.  ~p95
+// Default delay and retry configuration.  ~p90
 // typically less than 1s delay, up to 3.5s delay on first app start
 - (void)useBranchConfig {
     self.delay = 0.5;

--- a/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
+++ b/Branch-SDK/Branch-SDK/BNCAppleSearchAds.m
@@ -233,8 +233,8 @@ Printing description of attributionDetails:
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.delay * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 
         // track timeout
-        __block BOOL raceIsOver = NO;
-        __block NSObject *raceLock = [NSObject new];
+        __block BOOL completed = NO;
+        __block NSObject *lock = [NSObject new];
         
         // track apple search ads API performance
         __block NSDate *startDate = [NSDate date];
@@ -242,11 +242,11 @@ Printing description of attributionDetails:
         [self.adClient requestAttributionDetailsWithBlock:^(NSDictionary<NSString *,NSObject *> * _Nonnull attributionDetails, NSError * _Nonnull error) {
             
             // skip callback if request already timed out
-            @synchronized (raceLock) {
-                if (raceIsOver) {
+            @synchronized (lock) {
+                if (completed) {
                     return;
                 } else {
-                    raceIsOver = YES;
+                    completed = YES;
                 }
             }
             
@@ -259,11 +259,11 @@ Printing description of attributionDetails:
         
         // Apple recommends we implement our own timeout, this is racing the call to Apple Search Ads
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.timeOut * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            @synchronized (raceLock) {
-                if (raceIsOver) {
+            @synchronized (lock) {
+                if (completed) {
                     return;
                 } else {
-                    raceIsOver = YES;
+                    completed = YES;
                 }
             }
             

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -626,15 +626,15 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 /**
  Check for Apple Search Ads before initialization.
  
- This will add about 1 second to first time startup.  Up to 3.5 seconds if Apple Search Ads fails to respond.
+ This will usually add less than 1 second to first time startup.  Up to 3.5 seconds if Apple Search Ads fails to respond.
  */
 - (void)delayInitToCheckForSearchAds;
 
 /**
  Increases the amount of time the SDK waits for Apple Search Ads to respond.
- The default wait has a better than 95% success rate, however waiting longer can improve success rate.
+ The default wait has a better than 90% success rate, however waiting longer can improve the success rate.
 
- This will increase the wait up to about 15 seconds if Apple Search Ads fails to respond.
+ This will increase the usual delay to about 3 seconds to first time startup.  Up to about 15 seconds if Apple Search Ads fails to respond.
  */
 - (void)useLongerWaitForAppleSearchAds;
 

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -625,6 +625,7 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 
 /**
  Check for Apple Search Ads before initialization.
+ 
  This will add about 1 second to first time startup.  Up to 3.5 seconds if Apple Search Ads fails to respond.
  */
 - (void)delayInitToCheckForSearchAds;
@@ -636,6 +637,13 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  This will increase the wait up to about 15 seconds if Apple Search Ads fails to respond.
  */
 - (void)useLongerWaitForAppleSearchAds;
+
+/**
+ Ignores Apple Search Ads test data.
+ 
+ Apple returns test data for all calls made to the Apple Search Ads API on developer and testflight builds.
+ */
+- (void)ignoreAppleSearchAdsTestData;
 
 /**
  Specify the time to wait in seconds between retries in the case of a Branch server error

--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -624,9 +624,18 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 - (void)registerFacebookDeepLinkingClass:(id)FBSDKAppLinkUtility;
 
 /**
- Check for Apple Search Ads before initialization. Will add about 1 second from call to initSession to callback due to Apple's latency.
+ Check for Apple Search Ads before initialization.
+ This will add about 1 second to first time startup.  Up to 3.5 seconds if Apple Search Ads fails to respond.
  */
 - (void)delayInitToCheckForSearchAds;
+
+/**
+ Increases the amount of time the SDK waits for Apple Search Ads to respond.
+ The default wait has a better than 95% success rate, however waiting longer can improve success rate.
+
+ This will increase the wait up to about 15 seconds if Apple Search Ads fails to respond.
+ */
+- (void)useLongerWaitForAppleSearchAds;
 
 /**
  Specify the time to wait in seconds between retries in the case of a Branch server error

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -895,6 +895,10 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
     [BNCAppleSearchAds sharedInstance].enableAppleSearchAdsCheck = YES;
 }
 
+- (void)useLongerWaitForAppleSearchAds {
+    [[BNCAppleSearchAds sharedInstance] useAppleConfig];
+}
+
 - (void)checkAppleSearchAdsAttribution {
     if (![BNCAppleSearchAds sharedInstance].enableAppleSearchAdsCheck) {
         return;

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -896,7 +896,7 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
 }
 
 - (void)useLongerWaitForAppleSearchAds {
-    [[BNCAppleSearchAds sharedInstance] useAppleConfig];
+    [[BNCAppleSearchAds sharedInstance] useLongWaitAppleSearchAdsConfig];
 }
 
 - (void)ignoreAppleSearchAdsTestData {

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -899,6 +899,10 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
     [[BNCAppleSearchAds sharedInstance] useAppleConfig];
 }
 
+- (void)ignoreAppleSearchAdsTestData {
+    [BNCAppleSearchAds sharedInstance].ignoreAppleTestData = YES;
+}
+
 - (void)checkAppleSearchAdsAttribution {
     if (![BNCAppleSearchAds sharedInstance].enableAppleSearchAdsCheck) {
         return;

--- a/Branch-SDK/Branch-SDK/BranchCrossPlatformID.h
+++ b/Branch-SDK/Branch-SDK/BranchCrossPlatformID.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, readonly) NSString *crossPlatformID;
 @property (nonatomic, copy, readonly) NSNumber *score;
 
-+ (BranchProbabilisticCrossPlatformID *)buildFromJSON:(NSDictionary *)json;
++ (nullable BranchProbabilisticCrossPlatformID *)buildFromJSON:(NSDictionary *)json;
 
 @end
 
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSArray<NSString *> *pastCrossPlatformIDs;
 @property (nonatomic, strong, readonly) NSArray<BranchProbabilisticCrossPlatformID *> *probabiliticCrossPlatformIDs;
 
-+ (BranchCrossPlatformID *)buildFromJSON:(NSDictionary *)json;
++ (nullable BranchCrossPlatformID *)buildFromJSON:(NSDictionary *)json;
 
 + (void)requestCrossPlatformIdData:(BNCServerInterface *)serverInterface key:(NSString *)key completion:(void(^) (BranchCrossPlatformID * _Nullable cpid))completion;
 

--- a/Branch-SDK/Branch-SDK/BranchLastAttributedTouchData.h
+++ b/Branch-SDK/Branch-SDK/BranchLastAttributedTouchData.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, readonly) NSNumber *attributionWindow;
 
-+ (BranchLastAttributedTouchData *)buildFromJSON:(NSDictionary *)json;
++ (nullable BranchLastAttributedTouchData *)buildFromJSON:(NSDictionary *)json;
 
 + (void)requestLastTouchAttributedData:(BNCServerInterface *)serverInterface key:(NSString *)key attributionWindow:(NSInteger)window completion:(void(^) (BranchLastAttributedTouchData *latd))completion;
 

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -170,6 +170,9 @@
 		5F3D671F2330638D00454FF1 /* cpid.json in Resources */ = {isa = PBXBuildFile; fileRef = 5F3D671E2330638D00454FF1 /* cpid.json */; };
 		5F44AC3E2339474B007A9A7C /* cpid_empty_dev_id.json in Resources */ = {isa = PBXBuildFile; fileRef = 5F44AC3A23394742007A9A7C /* cpid_empty_dev_id.json */; };
 		5F44AC3F2339474B007A9A7C /* cpid_missing_dev_id.json in Resources */ = {isa = PBXBuildFile; fileRef = 5F44AC3B23394742007A9A7C /* cpid_missing_dev_id.json */; };
+		5F5EC45B2374D95300AAAFC7 /* BNCAppleAdClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F5EC4592374D95300AAAFC7 /* BNCAppleAdClient.h */; };
+		5F5EC45C2374D95300AAAFC7 /* BNCAppleAdClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F5EC45A2374D95300AAAFC7 /* BNCAppleAdClient.m */; };
+		5F5EC4602374E96B00AAAFC7 /* BNCAppleAdClientTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F5EC45F2374E96B00AAAFC7 /* BNCAppleAdClientTests.m */; };
 		5F67F48E228F535500067429 /* BNCEncodingUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F67F48D228F535500067429 /* BNCEncodingUtilsTests.m */; };
 		5F73FC7E23313F7A000EBD32 /* BNCJSONUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F73FC7C23313F7A000EBD32 /* BNCJSONUtility.h */; };
 		5F73FC7F23313F7A000EBD32 /* BNCJSONUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F73FC7D23313F7A000EBD32 /* BNCJSONUtility.m */; };
@@ -435,6 +438,9 @@
 		5F3D671E2330638D00454FF1 /* cpid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = cpid.json; sourceTree = "<group>"; };
 		5F44AC3A23394742007A9A7C /* cpid_empty_dev_id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = cpid_empty_dev_id.json; sourceTree = "<group>"; };
 		5F44AC3B23394742007A9A7C /* cpid_missing_dev_id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = cpid_missing_dev_id.json; sourceTree = "<group>"; };
+		5F5EC4592374D95300AAAFC7 /* BNCAppleAdClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BNCAppleAdClient.h; sourceTree = "<group>"; };
+		5F5EC45A2374D95300AAAFC7 /* BNCAppleAdClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCAppleAdClient.m; sourceTree = "<group>"; };
+		5F5EC45F2374E96B00AAAFC7 /* BNCAppleAdClientTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCAppleAdClientTests.m; sourceTree = "<group>"; };
 		5F67F48D228F535500067429 /* BNCEncodingUtilsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCEncodingUtilsTests.m; sourceTree = "<group>"; };
 		5F73FC7C23313F7A000EBD32 /* BNCJSONUtility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BNCJSONUtility.h; sourceTree = "<group>"; };
 		5F73FC7D23313F7A000EBD32 /* BNCJSONUtility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCJSONUtility.m; sourceTree = "<group>"; };
@@ -664,6 +670,7 @@
 			children = (
 				5F3D671D2330638D00454FF1 /* cannedData */,
 				5FC7326F22DD1F93006E6FBC /* BNCAppleReceiptTests.m */,
+				5F5EC45F2374E96B00AAAFC7 /* BNCAppleAdClientTests.m */,
 				5F892EBA2360F0290023AEC1 /* BNCAppleSearchAdsTests.m */,
 				5F892ECD23624E0A0023AEC1 /* BNCFacebookAppLinksTests.m */,
 				5F205D022318641700C776D1 /* BNCUserAgentCollectorTests.m */,
@@ -848,6 +855,8 @@
 			children = (
 				5F892ED7236258390023AEC1 /* BNCFacebookAppLinks.h */,
 				5F892ED6236258390023AEC1 /* BNCFacebookAppLinks.m */,
+				5F5EC4592374D95300AAAFC7 /* BNCAppleAdClient.h */,
+				5F5EC45A2374D95300AAAFC7 /* BNCAppleAdClient.m */,
 				5F892EB72360EFE90023AEC1 /* BNCAppleSearchAds.h */,
 				5F892EB62360EFE90023AEC1 /* BNCAppleSearchAds.m */,
 				5FC7326622D81002006E6FBC /* BNCAppleReceipt.h */,
@@ -963,6 +972,7 @@
 				9A2B7DD51FEC3BAF00CD188B /* Branch+Validator.h in Headers */,
 				F185BAAA1F3D30D70056300C /* BNCSpotlightService.h in Headers */,
 				4DCAC80F1F426F7C00405D1D /* BNCAvailability.h in Headers */,
+				5F5EC45B2374D95300AAAFC7 /* BNCAppleAdClient.h in Headers */,
 				4D955CCC2035021400FB8008 /* BNCURLBlackList.h in Headers */,
 				E2B9474A1D15D75000F2270D /* BNCCallbacks.h in Headers */,
 				4DCAC8011F426F7C00405D1D /* BNCCommerceEvent.h in Headers */,
@@ -1290,6 +1300,7 @@
 				5F892EB82360EFE90023AEC1 /* BNCAppleSearchAds.m in Sources */,
 				466B58591B17779C00A69EDE /* BNCPreferenceHelper.m in Sources */,
 				4D8999ED1DC108FF00F7EE0A /* BNCAvailability.m in Sources */,
+				5F5EC45C2374D95300AAAFC7 /* BNCAppleAdClient.m in Sources */,
 				4D59B5222006979C00F89FD5 /* BNCKeyChain.m in Sources */,
 				F1D359211ED4DCC500A93FD5 /* BNCDeepLinkViewControllerInstance.m in Sources */,
 				466B585F1B17779C00A69EDE /* BNCSystemObserver.m in Sources */,
@@ -1397,6 +1408,7 @@
 				4D7881FF209CF2D4002B750F /* BNCApplication+BNCTest.m in Sources */,
 				5F3D671B233062FD00454FF1 /* BNCJsonLoader.m in Sources */,
 				4D1683C02098C902008819E3 /* BranchUniversalObject.Test.m in Sources */,
+				5F5EC4602374E96B00AAAFC7 /* BNCAppleAdClientTests.m in Sources */,
 				4D1683B52098C902008819E3 /* BNCLocalization.Test.m in Sources */,
 				5FC7327022DD1F93006E6FBC /* BNCAppleReceiptTests.m in Sources */,
 				4D1683C82098C902008819E3 /* NSString+Branch.Test.m in Sources */,

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -81,7 +81,6 @@
 		4D59B5202006979C00F89FD5 /* BNCApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D59B51C2006979B00F89FD5 /* BNCApplication.m */; };
 		4D59B5212006979C00F89FD5 /* BNCKeyChain.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D59B51D2006979C00F89FD5 /* BNCKeyChain.h */; };
 		4D59B5222006979C00F89FD5 /* BNCKeyChain.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D59B51E2006979C00F89FD5 /* BNCKeyChain.m */; };
-		4D698B7D1FB287A700AFF38C /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67163AAD1B9A036F007A8AB1 /* SafariServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		4D7881F7209CF28F002B750F /* BNCThreads.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D7881F5209CF28E002B750F /* BNCThreads.m */; };
 		4D7881F8209CF28F002B750F /* BNCThreads.h in Headers */ = {isa = PBXBuildFile; fileRef = 4D7881F6209CF28E002B750F /* BNCThreads.h */; };
 		4D7881FD209CF2D4002B750F /* BNCTestCase.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4D7881F9209CF2D4002B750F /* BNCTestCase.strings */; };
@@ -221,7 +220,6 @@
 		6700166E1940F51400A9E103 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6700166C1940F51400A9E103 /* InfoPlist.strings */; };
 		670016701940F51400A9E103 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6700166F1940F51400A9E103 /* main.m */; };
 		6700167A1940F51400A9E103 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 670016791940F51400A9E103 /* ViewController.m */; };
-		67163AAE1B9A036F007A8AB1 /* SafariServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67163AAD1B9A036F007A8AB1 /* SafariServices.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		677F4CB51C1FB1910029F2B3 /* Branch-TestBed.entitlements in Resources */ = {isa = PBXBuildFile; fileRef = 677F4CB41C1FB0FA0029F2B3 /* Branch-TestBed.entitlements */; };
 		67F270891BA9FCFF002546A7 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		7B18DF491F1F00E200C25C84 /* BNCCrashlyticsWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B18DF471F1F00E200C25C84 /* BNCCrashlyticsWrapper.h */; };
@@ -548,7 +546,6 @@
 				466B584F1B17775900A69EDE /* AdSupport.framework in Frameworks */,
 				F1CF14111F4CC79F00BB2694 /* CoreSpotlight.framework in Frameworks */,
 				466B58521B17776500A69EDE /* Foundation.framework in Frameworks */,
-				4D698B7D1FB287A700AFF38C /* SafariServices.framework in Frameworks */,
 				4D1851C120180F3300E48994 /* Security.framework in Frameworks */,
 				466B58531B17776A00A69EDE /* UIKit.framework in Frameworks */,
 			);
@@ -572,7 +569,6 @@
 				67F270891BA9FCFF002546A7 /* CoreSpotlight.framework in Frameworks */,
 				670016641940F51400A9E103 /* Foundation.framework in Frameworks */,
 				4DDC52621DCC08E700CFB737 /* iAd.framework in Frameworks */,
-				67163AAE1B9A036F007A8AB1 /* SafariServices.framework in Frameworks */,
 				466B58811B1778DB00A69EDE /* libBranch.a in Frameworks */,
 				670016681940F51400A9E103 /* UIKit.framework in Frameworks */,
 			);

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -46,7 +46,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     //[branch validateSDKIntegration];
 
     // Check for Apple Search Ad attribution (trade-off: slows down app startup):
-    // [branch delayInitToCheckForSearchAds];
+    [branch delayInitToCheckForSearchAds];
     
     // Optional. Use if presenting SFSafariViewController as part of onboarding. Cannot use with setDebug.
     // [self onboardUserOnInstall];

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -13,14 +13,6 @@
 #import "Branch.h"
 #import "BNCEncodingUtils.h"
 
-// Ignore Safari availability for iOS 8 and lower in this example.
-#pragma clang diagnostic ignored "-Wpartial-availability"
-#pragma clang diagnostic ignored "-Wunguarded-availability"
-
-@interface AppDelegate() <SFSafariViewControllerDelegate>
-@property (nonatomic, strong) SFSafariViewController *onboardingVC;
-@end
-
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application
@@ -47,9 +39,6 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
     // Check for Apple Search Ad attribution (trade-off: slows down app startup):
     [branch delayInitToCheckForSearchAds];
-    
-    // Optional. Use if presenting SFSafariViewController as part of onboarding. Cannot use with setDebug.
-    // [self onboardUserOnInstall];
 
     /*
      *    Required: Initialize Branch, passing a deep link handler block:
@@ -116,43 +105,6 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
                 deeplinkText, [[[Branch getInstance] getLatestReferringParams] description]];
         logOutputViewController.logOutput = logOutput;
     }
-}
-
-- (void)onboardUserOnInstall {
-    NSURL *urlForOnboarding = [NSURL URLWithString:@"http://example.com"]; // Put your onboarding link here
-    
-    id notInstall = [[NSUserDefaults standardUserDefaults] objectForKey:@"notInstall"];
-    if (!notInstall) {
-        [[NSUserDefaults standardUserDefaults] setObject:@YES forKey:@"notInstall"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-
-        Branch *branch = [Branch getInstance];
-
-        // Note that this must be invoked *before* initSession
-        [branch enableDelayedInit];
-
-        NSURL *updatedUrlForOnboarding = [branch getUrlForOnboardingWithRedirectUrl:urlForOnboarding.absoluteString];
-        if (updatedUrlForOnboarding) {
-            // replace url for onboarding with the URL provided by Branch
-            urlForOnboarding = updatedUrlForOnboarding;
-        }
-        else {
-            // do not replace url for onboarding
-            NSLog(@"Was unable to get onboarding URL from Branch SDK, so proceeding with normal onboarding URL.");
-            [branch disableDelayedInit];
-        }
-
-        self.onboardingVC = [[SFSafariViewController alloc] initWithURL:urlForOnboarding];
-        self.onboardingVC.delegate = self;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[[[UIApplication sharedApplication].delegate window] rootViewController]
-                 presentViewController:self.onboardingVC animated:YES completion:NULL];
-        });
-    }
-}
-
-- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
-    [[Branch getInstance] resumeInit];
 }
 
 - (BOOL)application:(UIApplication *)application

--- a/Branch-TestBed/Branch-TestBed/Branch-TestBed-Prefix.pch
+++ b/Branch-TestBed/Branch-TestBed/Branch-TestBed-Prefix.pch
@@ -6,18 +6,12 @@
 
 #import <Availability.h>
 
-#ifndef __IPHONE_5_0
-#warning "This project uses features only available in iOS SDK 5.0 and later."
-#endif
-
 #ifdef __OBJC__
     #if __has_feature(modules)
     @import Foundation;
     @import UIKit;
-    @import SafariServices;
     #else
     #import <Foundation/Foundation.h>
     #import <UIKit/UIKit.h>
-    #import <SafariServices/SafariServices.h>
     #endif
 #endif


### PR DESCRIPTION
See ticket for background information on this design. 

1.  Used the same delay for first and every retry.  Which is different from spec.
2.  No public API to modify behavior, negotiating with Product on that.
3.  Missing end to end tests around delay, retry and time outs.