### PR TITLE
SDK-1106 remove initialize use

### DIFF
--- a/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/BNCPreferenceHelper.m
@@ -872,48 +872,10 @@ static NSString * const BRANCH_PREFS_KEY_ANALYTICS_MANIFEST = @"bnc_branch_analy
 
 #pragma mark - Preferences File URL
 
-+ (NSString *)prefsFile_deprecated {
-    NSString * path =
-        [[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)
-            firstObject]
-                stringByAppendingPathComponent:BRANCH_PREFS_FILE];
-    return path;
-}
-
 + (NSURL* _Nonnull) URLForPrefsFile {
     NSURL *URL = BNCURLForBranchDirectory();
     URL = [URL URLByAppendingPathComponent:BRANCH_PREFS_FILE isDirectory:NO];
     return URL;
-}
-
-+ (void) moveOldPrefsFile {
-    NSString* oldPath = self.prefsFile_deprecated;
-    NSURL *oldURL = (oldPath) ? [NSURL fileURLWithPath:self.prefsFile_deprecated] : nil;
-    NSURL *newURL = [self URLForPrefsFile];
-
-    if (!oldURL || !newURL) { return; }
-
-    NSError *error = nil;
-    [[NSFileManager defaultManager]
-        moveItemAtURL:oldURL
-        toURL:newURL
-        error:&error];
-
-    if (error && error.code != NSFileNoSuchFileError) {
-        if (error.code == NSFileWriteFileExistsError) {
-            [[NSFileManager defaultManager]
-                removeItemAtURL:oldURL
-                error:&error];
-        } else {
-            BNCLogError([NSString stringWithFormat:@"Can't move prefs file: %@.", error]);
-        }
-    }
-}
-
-+ (void) initialize {
-    if (self == [BNCPreferenceHelper self]) {
-        [self moveOldPrefsFile];
-    }
 }
 
 @end

--- a/Branch-SDK/BNCServerRequestQueue.m
+++ b/Branch-SDK/BNCServerRequestQueue.m
@@ -365,47 +365,10 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
             [exception.callStackSymbols componentsJoinedByString:@"\n\t"]];
 }
 
-+ (NSString *)queueFile_deprecated {
-    NSString *path =
-        [[NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)
-            firstObject]
-                stringByAppendingPathComponent:BRANCH_QUEUE_FILE];
-    return path;
-}
-
 + (NSURL* _Nonnull) URLForQueueFile {
     NSURL *URL = BNCURLForBranchDirectory();
     URL = [URL URLByAppendingPathComponent:BRANCH_QUEUE_FILE isDirectory:NO];
     return URL;
-}
-
-+ (void) moveOldQueueFile {
-    NSURL *oldURL = [NSURL fileURLWithPath:self.queueFile_deprecated];
-    NSURL *newURL = [self URLForQueueFile];
-    
-    if (!oldURL || !newURL) { return; }
-    
-    NSError *error = nil;
-    [[NSFileManager defaultManager]
-        moveItemAtURL:oldURL
-        toURL:newURL
-        error:&error];
-
-    if (error && error.code != NSFileNoSuchFileError) {
-        if (error.code == NSFileWriteFileExistsError) {
-            [[NSFileManager defaultManager]
-                removeItemAtURL:oldURL
-                error:&error];
-        } else {
-            BNCLogError([NSString stringWithFormat:@"Failed to move the queue file: %@.", error]);
-        }
-    }
-}
-
-+ (void) initialize {
-    if (self == [BNCServerRequestQueue self]) {
-        [self moveOldQueueFile];
-    }
 }
 
 #pragma mark - Shared Method

--- a/Branch-TestBed/Branch-SDK-Tests/BNCUserAgentCollectorTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCUserAgentCollectorTests.m
@@ -70,7 +70,7 @@
         [expectation fulfill];
     }];
 
-    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError * _Nullable error) {
+    [self waitForExpectationsWithTimeout:4.0 handler:^(NSError * _Nullable error) {
         
     }];
 }


### PR DESCRIPTION
Removes a couple very old data copy methods when upgrading from SDK version 0.12.13. 
