### PR TITLE
SDK-450 rare serialization issue

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCCommerceEvent.m
+++ b/Branch-SDK/Branch-SDK/BNCCommerceEvent.m
@@ -605,7 +605,7 @@ NSArray<BNCCurrency>* BNCCurrencyAllCurrencies(void) {
     self = [super initWithCoder:decoder];
 	if (!self) return self;
 	self.commerceDictionary = [decoder decodeObjectOfClass:NSDictionary.class forKey:@"commerceDictionary"];
-	self.metadata = [decoder decodeObjectOfClass:NSDictionary.class forKey:@"metaData"];
+	self.metadata = [decoder decodeObjectOfClass:NSDictionary.class forKey:@"metadata"];
     return self;
 }
 

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1931,7 +1931,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
                 
             }
 
-            dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+            dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
             dispatch_async(queue, ^ {
                 [req makeRequest:self.serverInterface key:self.class.branchKey callback:
                     ^(BNCServerResponse* response, NSError* error) {


### PR DESCRIPTION
Blind fix attempt for a rare crash I'm not able to repro.

1.  Typo in serialization for commerce event.
2.  Queue priorities are now set to default.  

