### PR TITLE
SDK-422 object cache improvement

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.h
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.h
@@ -42,7 +42,7 @@ extern NSString* BNCWireFormatFromString(NSString *string);
 + (NSString *)base64EncodeData:(NSData *)objData;
 + (NSData *)base64DecodeString:(NSString *)strBase64;
 
-+ (NSString *)md5Encode:(NSString *)input;
++ (NSString *)sha256Encode:(NSString *)input;
 
 + (NSString *)urlEncodedString:(NSString *)string;
 + (NSString *)encodeArrayToJsonString:(NSArray *)dictionary;

--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
@@ -105,20 +105,20 @@ NSString* BNCWireFormatFromString(NSString *string) {
     return nil;
 }
 
-#pragma mark - MD5 methods
+#pragma mark - SHA 256 methods
 
-+ (NSString *)md5Encode:(NSString *)input {
++ (NSString *)sha256Encode:(NSString *)input {
     if (!input) {
         return @"";
     }
-
+    
     const char *cStr = [input UTF8String];
-    unsigned char digest[CC_MD5_DIGEST_LENGTH];
-    CC_MD5(cStr, (CC_LONG)strlen(cStr), digest);
+    unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(cStr, (CC_LONG)strlen(cStr), digest);
+
+    NSMutableString *output = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 2];
     
-    NSMutableString *output = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
-    
-    for (int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
         [output appendFormat:@"%02x", digest[i]];
     }
 

--- a/Branch-SDK/Branch-SDK/BNCLinkData.m
+++ b/Branch-SDK/Branch-SDK/BNCLinkData.m
@@ -122,16 +122,16 @@
 
     NSString *encodedParams = [BNCEncodingUtils encodeDictionaryToJsonString:self.params];
     result = prime * result + self.type;
-    result = prime * result + [[BNCEncodingUtils md5Encode:self.alias] hash];
-    result = prime * result + [[BNCEncodingUtils md5Encode:self.channel] hash];
-    result = prime * result + [[BNCEncodingUtils md5Encode:self.feature] hash];
-    result = prime * result + [[BNCEncodingUtils md5Encode:self.stage] hash];
-    result = prime * result + [[BNCEncodingUtils md5Encode:self.campaign] hash];
-    result = prime * result + [[BNCEncodingUtils md5Encode:encodedParams] hash];
+    result = prime * result + [[BNCEncodingUtils sha256Encode:self.alias] hash];
+    result = prime * result + [[BNCEncodingUtils sha256Encode:self.channel] hash];
+    result = prime * result + [[BNCEncodingUtils sha256Encode:self.feature] hash];
+    result = prime * result + [[BNCEncodingUtils sha256Encode:self.stage] hash];
+    result = prime * result + [[BNCEncodingUtils sha256Encode:self.campaign] hash];
+    result = prime * result + [[BNCEncodingUtils sha256Encode:encodedParams] hash];
     result = prime * result + self.duration;
     
     for (NSString *tag in self.tags) {
-        result = prime * result + [[BNCEncodingUtils md5Encode:tag] hash];
+        result = prime * result + [[BNCEncodingUtils sha256Encode:tag] hash];
     }
     
     return result;

--- a/Branch-SDK/Branch-SDK/BranchContentDiscoverer.m
+++ b/Branch-SDK/Branch-SDK/BranchContentDiscoverer.m
@@ -253,7 +253,7 @@
         contentData = [contentData substringToIndex:self.contentManifest.maxTextLen];
     }
     if (!isClearText) {
-        contentData = [BNCEncodingUtils md5Encode:contentData];
+        contentData = [BNCEncodingUtils sha256Encode:contentData];
     }
     if (contentData)
         [contentDataArray addObject:contentData];


### PR DESCRIPTION
Used an MD5 to create keys for an object cache, this triggers security scanners.  Replace this code.

