### PR TITLE
SDK-667 add fallback for no modules

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCAppleReceipt.h
+++ b/Branch-SDK/Branch-SDK/BNCAppleReceipt.h
@@ -6,7 +6,11 @@
 //  Copyright © 2019 Branch, Inc. All rights reserved.
 //
 
+#if __has_feature(modules)
 @import Foundation;
+#else
+#import <Foundation/Foundation.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Branch-SDK/Branch-SDK/BNCUserAgentCollector.h
+++ b/Branch-SDK/Branch-SDK/BNCUserAgentCollector.h
@@ -6,7 +6,11 @@
 //  Copyright © 2019 Branch, Inc. All rights reserved.
 //
 
+#if __has_feature(modules)
 @import Foundation;
+#else
+#import <Foundation/Foundation.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Branch-SDK/Branch-SDK/BNCUserAgentCollector.m
+++ b/Branch-SDK/Branch-SDK/BNCUserAgentCollector.m
@@ -9,7 +9,11 @@
 #import "BNCUserAgentCollector.h"
 #import "BNCPreferenceHelper.h"
 #import "BNCDeviceSystem.h"
+#if __has_feature(modules)
 @import WebKit;
+#else
+#import <WebKit/WebKit.h>
+#endif
 
 @interface BNCUserAgentCollector()
 // need to hold onto the webview until the async user agent fetch is done

--- a/Branch-SDK/Branch-SDK/NSError+Branch.h
+++ b/Branch-SDK/Branch-SDK/NSError+Branch.h
@@ -8,7 +8,11 @@
  @copyright     Copyright © 2014 Branch. All rights reserved.
 */
 
+#if __has_feature(modules)
 @import Foundation;
+#else
+#import <Foundation/Foundation.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
C++ does not enable modules by default.  Add fallbacks to support it.

