### PR TITLE
SDK-717 convert cpu type to a string

### DIFF
--- a/Branch-SDK-Tests/BNCDeviceInfoTests.m
+++ b/Branch-SDK-Tests/BNCDeviceInfoTests.m
@@ -59,13 +59,13 @@
 }
 
 - (void)testCpuType_Simulator {
-    NSNumber *expected = @(7);
-    XCTAssert([expected isEqualToNumber:self.deviceInfo.cpuType]);
+    NSString *expected = @"7";
+    XCTAssert([expected isEqualToString:self.deviceInfo.cpuType]);
 }
 
 //- (void)testCpuType_iPhone7 {
-//    NSNumber *expected = @(16777228);
-//    XCTAssert([expected isEqualToNumber:self.deviceInfo.cpuType]);
+//    NSString *expected = @"16777228";
+//    XCTAssert([expected isEqualToString:self.deviceInfo.cpuType]);
 //}
 
 - (void)testScreenWidth {

--- a/Branch-SDK/Branch-SDK/BNCDeviceInfo.h
+++ b/Branch-SDK/Branch-SDK/BNCDeviceInfo.h
@@ -45,7 +45,7 @@
 @property (nonatomic, copy, readwrite) NSString *osVersion;
 @property (nonatomic, copy, readwrite) NSString *osBuildVersion;
 @property (nonatomic, copy, readwrite) NSString *extensionType;
-@property (nonatomic, copy, readwrite) NSNumber *cpuType;
+@property (nonatomic, copy, readwrite) NSString *cpuType;
 @property (nonatomic, copy, readwrite) NSNumber *screenWidth;
 @property (nonatomic, copy, readwrite) NSNumber *screenHeight;
 @property (nonatomic, copy, readwrite) NSNumber *screenScale;

--- a/Branch-SDK/Branch-SDK/BNCDeviceInfo.m
+++ b/Branch-SDK/Branch-SDK/BNCDeviceInfo.m
@@ -79,7 +79,11 @@
     self.osName = [BNCSystemObserver getOS];
     self.osVersion = [BNCSystemObserver getOSVersion];
     self.osBuildVersion = deviceSystem.systemBuildVersion;
-    self.cpuType = deviceSystem.cpuType;
+    
+    if (deviceSystem.cpuType) {
+        self.cpuType = [deviceSystem.cpuType stringValue];
+    }
+    
     self.screenWidth = [BNCSystemObserver getScreenWidth];
     self.screenHeight = [BNCSystemObserver getScreenHeight];
     self.screenScale = @([UIScreen mainScreen].scale);


### PR DESCRIPTION
Server release today broke the iOS SDK 0.31.x series.  Fixing it on the client side first.
