### PR TITLE
CORE-1711 reduce default SKAdNetwork timeout from 72 hours to 24 hours

### DIFF
--- a/Branch-SDK/BNCSKAdNetwork.m
+++ b/Branch-SDK/BNCSKAdNetwork.m
@@ -33,8 +33,8 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        // by default, we send updates to SKAdNetwork for up to 3 days after install
-        self.maxTimeSinceInstall = 3600.0 * 24.0 * 3.0;
+        // by default, we send updates to SKAdNetwork for up a day after install
+        self.maxTimeSinceInstall = 3600.0 * 24.0;
         self.installDate = [BNCApplication currentApplication].currentInstallDate;
         
         self.skAdNetworkClass = NSClassFromString(@"SKAdNetwork");

--- a/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch.h
@@ -684,7 +684,7 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
 - (void)setAppClipAppGroup:(NSString *)appGroup;
 
 /**
- Set time window for SKAdNetwork callouts.  By default, Branch limits calls to SKAdNetwork to within 72 hours after first install.
+ Set time window for SKAdNetwork callouts.  By default, Branch limits calls to SKAdNetwork to within 24 hours after first install.
  
  Note: Branch does not automatically call SKAdNetwork unless configured on the dashboard.
  */

--- a/Branch-TestBed/Branch-SDK-Tests/BNCSKAdNetworkTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCSKAdNetworkTests.m
@@ -36,8 +36,8 @@
 }
 
 - (void)testDefaultMaxTimeout {
-    NSTimeInterval threeDays = 3600.0 * 24.0 * 3.0;
-    XCTAssertTrue(self.skAdNetwork.maxTimeSinceInstall == threeDays);
+    NSTimeInterval oneDay = 3600.0 * 24.0;
+    XCTAssertTrue(self.skAdNetwork.maxTimeSinceInstall == oneDay);
 }
 
 - (void)testShouldAttemptSKAdNetworkCallout {


### PR DESCRIPTION
Reduce the default timeout to 24 hours.

