### PR TITLE
Fix warning: MobileCoreServices has been renamed. Use CoreServices instead.

### DIFF
--- a/Branch.podspec
+++ b/Branch.podspec
@@ -27,7 +27,7 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
 
   s.subspec 'Core' do |core|
     core.source_files = source_files
-    core.frameworks = 'AdSupport', 'MobileCoreServices', 'WebKit', 'iAd', 'SystemConfiguration', 'CoreTelephony'
+    core.frameworks = 'AdSupport', 'WebKit', 'iAd', 'SystemConfiguration', 'CoreTelephony'
   end
 
 end


### PR DESCRIPTION
Close #1012 #999

If our library was installed via CocoaPods, Xcode 11.4 will issue the warning "MobileCoreServices has been renamed. Use CoreServices instead.".

![image](https://user-images.githubusercontent.com/526008/77892980-eecffd80-72a5-11ea-891b-78acd78d4b7c.png)

How to fix: Do not explicitly link `MobileCoreServices.framework` in the CocoaPods generated project, by deleting `MobileCoreServices` from the `spec.frameworks` attribute in our podspec file.

More info: https://github.com/AFNetworking/AFNetworking/pull/4532
