### PR TITLE
CORE-1768 rename api for better readability, add safety check

### DIFF
--- a/Branch-SDK/BNCPreferenceHelper.h
+++ b/Branch-SDK/BNCPreferenceHelper.h
@@ -37,6 +37,7 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 @property (assign, nonatomic) BOOL checkedAppleSearchAdAttribution;
 @property (nonatomic, assign, readwrite) BOOL appleAttributionTokenChecked;
 @property (nonatomic, assign, readwrite) BOOL hasOptedInBefore;
+@property (nonatomic, assign, readwrite) BOOL hasCalledHandleATTAuthorizationStatus;
 @property (assign, nonatomic) NSInteger retryCount;
 @property (assign, nonatomic) NSTimeInterval retryInterval;
 @property (assign, nonatomic) NSTimeInterval timeout;

--- a/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/BNCPreferenceHelper.m
@@ -400,6 +400,14 @@ static NSString * const BRANCH_PREFS_KEY_ANALYTICS_MANIFEST = @"bnc_branch_analy
     return [self readBoolFromDefaults:@"_hasOptedInBefore"];
 }
 
+- (void)setHasCalledHandleATTAuthorizationStatus:(BOOL)hasCalledHandleATTAuthorizationStatus {
+    [self writeBoolToDefaults:@"_hasCalledHandleATTAuthorizationStatus" value:hasCalledHandleATTAuthorizationStatus];
+}
+
+- (BOOL)hasCalledHandleATTAuthorizationStatus {
+    return [self readBoolFromDefaults:@"_hasCalledHandleATTAuthorizationStatus"];
+}
+
 - (NSString*) lastSystemBuildVersion {
     if (!_lastSystemBuildVersion) {
         _lastSystemBuildVersion = [self readStringFromDefaults:@"_lastSystemBuildVersion"];

--- a/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch.h
@@ -692,7 +692,7 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  Otherwise the prompt will not display and the completion will be called with current status.
  This will inflate the number of OPT_IN and OPT_OUT events tracked by Branch.
  */
-- (void)handleOptInStatus:(NSUInteger)status;
+- (void)handleATTAuthorizationStatus:(NSUInteger)status;
 
 /**
  Set time window for SKAdNetwork callouts.  By default, Branch limits calls to SKAdNetwork to within 24 hours after first install.

--- a/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch.m
@@ -970,7 +970,7 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
     [BNCAppGroupsData shared].appGroup = appGroup;
 }
 
-- (void)handleOptInStatus:(NSUInteger)status {
+- (void)handleATTAuthorizationStatus:(NSUInteger)status {
     BranchEvent *event;
     switch (status) {
         case 2:

--- a/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch.m
@@ -971,6 +971,13 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
 }
 
 - (void)handleATTAuthorizationStatus:(NSUInteger)status {
+    // limits impact if the client fails to check that status = notDetermined before calling
+    if ([BNCPreferenceHelper preferenceHelper].hasCalledHandleATTAuthorizationStatus) {
+        return;
+    } else {
+        [BNCPreferenceHelper preferenceHelper].hasCalledHandleATTAuthorizationStatus = YES;
+    }
+    
     BranchEvent *event;
     switch (status) {
         case 2:


### PR DESCRIPTION
Renamed the API for better readability in Swift.

Also added a safety check that only allows calling the method once, since the ATT prompt can only be shown once.  This limits the impact of an erroneous implementation from sending a lot of opt_in or opt_out events.
