### PR TITLE
SDK-713 fix log event error

### DIFF
--- a/Branch-SDK/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch-SDK/Branch.h
@@ -1697,7 +1697,7 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
     __attribute__((deprecated(("This API is deprecated. Please use BranchEvent:BranchStandardEventViewItem instead."))));
 
 - (void) sendServerRequest:(BNCServerRequest*)request;
-- (void) sendServerRequestWithoutSession:(BNCServerRequest*)request;
+- (void) sendServerRequestWithoutSession:(BNCServerRequest*)request __attribute__((deprecated(("This API is deprecated. Please use sendServerRequest instead."))));
 
 /**
  This is the block that is called each time a new Branch session is started. It is automatically set

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1964,7 +1964,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 // There is a follow up ticket to improve this.  SDK-633
 - (void)initSafetyCheck {
     if (self.initializationStatus == BNCInitStatusUninitialized) {
-        BNCLogWarning(@"Branch avoided an error by preemptively initializing.");
+        BNCLogDebug(@"Branch avoided an error by preemptively initializing.");
         [self initUserSessionAndCallCallback:NO];
     }
 }

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1052,9 +1052,9 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
     });
 }
 
+// deprecated, use sendServerRequest
 - (void)sendServerRequestWithoutSession:(BNCServerRequest*)request {
-    [self.requestQueue enqueue:request];
-    [self processNextQueueItem];
+    [self sendServerRequest:request];
 }
 
 - (void)sendCommerceEvent:(BNCCommerceEvent *)commerceEvent metadata:(NSDictionary*)metadata withCompletion:(void (^)(NSDictionary *, NSError *))completion {

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -121,9 +121,6 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 // This isolation queue protects branch initialization and ensures things are processed in order.
 @property (nonatomic, strong, readwrite) dispatch_queue_t isolationQueue;
 
-// SDK-716 used to confirm init is on queue
-@property (nonatomic, assign, readwrite) BOOL initSessionHasBeenCalled;
-
 @property (strong, nonatomic) BNCServerInterface *serverInterface;
 @property (strong, nonatomic) BNCServerRequestQueue *requestQueue;
 @property (strong, nonatomic) dispatch_semaphore_t processing_sema;
@@ -232,7 +229,6 @@ void BranchClassInitializeLog(void) {
         
     // Initialize instance variables
     self.isolationQueue = dispatch_queue_create([@"branchIsolationQueue" UTF8String], DISPATCH_QUEUE_SERIAL);
-    self.initSessionHasBeenCalled = NO;
     
     _serverInterface = interface;
     _serverInterface.preferenceHelper = preferenceHelper;
@@ -608,11 +604,6 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
       automaticallyDisplayController:(BOOL)automaticallyDisplayController {
     
     [self.class addBranchSDKVersionToCrashlyticsReport];
-    
-    @synchronized (self) {
-        self.initSessionHasBeenCalled = YES;
-    }
-    
     self.shouldAutomaticallyDeepLink = automaticallyDisplayController;
 
     // If the SDK is already initialized, this means that initSession was called after other lifecycle calls.
@@ -1972,16 +1963,8 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 // Some methods require init before they are called.  Instead of returning an error, we try to fix the situation by calling init ourselves.
 // There is a follow up ticket to improve this.  SDK-633
 - (void)initSafetyCheck {
-    
-    // SDK-716 user has already queued init via initSession
-    @synchronized (self) {
-        if (self.initSessionHasBeenCalled) {
-            return;
-        }
-    }
-    
     if (self.initializationStatus == BNCInitStatusUninitialized) {
-        BNCLogWarning(@"Branch avoided an error by preemptively initializing.");
+        BNCLogDebug(@"Branch avoided an error by preemptively initializing.");
         [self initUserSessionAndCallCallback:NO];
     }
 }

--- a/Branch-SDK/Branch-SDK/BranchEvent.m
+++ b/Branch-SDK/Branch-SDK/BranchEvent.m
@@ -229,7 +229,7 @@ BranchStandardEvent BranchStandardEventReserve                = @"RESERVE";
 
     NSDictionary *eventDictionary = [self buildEventDictionary];
     BranchEventRequest *request = [self buildRequestWithEventDictionary:eventDictionary];
-    [[Branch getInstance] sendServerRequestWithoutSession:request];
+    [[Branch getInstance] sendServerRequest:request];
 }
 
 - (BranchEventRequest *)buildRequestWithEventDictionary:(NSDictionary *)eventDictionary {


### PR DESCRIPTION
Found while researching INTENG-7730

Calling logEvent before init can complete leads to inconsistent behavior.  This could result in a deferred deeplink arriving late.
