### PR TITLE
Fix intermittent crash in `sanitizedStringFromString`

### DIFF
--- a/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/BNCPreferenceHelper.h
@@ -83,6 +83,7 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 
 - (void)addInstrumentationDictionaryKey:(NSString *)key value:(NSString *)value;
 - (NSMutableDictionary *)instrumentationDictionary;
+- (NSDictionary *)instrumentationParameters; // a safe copy to use in a POST body
 - (void)clearInstrumentationDictionary;
 
 - (void)saveBranchAnalyticsData:(NSDictionary *)analyticsData;

--- a/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/BNCPreferenceHelper.m
@@ -492,6 +492,15 @@ static NSString * const BRANCH_PREFS_KEY_ANALYTICS_MANIFEST = @"bnc_branch_analy
     }
 }
 
+- (NSDictionary *)instrumentationParameters {
+    @synchronized (self) {
+        if (_instrumentationDictionary.count == 0) {
+            return nil; // this avoids the .count check in prepareParamDict
+        }
+        return [[NSDictionary alloc] initWithDictionary:_instrumentationDictionary];
+    }
+}
+
 - (NSMutableDictionary *)instrumentationDictionary {
     @synchronized (self) {
         if (!_instrumentationDictionary) {

--- a/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/BNCServerInterface.m
@@ -453,10 +453,12 @@
         fullParamDict[BRANCH_REQUEST_KEY_STATE] = metadata;
     }
     // we only send instrumentation info in the POST body request
-    if (self.preferenceHelper.instrumentationDictionary.count && [reqType isEqualToString:@"POST"]) {
-        fullParamDict[BRANCH_REQUEST_KEY_INSTRUMENTATION] = self.preferenceHelper.instrumentationDictionary;
+    if ([reqType isEqualToString:@"POST"]) {
+        NSDictionary *instrumentationDictionary = self.preferenceHelper.instrumentationParameters;
+        if (instrumentationDictionary) {
+            fullParamDict[BRANCH_REQUEST_KEY_INSTRUMENTATION] = instrumentationDictionary;
+        }
     }
-    
     return fullParamDict;
 }
 


### PR DESCRIPTION
A fix for the issue described in https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/issues/918

We are using Branch in a large application and get a small handful of crashes in `[BNCEncodingUtils sanitizedStringFromString:]`

I looked through the code and I believe I have found a potential source to the problem. In `prepareParamDict`, the NSMutableDictionary `instrumentationDictionary` is returned without making a copy. Given the `@synchronized` code around access to this dictionary, it is likely to be updated by multiple queues at once.

The correct fix is to create a new method which makes a copy of this dictionary _while still within the @synchronized lock`!