### PR TITLE
[SDK-992] Update repo URL and homepage in podspec

### DIFF
--- a/Branch.podspec
+++ b/Branch.podspec
@@ -12,10 +12,10 @@ Pod::Spec.new do |s|
 
 Use the Branch SDK (branch.io) to create and power the links that point back to your apps for all of these things and more. Branch makes it incredibly simple to create powerful deep links that can pass data across app install and open while handling all edge cases (using on desktop vs. mobile vs. already having the app installed, etc). Best of all, it's really simple to start using the links for your own app: only 2 lines of code to register the deep link router and one more line of code to create the links with custom data.
                        DESC
-  s.homepage         = "https://branch.io"
+  s.homepage         = "https://help.branch.io/developers-hub/docs/ios-sdk-overview"
   s.license          = 'MIT'
   s.author           = { "Branch" => "support@branch.io" }
-  s.source           = { git: "https://github.com/BranchMetrics/iOS-Deferred-Deep-Linking-SDK.git", tag: s.version.to_s }
+  s.source           = { git: "https://github.com/BranchMetrics/ios-branch-deep-linking-attribution", tag: s.version.to_s }
   s.platform         = :ios, '8.0'
   s.requires_arc     = true
 


### PR DESCRIPTION
Updating the repo URL in the podspec to the current URL, instead of an old one requiring a redirect.

Also updated the homepage element to point to the docs. I've been doing that elsewhere: web, RN, C++.

~~Still need to test this.~~ Works when testing from my local copy with `pod 'Branch', path: '...'`.
