### PR TITLE
SDK-886 `getDefaultUriScheme breaks if URI scheme used for Branch is not first`

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.h
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.h
@@ -19,6 +19,7 @@
                           andType:(NSString *__autoreleasing*)type;
 + (NSString *)getVendorId;
 + (NSString *)getDefaultUriScheme;
++ (NSArray *) getAllClientUriSchemes;
 + (NSString *)getAppVersion;
 + (NSString *)getBundleID;
 + (NSString *)getTeamIdentifier;

--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.m
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.m
@@ -86,6 +86,22 @@
     return YES;
 }
 
++ (NSArray *) filterOutSanPrefixs:(NSArray*)urlSchemes {
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"NOT SELF BEGINSWITH[c] %@", @"fb", @"db", @"twitterkit-", @"pdk", @"pin", @"com.googleusercontent.apps"];
+    NSArray *filteredArray = [urlSchemes filteredArrayUsingPredicate:predicate];
+    return filteredArray;
+}
+
++ (NSArray *) getAllClientUriSchemes {
+    NSMutableArray *usersUriSchemes = [NSMutableArray new];
+    for (NSDictionary *urlType in [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"]) {
+        for (NSString *uriScheme in [urlType objectForKey:@"CFBundleURLSchemes"]) {
+            [usersUriSchemes addObject:uriScheme];
+        }
+    }
+    return [self filterOutSanPrefixs:usersUriSchemes];
+}
+
 + (NSString *)getDefaultUriScheme {
     NSArray *urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
 

--- a/Branch-SDK/Branch-SDK/BNCSystemObserver.m
+++ b/Branch-SDK/Branch-SDK/BNCSystemObserver.m
@@ -86,12 +86,23 @@
     return YES;
 }
 
+/**
+ @brief Filters out any URI scheme that would be used by a SAN provider (facebook, twitter, etc)
+ @discussion This method will accept an array of URI schemes Strings and will return another array with only the URI schemes that were created by the client.
+ @param urlSchemes The array of URI schemes to be filtered
+ @return NSArray The filtered array which only contains client generated URI schemes
+ */
 + (NSArray *) filterOutSanPrefixs:(NSArray*)urlSchemes {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"NOT SELF BEGINSWITH[c] %@", @"fb", @"db", @"twitterkit-", @"pdk", @"pin", @"com.googleusercontent.apps"];
     NSArray *filteredArray = [urlSchemes filteredArrayUsingPredicate:predicate];
     return filteredArray;
 }
 
+/**
+ @brief Will return an array of all client URI schemes from the plist file
+ @discussion This method will loop through every URL type and retrieve the URL scheme then return the filtered array with only client URI schemes
+ @return NSArray The filtered array which contains client generated URI schcmes 
+ */
 + (NSArray *) getAllClientUriSchemes {
     NSMutableArray *usersUriSchemes = [NSMutableArray new];
     for (NSDictionary *urlType in [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"]) {

--- a/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
+++ b/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>AppIdentifierPrefix</key>
 	<string>$(AppIdentifierPrefix)</string>
-	<key>BranchLogLevel</key>
-	<string>BNCLogLevelAll</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -27,16 +25,6 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>branchtest2</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>branchtest</string>
@@ -61,13 +49,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>branch_key</key>
-	<dict>
-		<key>live</key>
-		<string>key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv</string>
-		<key>test</key>
-		<string>key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc</string>
-	</dict>
+	<key>BranchLogLevel</key>
+	<string>BNCLogLevelAll</string>
 	<key>branch_universal_link_domains</key>
 	<array>
 		<string>bnctestbed.app.link</string>
@@ -75,5 +58,12 @@
 		<string>bnctestbed-alternate.app.link</string>
 		<string>bnc.lt</string>
 	</array>
+	<key>branch_key</key>
+	<dict>
+		<key>live</key>
+		<string>key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv</string>
+		<key>test</key>
+		<string>key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc</string>
+	</dict>
 </dict>
 </plist>

--- a/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
+++ b/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
@@ -42,14 +42,6 @@
 				<string>branchtest</string>
 			</array>
 		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>fb</string>
-			</array>
-		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>

--- a/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
+++ b/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>AppIdentifierPrefix</key>
 	<string>$(AppIdentifierPrefix)</string>
+	<key>BranchLogLevel</key>
+	<string>BNCLogLevelAll</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -25,9 +27,27 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>branchtest2</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>branchtest</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>fb</string>
 			</array>
 		</dict>
 	</array>
@@ -49,15 +69,6 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>BranchLogLevel</key>
-	<string>BNCLogLevelAll</string>
-	<key>branch_universal_link_domains</key>
-	<array>
-		<string>bnctestbed.app.link</string>
-		<string>bnctestbed.test-app.link</string>
-		<string>bnctestbed-alternate.app.link</string>
-		<string>bnc.lt</string>
-	</array>
 	<key>branch_key</key>
 	<dict>
 		<key>live</key>
@@ -65,5 +76,12 @@
 		<key>test</key>
 		<string>key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc</string>
 	</dict>
+	<key>branch_universal_link_domains</key>
+	<array>
+		<string>bnctestbed.app.link</string>
+		<string>bnctestbed.test-app.link</string>
+		<string>bnctestbed-alternate.app.link</string>
+		<string>bnc.lt</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This PR is a solution to SDK-886 where the validation fails if the URI scheme used for Branch is not the first in the plist file.  I did notice that `getDefaultUriScheme()` is used in more areas than just in the validation logic which is why I decided to create a new function to keep it separate to not interfere with internal logic.  I think since `getDefaultUriScheme()` only checks for the 1st entry we should refactor that to use the validated URI scheme that matches the server side URI scheme (if it exists) but didn't want to make that decision in this PR.  Just some thoughts!

Unit Testing Note:
I am having issues running unit tests locally.  I have unit tests created for the new methods but whenever I try to run them I am unable to build successful to run the tests thus I am not sure if they working correctly.  The tests are not included in this PR, but will be after I figure out the issue.  If we could have a working session to possibly solve my problem faster, I'd appreciate it!  Just wanted to give you a look into the solution in case I went down the wrong path to save time.  

