### PR TITLE
improve BranchEvent's contentItems and customData properties

### DIFF
--- a/Branch-SDK/Branch-SDK/BranchEvent.h
+++ b/Branch-SDK/Branch-SDK/BranchEvent.h
@@ -85,8 +85,8 @@ typedef NS_ENUM(NSInteger, BranchEventAdType) {
 @property (nonatomic, assign) BranchEventAdType                 adType;
 
 
-@property (nonatomic, copy) NSMutableArray<BranchUniversalObject*>*_Nonnull       contentItems;
-@property (nonatomic, copy) NSMutableDictionary<NSString*, NSString*> *_Nonnull   customData;
+@property (nonatomic, copy) NSArray<BranchUniversalObject*>*_Nonnull       contentItems;
+@property (nonatomic, copy) NSDictionary<NSString*, NSString*> *_Nonnull   customData;
 
 - (void) logEvent;                      //!< Logs the event on the Branch server.
 - (NSDictionary*_Nonnull) dictionary;   //!< Returns a dictionary representation of the event.

--- a/Branch-SDK/Branch-SDK/BranchEvent.m
+++ b/Branch-SDK/Branch-SDK/BranchEvent.m
@@ -103,12 +103,8 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
 
 #pragma mark - BranchEvent
 
-@interface BranchEvent () {
-    NSMutableDictionary *_customData;
-    NSMutableArray      *_contentItems;
-}
+@interface BranchEvent ()
 @property (nonatomic, strong) NSString*  eventName;
-
 @end
 
 @implementation BranchEvent : NSObject
@@ -117,7 +113,8 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
     self = [super init];
     if (!self) return self;
     _eventName = name;
-    
+    _contentItems = [NSArray new];
+    _customData = [NSDictionary new];
     _adType = BranchEventAdTypeNone;
     return self;
 }
@@ -130,7 +127,7 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
                withContentItem:(BranchUniversalObject*)contentItem {
     BranchEvent *e = [BranchEvent standardEvent:standardEvent];
     if (contentItem) {
-        e.contentItems = (NSMutableArray*) @[ contentItem ];
+        e.contentItems = @[ contentItem ];
     }
     return e;
 }
@@ -143,34 +140,9 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
                          contentItem:(BranchUniversalObject*)contentItem {
     BranchEvent *e = [BranchEvent customEventWithName:name];
     if (contentItem) {
-        e.contentItems = (NSMutableArray*) @[ contentItem ];
+        e.contentItems = @[ contentItem ];
     }
     return e;
-}
-
-- (NSMutableDictionary*) customData {
-    if (!_customData) _customData = [NSMutableDictionary new];
-    return _customData;
-}
-
-- (void) setCustomData:(NSMutableDictionary<NSString *,NSString *> *)userInfo {
-    _customData = [userInfo mutableCopy];
-}
-
-- (NSMutableArray*) contentItems {
-    if (!_contentItems) _contentItems = [NSMutableArray new];
-    return _contentItems;
-}
-
-- (void) setContentItems:(NSMutableArray<BranchUniversalObject *> *)contentItems {
-    
-    
-    if ([contentItems isKindOfClass:[BranchUniversalObject class]]) {
-        _contentItems = [NSMutableArray arrayWithObject:contentItems];
-    } else
-    if ([contentItems isKindOfClass:[NSArray class]]) {
-        _contentItems = [contentItems mutableCopy];
-    }
 }
 
 - (NSString *)jsonStringForAdType:(BranchEventAdType)adType {


### PR DESCRIPTION
The contentItems and customData properties of BranchEvent are unnecessarily using mutable collection objects, rather than immutable ones.

Casting a NSDictionary to NSMutableDictionary does not actually make it a mutable dictionary. It just makes the compiler *think* that it is mutable, allowing the developer to call a method that only applies to mutable collections on an immutable one, which causes a crash.