### PR TITLE
Fixing sanitized string

### DIFF
--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
@@ -142,6 +142,10 @@ NSString* BNCWireFormatFromString(NSString *string) {
 }
 
 + (NSString *)sanitizedStringFromString:(NSString *)dirtyString {
+    if ([dirtyString isEqual:[NSNull null]]) {
+        return @"";
+    }
+    
     NSString *dirtyCopy = [dirtyString copy]; // dirtyString seems to get dealloc'ed sometimes. Make a copy.
     NSString *cleanString = [[[[[[[[dirtyCopy
         stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"]

--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
@@ -142,10 +142,6 @@ NSString* BNCWireFormatFromString(NSString *string) {
 }
 
 + (NSString *)sanitizedStringFromString:(NSString *)dirtyString {
-    if ([dirtyString isEqual:[NSNull null]]) {
-        return @"";
-    }
-    
     NSString *dirtyCopy = [dirtyString copy]; // dirtyString seems to get dealloc'ed sometimes. Make a copy.
     NSString *cleanString = [[[[[[[[dirtyCopy
         stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"]

--- a/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
+++ b/Branch-SDK/Branch-SDK/BNCEncodingUtils.m
@@ -175,6 +175,7 @@ NSString* BNCWireFormatFromString(NSString *string) {
             continue;
         }
         
+        NSString *key = key;
         NSString *value = nil;
         BOOL string = YES;
         

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1932,11 +1932,10 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
             }
 
             dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-            __weak __typeof__(self) weakSelf = self;
             dispatch_async(queue, ^ {
-                [req makeRequest:weakSelf.serverInterface key:weakSelf.class.branchKey callback:
-                 ^(BNCServerResponse* response, NSError* error) {
-                    [weakSelf processRequest:req response:response error:error];
+                [req makeRequest:self.serverInterface key:self.class.branchKey callback:
+                    ^(BNCServerResponse* response, NSError* error) {
+                        [self processRequest:req response:response error:error];
                 }];
             });
         }

--- a/Branch-SDK/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch-SDK/Branch.m
@@ -1932,10 +1932,11 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
             }
 
             dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+            __weak __typeof__(self) weakSelf = self;
             dispatch_async(queue, ^ {
-                [req makeRequest:self.serverInterface key:self.class.branchKey callback:
-                    ^(BNCServerResponse* response, NSError* error) {
-                        [self processRequest:req response:response error:error];
+                [req makeRequest:weakSelf.serverInterface key:weakSelf.class.branchKey callback:
+                 ^(BNCServerResponse* response, NSError* error) {
+                    [weakSelf processRequest:req response:response error:error];
                 }];
             });
         }


### PR DESCRIPTION
Hi, I've reproduced [this issue](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/issues/918).
CMIIW, I think the culprit is the NSString pointer on https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/blob/master/Branch-SDK/BNCEncodingUtils.m#L215
<img width="1244" alt="Screen Shot 2020-08-27 at 13 49 43" src="https://user-images.githubusercontent.com/3015018/91431341-70927a00-e88a-11ea-8378-60e1ab6d5568.png">