### PR TITLE
CORE-1916 fix keychain and queue

### DIFF
--- a/Branch-SDK/BNCApplication.h
+++ b/Branch-SDK/BNCApplication.h
@@ -48,9 +48,6 @@
 /// The date this app was first installed on this device.
 @property (atomic, readonly) NSDate*_Nullable firstInstallDate;
 
-/// Returns a dictionary of device / identity pairs.
-@property (atomic, readonly) NSDictionary<NSString*, NSString*>*_Nonnull deviceKeyIdentityValueDictionary;
-
 /// The team identifier for the app.
 @property (atomic, readonly) NSString*_Nullable teamID;
 

--- a/Branch-SDK/BNCApplication.m
+++ b/Branch-SDK/BNCApplication.m
@@ -13,7 +13,6 @@
 #import "BNCKeyChain.h"
 
 static NSString*const kBranchKeychainService          = @"BranchKeychainService";
-static NSString*const kBranchKeychainDevicesKey       = @"BranchKeychainDevices";
 static NSString*const kBranchKeychainFirstBuildKey    = @"BranchKeychainFirstBuild";
 static NSString*const kBranchKeychainFirstInstalldKey = @"BranchKeychainFirstInstall";
 
@@ -101,14 +100,14 @@ static NSString*const kBranchKeychainFirstInstalldKey = @"BranchKeychainFirstIns
 + (NSDate*) firstInstallBuildDate {
     NSError *error = nil;
     NSDate *firstBuildDate =
-        [BNCKeyChain retrieveValueForService:kBranchKeychainService
+        [BNCKeyChain retrieveDateForService:kBranchKeychainService
             key:kBranchKeychainFirstBuildKey
             error:&error];
     if (firstBuildDate)
         return firstBuildDate;
 
     firstBuildDate = [self currentBuildDate];
-    error = [BNCKeyChain storeValue:firstBuildDate
+    error = [BNCKeyChain storeDate:firstBuildDate
         forService:kBranchKeychainService
         key:kBranchKeychainFirstBuildKey
         cloudAccessGroup:nil];
@@ -145,7 +144,7 @@ static NSString*const kBranchKeychainFirstInstalldKey = @"BranchKeychainFirstIns
 + (NSDate*) firstInstallDate {
     // check keychain for stored install date, on iOS this is lost on app deletion.
     NSError *error = nil;
-    NSDate* firstInstallDate = [BNCKeyChain retrieveValueForService:kBranchKeychainService key:kBranchKeychainFirstInstalldKey error:&error];
+    NSDate* firstInstallDate = [BNCKeyChain retrieveDateForService:kBranchKeychainService key:kBranchKeychainFirstInstalldKey error:&error];
     if (firstInstallDate) {
         return firstInstallDate;
     }
@@ -154,24 +153,11 @@ static NSString*const kBranchKeychainFirstInstalldKey = @"BranchKeychainFirstIns
     firstInstallDate = [self currentInstallDate];
     
     // save filesystem time to keychain
-    error = [BNCKeyChain storeValue:firstInstallDate forService:kBranchKeychainService key:kBranchKeychainFirstInstalldKey cloudAccessGroup:nil];
+    error = [BNCKeyChain storeDate:firstInstallDate forService:kBranchKeychainService key:kBranchKeychainFirstInstalldKey cloudAccessGroup:nil];
     if (error) {
         BNCLogError([NSString stringWithFormat:@"Keychain store: %@.", error]);
     }
     return firstInstallDate;
-}
-
-- (NSDictionary*) deviceKeyIdentityValueDictionary {
-    @synchronized (self.class) {
-        NSError *error = nil;
-        NSDictionary *deviceDictionary =
-            [BNCKeyChain retrieveValueForService:kBranchKeychainService
-                key:kBranchKeychainDevicesKey
-                error:&error];
-        if (error) BNCLogWarning([NSString stringWithFormat:@"While retrieving deviceKeyIdentityValueDictionary: %@.", error]);
-        if (!deviceDictionary) deviceDictionary = @{};
-        return deviceDictionary;
-    }
 }
 
 @end

--- a/Branch-SDK/BNCKeyChain.h
+++ b/Branch-SDK/BNCKeyChain.h
@@ -17,48 +17,43 @@
 @interface BNCKeyChain : NSObject
 
 /**
- @brief Remove a value for a service and key. Optionally removes all keys and values for a service.
+ @brief Remove all values for a service and key.
 
- @param service     The name of the service under which to store the key.
- @param key         The key to remove the value from. If `nil` is passed, all keys and values are removed for that service.
- @return            Returns an `NSError` if an error occurs.
+ @param service The name of the service under which to store the key.
+ @param key The key to remove the value from. If `nil` is passed, all keys and values are removed for that service.
+ @return Returns an `NSError` if an error occurs.
 */
-+ (NSError*_Nullable) removeValuesForService:(NSString*_Nullable)service
-                                         key:(NSString*_Nullable)key;
++ (NSError * _Nullable) removeValuesForService:(NSString * _Nullable)service
+                                           key:(NSString * _Nullable)key;
+
 
 /**
- @brief Returns a value for the passed service and key.
+ @brief Returns a date for the passed service and key.
 
- @param service     The name of the service that the value is stored under.
- @param key         The key that the value is stored under.
- @param error       If an error occurs, and `error` is a pointer to an error pointer, the error is returned here.
- @return            Returns the value stored under `service` and `key`, or `nil` if none found.
+ @param service The name of the service that the value is stored under.
+ @param key The key that the value is stored under.
+ @param error If an error occurs, and `error` is a pointer to an error pointer, the error is returned here.
+ @return Returns the date stored under `service` and `key`, or `nil` if none found.
 */
-+ (id _Nullable) retrieveValueForService:(NSString*_Nonnull)service
-                                     key:(NSString*_Nonnull)key
-                                   error:(NSError*_Nullable __autoreleasing *_Nullable)error;
++ (NSDate * _Nullable) retrieveDateForService:(NSString * _Nonnull)service
+                                          key:(NSString * _Nonnull)key
+                                        error:(NSError * _Nullable __autoreleasing * _Nullable)error;
 
 /**
- @brief Returns an array of all items found in the keychain for an app.
+ @brief Stores a date in the keychain.
 
- @param error       If an error occurs, the error is returned in `error` if it is not `NULL`.
- @return            Returns an array of the items stored in the keychain or `nil`.
-*/
-+ (NSArray*_Nullable) retieveAllValuesWithError:(NSError*_Nullable __autoreleasing *_Nullable)error;
-
-/**
- @brief Stores an item in the keychain.
-
- @param service     The service name to store the item under.
- @param key         The key to store the item under.
+ @param date Date to store
+ @param service The service name to store the item under.
+ @param key The key to store the item under.
  @param accessGroup The iCloud security access group for sharing the item. Specify `nil` if item should not be shared.
- @return            Returns an error if an error occurs.
+ @return Returns an error if an error occurs.
  */
-+ (NSError*_Nullable) storeValue:(id _Nonnull)value
-                      forService:(NSString*_Nonnull)service
-                             key:(NSString*_Nonnull)key
-                cloudAccessGroup:(NSString*_Nullable)accessGroup;
++ (NSError * _Nullable) storeDate:(NSDate * _Nonnull)date
+                       forService:(NSString * _Nonnull)service
+                              key:(NSString * _Nonnull)key
+                 cloudAccessGroup:(NSString * _Nullable)accessGroup;
 
 /// The default security access group for the app.
 + (NSString*_Nullable) securityAccessGroup;
+
 @end

--- a/Branch-SDK/BNCKeyChain.m
+++ b/Branch-SDK/BNCKeyChain.m
@@ -40,7 +40,7 @@ CFStringRef SecCopyErrorMessageString(OSStatus status, void *reserved) {
 
 @implementation BNCKeyChain
 
-+ (NSError*) errorWithKey:(NSString*)key OSStatus:(OSStatus)status {
++ (NSError *) errorWithKey:(NSString *)key OSStatus:(OSStatus)status {
     // Security errors are defined in Security/SecBase.h
     if (status == errSecSuccess) return nil;
     NSString *reason = nil;
@@ -64,55 +64,7 @@ CFStringRef SecCopyErrorMessageString(OSStatus status, void *reserved) {
     return error;
 }
 
-+ (NSArray*) retieveAllValuesWithError:(NSError**)error {
-    if (error) *error = nil;
-    NSDictionary* dictionary = @{
-        (__bridge id)kSecClass:                 (__bridge id)kSecClassGenericPassword,
-        (__bridge id)kSecReturnData:            (__bridge id)kCFBooleanTrue,
-        (__bridge id)kSecAttrSynchronizable:    (__bridge id)kSecAttrSynchronizableAny,
-        (__bridge id)kSecMatchLimit:            (__bridge id)kSecMatchLimitAll
-    };
-    CFTypeRef valueData = NULL;
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)dictionary, &valueData);
-    if (status == errSecItemNotFound) status = 0;
-    if (status) {
-        NSError *localError = [self errorWithKey:@"<all>" OSStatus:status];
-        BNCLogDebugSDK([NSString stringWithFormat:@"Can't retrieve key: %@.", localError]);
-        if (error) *error = localError;
-        if (valueData) CFRelease(valueData);
-        return nil;
-    }
-    NSMutableArray *array = nil;
-    if ([((__bridge NSArray*)valueData) isKindOfClass:[NSArray class]]) {
-        NSArray *dataArray = (__bridge NSArray*) valueData;
-        array = [NSMutableArray new];
-        for (NSData* data in dataArray) {
-            id value = nil;
-            @try {
-                if (@available(iOS 12.0, *)) {
-                    value = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSData class] fromData:data error:NULL];
-                } else {
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < 12000
-                    value = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-                }
-            }
-            @catch (id) {
-                value = nil;
-            }
-            if (value)
-                [array addObject:value];
-            else
-            if (data)
-                [array addObject:data];
-        }
-    }
-    if (valueData)
-        CFRelease(valueData);
-    return array;
-}
-
-+ (id) retrieveValueForService:(NSString*)service key:(NSString*)key error:(NSError**)error {
++ (NSDate *) retrieveDateForService:(NSString *)service key:(NSString *)key error:(NSError **)error {
     if (error) *error = nil;
     if (service == nil || key == nil) {
         NSError *localError = [self errorWithKey:key OSStatus:errSecParam];
@@ -141,10 +93,10 @@ CFStringRef SecCopyErrorMessageString(OSStatus status, void *reserved) {
     if (valueData) {
         @try {
             if (@available(iOS 12.0, *)) {
-                value = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSData class] fromData:(__bridge NSData*)valueData error:NULL];
+                value = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSDate class] fromData:(__bridge NSData*)valueData error:NULL];
             } else {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 12000
-                value = [NSKeyedUnarchiver unarchiveObjectWithData:(__bridge NSData*)valueData];
+                value = [NSKeyedUnarchiver unarchiveObjectWithData:(__bridge NSDate*)valueData];
 #endif
             }
         }
@@ -158,18 +110,18 @@ CFStringRef SecCopyErrorMessageString(OSStatus status, void *reserved) {
     return value;
 }
 
-+ (NSError*) storeValue:(id)value
-             forService:(NSString*)service
-                    key:(NSString*)key
-       cloudAccessGroup:(NSString*)accessGroup {
++ (NSError *) storeDate:(NSDate *)date
+             forService:(NSString *)service
+                    key:(NSString *)key
+       cloudAccessGroup:(NSString *)accessGroup {
 
-    if (value == nil || service == nil || key == nil)
+    if (date == nil || service == nil || key == nil)
         return [self errorWithKey:key OSStatus:errSecParam];
 
     NSData* valueData = nil;
     @try {
         if (@available( iOS 12.0, *)) {
-            valueData = [NSKeyedArchiver archivedDataWithRootObject:value requiringSecureCoding:YES error:NULL];
+            valueData = [NSKeyedArchiver archivedDataWithRootObject:date requiringSecureCoding:YES error:NULL];
         } else {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 12000
             valueData = [NSKeyedArchiver archivedDataWithRootObject:value];
@@ -215,8 +167,8 @@ CFStringRef SecCopyErrorMessageString(OSStatus status, void *reserved) {
     return nil;
 }
 
-+ (NSError*) removeValuesForService:(NSString*)service key:(NSString*)key {
-    NSMutableDictionary* dictionary = [NSMutableDictionary dictionaryWithDictionary:@{
++ (NSError*) removeValuesForService:(NSString *)service key:(NSString *)key {
+    NSMutableDictionary *dictionary = [NSMutableDictionary dictionaryWithDictionary:@{
         (__bridge id)kSecClass:                 (__bridge id)kSecClassGenericPassword,
         (__bridge id)kSecAttrSynchronizable:    (__bridge id)kSecAttrSynchronizableAny
     }];
@@ -233,14 +185,14 @@ CFStringRef SecCopyErrorMessageString(OSStatus status, void *reserved) {
     return nil;
 }
 
-+ (NSString*_Nullable) securityAccessGroup {
++ (NSString * _Nullable) securityAccessGroup {
     // https://stackoverflow.com/questions/11726672/access-app-identifier-prefix-programmatically
     @synchronized(self) {
         static NSString*_securityAccessGroup = nil;
         if (_securityAccessGroup) return _securityAccessGroup;
 
         // First store a value:
-        NSError*error = [self storeValue:@"Value" forService:@"BranchKeychainService" key:@"Temp" cloudAccessGroup:nil];
+        NSError *error = [self storeDate:[NSDate date] forService:@"BranchKeychainService" key:@"Temp" cloudAccessGroup:nil];
         if (error) BNCLogDebugSDK([NSString stringWithFormat:@"Error storing temp value: %@.", error]);
         
         NSDictionary* dictionary = @{

--- a/Branch-SDK/BNCServerRequestQueue.h
+++ b/Branch-SDK/BNCServerRequestQueue.h
@@ -18,17 +18,16 @@
 - (void)insert:(BNCServerRequest *)request at:(NSUInteger)index;
 - (BNCServerRequest *)removeAt:(NSUInteger)index;
 - (void)remove:(BNCServerRequest *)request;
-- (void)persistEventually;
-- (void)persistImmediately;
 - (void)clearQueue;
+- (NSInteger)queueDepth;
 
 - (BOOL)containsInstallOrOpen;
 - (BOOL)removeInstallOrOpen;
 - (BOOL)containsClose;
 - (BranchOpenRequest *)moveInstallOrOpenToFront:(NSInteger)networkCount;
 
-+ (id)getInstance;
+- (void)persistEventually;
+- (void)persistImmediately;
 
-@property (readonly, assign, atomic) NSInteger queueDepth;
-@property (readonly, assign, atomic) BOOL isDirty;
++ (id)getInstance;
 @end

--- a/Branch-SDK/BNCServerRequestQueue.m
+++ b/Branch-SDK/BNCServerRequestQueue.m
@@ -380,7 +380,7 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
 
     } else {
         #if __IPHONE_OS_VERSION_MIN_REQUIRED < 12000
-          object = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+        object = [NSKeyedUnarchiver unarchiveObjectWithData:data];
         #endif
     }
     return object;

--- a/Branch-TestBed/Branch-SDK-Tests/BNCApplication.Test.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCApplication.Test.m
@@ -48,18 +48,17 @@
     XCTAssertTrue(application.currentBuildDate && [application.currentBuildDate timeIntervalSinceNow] > kOneYearAgo);
 
     NSString*const kBranchKeychainService          = @"BranchKeychainService";
-//  NSString*const kBranchKeychainDevicesKey       = @"BranchKeychainDevices";
     NSString*const kBranchKeychainFirstBuildKey    = @"BranchKeychainFirstBuild";
     NSString*const kBranchKeychainFirstInstalldKey = @"BranchKeychainFirstInstall";
 
     NSDate * firstBuildDate =
-        [BNCKeyChain retrieveValueForService:kBranchKeychainService
+        [BNCKeyChain retrieveDateForService:kBranchKeychainService
             key:kBranchKeychainFirstBuildKey
             error:nil];
     XCTAssertEqualObjects(application.firstInstallBuildDate, firstBuildDate);
 
     NSDate * firstInstallDate =
-        [BNCKeyChain retrieveValueForService:kBranchKeychainService
+        [BNCKeyChain retrieveDateForService:kBranchKeychainService
             key:kBranchKeychainFirstInstalldKey
             error:nil];
     XCTAssertEqualObjects(application.firstInstallDate, firstInstallDate);

--- a/Branch-TestBed/Branch-SDK-Tests/BNCKeyChain.Test.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCKeyChain.Test.m
@@ -18,11 +18,12 @@
 @implementation BNCKeyChainTest
 
 - (void)testKeyChain {
+    NSDate *testDate = [NSDate date];
+    
     NSError *error = nil;
-    NSString *value = nil;
-    NSArray *array = nil;
-    NSString*const kServiceName = @"Service";
-
+    NSDate *date = nil;
+    NSString * const kServiceName = @"Service";
+    
     // Remove and validate gone:
 
     error = [BNCKeyChain removeValuesForService:nil key:nil];
@@ -30,19 +31,12 @@
     // This happens when the unit test bundle isn't code signed.
     XCTAssertTrue(error == nil || error.code == -34018);
 
-    array = [BNCKeyChain retieveAllValuesWithError:&error];
-    XCTAssertTrue(array == nil && error == errSecSuccess);
-
     // Check some keys:
+    date = [BNCKeyChain retrieveDateForService:kServiceName key:@"key1" error:&error];
+    XCTAssertTrue(date == nil && error.code == errSecItemNotFound);
 
-    value = [BNCKeyChain retrieveValueForService:kServiceName key:@"key1" error:&error];
-    XCTAssertTrue(value == nil && error.code == errSecItemNotFound);
-
-    value = [BNCKeyChain retrieveValueForService:kServiceName key:@"key2" error:&error];
-    XCTAssertTrue(value == nil && error.code == errSecItemNotFound);
-
-    value = [BNCKeyChain retrieveValueForService:kServiceName key:@"key3" error:&error];
-    XCTAssertTrue(value == nil && error.code == errSecItemNotFound);
+    date = [BNCKeyChain retrieveDateForService:kServiceName key:@"key2" error:&error];
+    XCTAssertTrue(date == nil && error.code == errSecItemNotFound);
 
     // TODO: Fix this.
     if ([UIApplication sharedApplication] == nil) {
@@ -52,37 +46,24 @@
     
     // Test that local storage works:
 
-    error = [BNCKeyChain storeValue:@"1xyz123" forService:kServiceName key:@"key1" cloudAccessGroup:nil];
+    error = [BNCKeyChain storeDate:testDate forService:kServiceName key:@"key1" cloudAccessGroup:nil];
     XCTAssertTrue(error == nil);
-    value = [BNCKeyChain retrieveValueForService:kServiceName key:@"key1" error:&error];
-    XCTAssertTrue(error == nil && [value isEqualToString:@"1xyz123"]);
+    date = [BNCKeyChain retrieveDateForService:kServiceName key:@"key1" error:&error];
+    XCTAssertTrue(error == nil && [date isEqual:testDate]);
 
-    error = [BNCKeyChain storeValue:@"2xyz123" forService:kServiceName key:@"key2" cloudAccessGroup:nil];
+    error = [BNCKeyChain storeDate:[NSDate date] forService:kServiceName key:@"key2" cloudAccessGroup:nil];
     XCTAssertTrue(error == nil);
-    value = [BNCKeyChain retrieveValueForService:kServiceName key:@"key2" error:&error];
-    XCTAssertTrue(error == nil && [value isEqualToString:@"2xyz123"]);
-
-    error = [BNCKeyChain storeValue:@"3xyz123" forService:@"Service2" key:@"skey2" cloudAccessGroup:nil];
-    XCTAssertTrue(error == nil);
-    value = [BNCKeyChain retrieveValueForService:@"Service2" key:@"skey2" error:&error];
-    XCTAssertTrue(error == nil && [value isEqualToString:@"3xyz123"]);
+    date = [BNCKeyChain retrieveDateForService:kServiceName key:@"key2" error:&error];
+    XCTAssertTrue(error == nil && ![date isEqual:testDate]);
 
     // Remove by service:
 
     error = [BNCKeyChain removeValuesForService:kServiceName key:nil];
-    value = [BNCKeyChain retrieveValueForService:kServiceName key:@"key1" error:&error];
-    XCTAssertTrue(value == nil && error.code == errSecItemNotFound);
+    date = [BNCKeyChain retrieveDateForService:kServiceName key:@"key1" error:&error];
+    XCTAssertTrue(date == nil && error.code == errSecItemNotFound);
 
-    value = [BNCKeyChain retrieveValueForService:kServiceName key:@"key2" error:&error];
-    XCTAssertTrue(value == nil && error.code == errSecItemNotFound);
-
-    value = [BNCKeyChain retrieveValueForService:@"Service2" key:@"skey2" error:&error];
-    XCTAssertTrue(error == nil && [value isEqualToString:@"3xyz123"]);
-
-    // Check all values:
-
-    array = [BNCKeyChain retieveAllValuesWithError:&error];
-    XCTAssertTrue([array isEqualToArray:@[ @"3xyz123" ]] && error == errSecSuccess);
+    date = [BNCKeyChain retrieveDateForService:kServiceName key:@"key2" error:&error];
+    XCTAssertTrue(date == nil && error.code == errSecItemNotFound);
 }
 
 - (void) testSecurityAccessGroup {

--- a/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueOldTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueOldTests.m
@@ -1,0 +1,124 @@
+//
+//  BNCServerRequestQueueTests.m
+//  Branch-TestBed
+//
+//  Created by Graham Mueller on 6/17/15.
+//  Copyright (c) 2015 Branch Metrics. All rights reserved.
+//
+
+#import "BNCTestCase.h"
+#import "BNCServerRequestQueue.h"
+#import "BranchOpenRequest.h"
+#import "BranchCloseRequest.h"
+#import <OCMock/OCMock.h>
+#import "Branch.h"
+
+@interface BNCServerRequestQueue (BNCTests)
+- (void)retrieve;
+- (void)cancelTimer;
+@end
+
+@interface BNCServerRequestQueueOldTests : BNCTestCase
+@end
+
+@implementation BNCServerRequestQueueOldTests
+
+#pragma mark - MoveOpenOrInstallToFront tests
+
++ (void) setUp {
+    [self clearAllBranchSettings]; // Clear any saved data before our tests start.
+//    Branch*branch = [Branch getInstance:@"key_live_foo"];
+//    [self clearAllBranchSettings];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenEmpty {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    XCTAssertNoThrow([requestQueue moveInstallOrOpenToFront:0]);
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenNotPresent {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    XCTAssertNoThrow([requestQueue moveInstallOrOpenToFront:0]);
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenAlreadyInFrontAndNoRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    [requestQueue insert:[[BranchOpenRequest alloc] init] at:0];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[requestQueueMock reject] removeAt:0];
+    
+    [requestQueue moveInstallOrOpenToFront:0];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenAlreadyInFrontWithRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    [requestQueue insert:[[BranchOpenRequest alloc] init] at:0];
+
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[requestQueueMock reject] removeAt:0];
+    
+    [requestQueue moveInstallOrOpenToFront:1];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenSecondInLineWithRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:[[BranchOpenRequest alloc] init] at:1];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[requestQueueMock reject] removeAt:1];
+    
+    [requestQueue moveInstallOrOpenToFront:1];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenSecondInLineWithNoRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:openRequest at:1];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[[requestQueueMock expect] andForwardToRealObject] removeAt:1];
+    
+    [requestQueue moveInstallOrOpenToFront:0];
+    XCTAssertEqual([requestQueue peek], openRequest);
+    
+    [requestQueueMock verify];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenThirdInLineWithRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:1];
+    [requestQueue insert:openRequest at:2];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[[requestQueueMock expect] andForwardToRealObject] removeAt:2];
+    
+    [requestQueue moveInstallOrOpenToFront:1];
+    XCTAssertEqual([requestQueue peekAt:1], openRequest);
+    
+    [requestQueueMock verify];
+}
+
+- (void)testMoveOpenOrInstallToFrontWhenThirdInLineWithNoRequestsInProgress {
+    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
+    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
+    [requestQueue insert:[[BNCServerRequest alloc] init] at:1];
+    [requestQueue insert:openRequest at:2];
+    
+    id requestQueueMock = OCMPartialMock(requestQueue);
+    [[[requestQueueMock expect] andForwardToRealObject] removeAt:2];
+    
+    [requestQueue moveInstallOrOpenToFront:0];
+    XCTAssertEqual([requestQueue peek], openRequest);
+    
+    [requestQueueMock verify];
+}
+
+@end

--- a/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueTests.m
@@ -1,291 +1,135 @@
 //
 //  BNCServerRequestQueueTests.m
-//  Branch-TestBed
+//  Branch-SDK-Tests
 //
-//  Created by Graham Mueller on 6/17/15.
-//  Copyright (c) 2015 Branch Metrics. All rights reserved.
+//  Created by Ernest Cho on 5/14/21.
+//  Copyright © 2021 Branch, Inc. All rights reserved.
 //
 
-#import "BNCTestCase.h"
+#import <XCTest/XCTest.h>
 #import "BNCServerRequestQueue.h"
+#import "BNCServerRequest.h"
 #import "BranchOpenRequest.h"
 #import "BranchCloseRequest.h"
-#import <OCMock/OCMock.h>
-#import "Branch.h"
+#import "BranchEvent.h"
 
-@interface BNCServerRequestQueue (BNCTests)
-- (void)retrieve;
-- (void) cancelTimer;
+@interface BNCServerRequestQueue ()
+- (NSData *)archiveQueue:(NSArray *)queue;
+- (NSMutableArray *)unarchiveQueueFromData:(NSData *)data;
+
+- (NSData *)archiveObject:(NSObject *)object;
+- (id)unarchiveObjectFromData:(NSData *)data;
+
+// returns data in the legacy format
+- (NSData *)oldArchiveQueue:(NSArray *)queue;
+
 @end
 
-@interface BNCServerRequestQueueTests : BNCTestCase
+@interface BNCServerRequestQueueTests : XCTestCase
+@property (nonatomic, strong, readwrite) BNCServerRequestQueue *queue;
 @end
 
 @implementation BNCServerRequestQueueTests
 
-#pragma mark - MoveOpenOrInstallToFront tests
-
-+ (void) setUp {
-    [self clearAllBranchSettings]; // Clear any saved data before our tests start.
-//    Branch*branch = [Branch getInstance:@"key_live_foo"];
-//    [self clearAllBranchSettings];
+- (void)setUp {
+    self.queue = [BNCServerRequestQueue new];
 }
 
-- (void)testMoveOpenOrInstallToFrontWhenEmpty {
-    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
-    XCTAssertNoThrow([requestQueue moveInstallOrOpenToFront:0]);
+- (void)tearDown {
+    self.queue = nil;
 }
 
-- (void)testMoveOpenOrInstallToFrontWhenNotPresent {
-    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
-    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
-    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
-    XCTAssertNoThrow([requestQueue moveInstallOrOpenToFront:0]);
-}
-
-- (void)testMoveOpenOrInstallToFrontWhenAlreadyInFrontAndNoRequestsInProgress {
-    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
-    [requestQueue insert:[[BranchOpenRequest alloc] init] at:0];
+- (void)testArchiveNil {
+    NSString *object = nil;
     
-    id requestQueueMock = OCMPartialMock(requestQueue);
-    [[requestQueueMock reject] removeAt:0];
+    NSData *archived = [self.queue archiveObject:object];
+    XCTAssertNotNil(archived);
     
-    [requestQueue moveInstallOrOpenToFront:0];
+    NSString *unarchived = [self.queue unarchiveObjectFromData:archived];
+    XCTAssertNil(unarchived);
 }
 
-- (void)testMoveOpenOrInstallToFrontWhenAlreadyInFrontWithRequestsInProgress {
-    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
-    [requestQueue insert:[[BranchOpenRequest alloc] init] at:0];
-
-    id requestQueueMock = OCMPartialMock(requestQueue);
-    [[requestQueueMock reject] removeAt:0];
+- (void)testArchiveString {
+    NSString *object = @"Hello World";
     
-    [requestQueue moveInstallOrOpenToFront:1];
+    NSData *archived = [self.queue archiveObject:object];
+    XCTAssertNotNil(archived);
+    
+    NSString *unarchived = [self.queue unarchiveObjectFromData:archived];
+    XCTAssertNotNil(unarchived);
+    XCTAssert([object isEqual:unarchived]);
 }
 
-- (void)testMoveOpenOrInstallToFrontWhenSecondInLineWithRequestsInProgress {
-    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
-    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
-    [requestQueue insert:[[BranchOpenRequest alloc] init] at:1];
+- (void)testArchiveRequest {
+    BranchOpenRequest *object = [BranchOpenRequest new];
     
-    id requestQueueMock = OCMPartialMock(requestQueue);
-    [[requestQueueMock reject] removeAt:1];
+    NSData *archived = [self.queue archiveObject:object];
+    XCTAssertNotNil(archived);
     
-    [requestQueue moveInstallOrOpenToFront:1];
+    BranchOpenRequest *unarchived = [self.queue unarchiveObjectFromData:archived];
+    XCTAssertNotNil(unarchived);
+    XCTAssert([unarchived isKindOfClass:[BranchOpenRequest class]]);
+
+    // The request object is not very test friendly, so comparing the two is not helpful at the moment
 }
 
-- (void)testMoveOpenOrInstallToFrontWhenSecondInLineWithNoRequestsInProgress {
-    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
-    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
-    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
-    [requestQueue insert:openRequest at:1];
+- (void)testArchiveArrayOfRequests {
+    NSMutableArray *tmp = [NSMutableArray new];
+    [tmp addObject:[BranchOpenRequest new]];
+    [tmp addObject:[BranchEventRequest new]];
     
-    id requestQueueMock = OCMPartialMock(requestQueue);
-    [[[requestQueueMock expect] andForwardToRealObject] removeAt:1];
-    
-    [requestQueue moveInstallOrOpenToFront:0];
-    XCTAssertEqual([requestQueue peek], openRequest);
-    
-    [requestQueueMock verify];
+    NSData *data = [self.queue archiveQueue:tmp];
+    XCTAssertNotNil(data);
+
+    NSMutableArray *unarchived = [self.queue unarchiveQueueFromData:data];
+    XCTAssertNotNil(unarchived);
+    XCTAssert(unarchived.count == 2);
 }
 
-- (void)testMoveOpenOrInstallToFrontWhenThirdInLineWithRequestsInProgress {
-    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
-    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
-    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
-    [requestQueue insert:[[BNCServerRequest alloc] init] at:1];
-    [requestQueue insert:openRequest at:2];
+- (void)testOldArchiveArrayOfRequests {
+    NSMutableArray *tmp = [NSMutableArray new];
+    [tmp addObject:[BranchOpenRequest new]];
+    [tmp addObject:[BranchEventRequest new]];
     
-    id requestQueueMock = OCMPartialMock(requestQueue);
-    [[[requestQueueMock expect] andForwardToRealObject] removeAt:2];
+    NSData *data = [self.queue oldArchiveQueue:tmp];
+    XCTAssertNotNil(data);
+
+    NSMutableArray *unarchived = [self.queue unarchiveQueueFromData:data];
+    XCTAssertNotNil(unarchived);
+    XCTAssert(unarchived.count == 2);
+}
+
+- (void)testArchiveArrayOfInvalidObjects {
+    NSMutableArray *tmp = [NSMutableArray new];
+    [tmp addObject:[BranchOpenRequest new]];
+    [tmp addObject:@"Hello World"];
+    [tmp addObject:[BranchEventRequest new]];
+    [tmp addObject:[BranchCloseRequest new]];
     
-    [requestQueue moveInstallOrOpenToFront:1];
-    XCTAssertEqual([requestQueue peekAt:1], openRequest);
+    NSData *data = [self.queue archiveQueue:tmp];
+    XCTAssertNotNil(data);
+
+    NSMutableArray *unarchived = [self.queue unarchiveQueueFromData:data];
     
-    [requestQueueMock verify];
+    XCTAssertNotNil(unarchived);
+    XCTAssert(unarchived.count == 2);
 }
 
-- (void)testMoveOpenOrInstallToFrontWhenThirdInLineWithNoRequestsInProgress {
-    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
-    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
-    [requestQueue insert:[[BNCServerRequest alloc] init] at:0];
-    [requestQueue insert:[[BNCServerRequest alloc] init] at:1];
-    [requestQueue insert:openRequest at:2];
+- (void)testOldArchiveArrayOfInvalidObjects {
+    NSMutableArray *tmp = [NSMutableArray new];
+    [tmp addObject:[BranchOpenRequest new]];
+    [tmp addObject:@"Hello World"];
+    [tmp addObject:[BranchEventRequest new]];
+    [tmp addObject:[BranchCloseRequest new]];
     
-    id requestQueueMock = OCMPartialMock(requestQueue);
-    [[[requestQueueMock expect] andForwardToRealObject] removeAt:2];
+    NSData *data = [self.queue oldArchiveQueue:tmp];
+    XCTAssertNotNil(data);
+
+    NSMutableArray *unarchived = [self.queue unarchiveQueueFromData:data];
     
-    [requestQueue moveInstallOrOpenToFront:0];
-    XCTAssertEqual([requestQueue peek], openRequest);
-    
-    [requestQueueMock verify];
+    XCTAssertNotNil(unarchived);
+    XCTAssert(unarchived.count == 2);
 }
 
-#pragma mark - Persist Tests
-
-- (void)testPersistEventually {
-    BNCServerRequestQueue *queue = [[BNCServerRequestQueue alloc] init];
-    [queue persistEventually];
-    XCTAssert(queue.isDirty);
-    sleep(4);
-    XCTAssert(!queue.isDirty);
-}
-
-// TODO: Mocking NSKeyedArchiver interferes with too many other classes. Maybe try something else?
-/*
-- (void)testPersistWhenArchiveFails {
-    BNCServerRequestQueue *queue = [[BNCServerRequestQueue alloc] init];
-    [queue cancelTimer];
-
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testPersistWhenArchiveFails"];
-    id archiverMock = OCMClassMock([NSKeyedArchiver class]);
-    [[[[[archiverMock expect]
-        andDo:^(NSInvocation *invocation) {
-            [expectation fulfill];
-        }]
-        andThrow:[NSException exceptionWithName:@"Exception" reason:@"I said so" userInfo:@{@"Test": @"TestReason"}]]
-        andReturn:[NSData data]]
-            archivedDataWithRootObject:[OCMArg any]];
-
-    [queue enqueue:[[BNCServerRequest alloc] init]];
-    [queue cancelTimer];
-
-    [queue persistImmediately];
-    [self awaitExpectations];
-    [archiverMock verify];
-    [archiverMock stopMocking];
-    [queue cancelTimer];
-}
-*/
-
-// TODO: Mocking NSKeyedArchiver interferes with too many other classes. Maybe try something else?
-/*
-- (void)testCloseRequestsArentPersisted {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"testCloseRequestsArentPersisted"];
-    BNCServerRequestQueue *requestQueue = [[BNCServerRequestQueue alloc] init];
-    [requestQueue cancelTimer];
-
-    id archiverMock = OCMClassMock([NSKeyedArchiver class]);
-    [[archiverMock reject] archiveRootObject:[OCMArg any] toFile:[OCMArg any]];
-    [[[archiverMock expect]
-        andReturn:[NSData data]]
-            archivedDataWithRootObject:[OCMArg checkWithBlock:^BOOL(NSArray *reqs) {
-                if ([reqs isKindOfClass:[NSArray class]]) {
-                    XCTAssert(reqs.count == 0);
-                    [self safelyFulfillExpectation:expectation];
-                    return YES;
-                }
-                return NO;
-            }]];
-
-    BranchCloseRequest *closeRequest = [[BranchCloseRequest alloc] init];
-    [requestQueue enqueue:closeRequest];
-    XCTAssertEqual(requestQueue.queueDepth, 1);
-    [requestQueue cancelTimer];
-    [requestQueue persistImmediately];
-
-    // Wait for operation to occur
-    [self awaitExpectations];
-    [archiverMock verify];
-    [archiverMock stopMocking];
-}
-*/
-
-#pragma mark - Retrieve Tests
-
-- (void)testRetrieveFailWhenReadingData {
-    //  Test handling an exception when reading data from storage.
-
-    XCTestExpectation *expectation = [self expectationWithDescription:@"RetrieveExpectation"];
-    id nsdataMock = [OCMockObject mockForClass:[NSData class]];
-    [[[[nsdataMock expect]
-        andDo:^(NSInvocation *invocation) {
-            [expectation fulfill];
-        }]
-        andReturn:nil]
-            dataWithContentsOfURL:[OCMArg any]
-            options:0
-            error:[OCMArg anyObjectRef]];
-
-    BNCServerRequestQueue *queue = [[BNCServerRequestQueue alloc] init];
-    [queue cancelTimer];
-    [queue retrieve];
-    [self awaitExpectations];
-    [nsdataMock verify];
-    [nsdataMock stopMocking];
-}
-
-- (void)testRetrieveFailWhenUnarchivingRecord {
-    //  Test handling an exception when unarchiving.
-
-    XCTestExpectation *expectation = [self expectationWithDescription:@"UnarchiveThrowExpectation"];
-    id unarchiverMock;
-    if (@available(iOS 12.0, *)) {
-        unarchiverMock = [OCMockObject mockForClass:[NSKeyedUnarchiver class]];
-        [[[[unarchiverMock expect]
-           andDo:^(NSInvocation *invocation) {
-            [expectation fulfill];
-        }]
-          andReturn:@[ [@"Garbage" dataUsingEncoding:NSUTF8StringEncoding] ]]
-         unarchivedObjectOfClass:[NSArray class] fromData:[OCMArg any] error:NULL];
-    } else {
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < 12000
-        unarchiverMock = [OCMockObject mockForClass:[NSKeyedUnarchiver class]];
-        [[[[unarchiverMock expect]
-           andDo:^(NSInvocation *invocation) {
-            [expectation fulfill];
-        }]
-          andReturn:@[ [@"Garbage" dataUsingEncoding:NSUTF8StringEncoding] ]]
-         unarchiveObjectWithData:[OCMArg any]];
-#endif
-    }
-    BNCServerRequestQueue *queue = [[BNCServerRequestQueue alloc] init];
-    [queue retrieve];
-    [self awaitExpectations];
-    [unarchiverMock verify];
-    [unarchiverMock stopMocking];
-}
-
-- (void)testPersistedCloseRequestsArentLoaded {
-    //  Mock up the 'saved' data:
-    BranchCloseRequest *closeRequest = [[BranchCloseRequest alloc] init];
-    BranchOpenRequest *openRequest = [[BranchOpenRequest alloc] init];
-    NSArray *requests;
-    id nsdataMock;
-    if (@available(iOS 12.0, *)) {
-        requests = @[
-            [NSKeyedArchiver archivedDataWithRootObject:closeRequest requiringSecureCoding:YES error:NULL],
-            [NSKeyedArchiver archivedDataWithRootObject:openRequest requiringSecureCoding:YES error:NULL],
-            [NSKeyedArchiver archivedDataWithRootObject:closeRequest requiringSecureCoding:YES error:NULL]
-        ];
-        NSData *encodedRequests = [NSKeyedArchiver archivedDataWithRootObject:requests requiringSecureCoding:YES error:NULL];
-        
-        nsdataMock = [OCMockObject mockForClass:[NSData class]];
-        [[[nsdataMock expect] andReturn:encodedRequests]
-         dataWithContentsOfURL:[OCMArg any]
-         options:0
-         error:[OCMArg anyObjectRef]];
-        
-    } else {
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < 12000
-        requests = @[
-            [NSKeyedArchiver archivedDataWithRootObject:closeRequest],
-            [NSKeyedArchiver archivedDataWithRootObject:openRequest],
-            [NSKeyedArchiver archivedDataWithRootObject:closeRequest]];
-            nsdataMock = [OCMockObject mockForClass:[NSData class]];
-            [[[nsdataMock expect]
-              andReturn:[NSKeyedArchiver archivedDataWithRootObject:requests]]
-             dataWithContentsOfURL:[OCMArg any]
-             options:0
-             error:[OCMArg anyObjectRef]];
-#endif
-    }
-   
-    BNCServerRequestQueue *queue = [[BNCServerRequestQueue alloc] init];
-    [queue retrieve];
-    [nsdataMock verify];
-    XCTAssertEqual([queue queueDepth], 1);
-    [nsdataMock stopMocking];
-}
 
 @end

--- a/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueTests.m
@@ -14,14 +14,14 @@
 #import "BranchEvent.h"
 
 @interface BNCServerRequestQueue ()
-- (NSData *)archiveQueue:(NSArray *)queue;
-- (NSMutableArray *)unarchiveQueueFromData:(NSData *)data;
+- (NSData *)archiveQueue:(NSArray<BNCServerRequest *> *)queue;
+- (NSMutableArray<BNCServerRequest *> *)unarchiveQueueFromData:(NSData *)data;
 
 - (NSData *)archiveObject:(NSObject *)object;
 - (id)unarchiveObjectFromData:(NSData *)data;
 
 // returns data in the legacy format
-- (NSData *)oldArchiveQueue:(NSArray *)queue;
+- (NSData *)oldArchiveQueue:(NSArray<BNCServerRequest *> *)queue;
 
 @end
 
@@ -74,7 +74,7 @@
 }
 
 - (void)testArchiveArrayOfRequests {
-    NSMutableArray *tmp = [NSMutableArray new];
+    NSMutableArray<BNCServerRequest *> *tmp = [NSMutableArray<BNCServerRequest *> new];
     [tmp addObject:[BranchOpenRequest new]];
     [tmp addObject:[BranchEventRequest new]];
     
@@ -87,7 +87,7 @@
 }
 
 - (void)testOldArchiveArrayOfRequests {
-    NSMutableArray *tmp = [NSMutableArray new];
+    NSMutableArray<BNCServerRequest *> *tmp = [NSMutableArray<BNCServerRequest *> new];
     [tmp addObject:[BranchOpenRequest new]];
     [tmp addObject:[BranchEventRequest new]];
     
@@ -100,7 +100,7 @@
 }
 
 - (void)testArchiveArrayOfInvalidObjects {
-    NSMutableArray *tmp = [NSMutableArray new];
+    NSMutableArray<BNCServerRequest *> *tmp = [NSMutableArray<BNCServerRequest *> new];
     [tmp addObject:[BranchOpenRequest new]];
     [tmp addObject:@"Hello World"];
     [tmp addObject:[BranchEventRequest new]];
@@ -116,7 +116,7 @@
 }
 
 - (void)testOldArchiveArrayOfInvalidObjects {
-    NSMutableArray *tmp = [NSMutableArray new];
+    NSMutableArray<BNCServerRequest *> *tmp = [NSMutableArray<BNCServerRequest *> new];
     [tmp addObject:[BranchOpenRequest new]];
     [tmp addObject:@"Hello World"];
     [tmp addObject:[BranchEventRequest new]];
@@ -130,6 +130,5 @@
     XCTAssertNotNil(unarchived);
     XCTAssert(unarchived.count == 2);
 }
-
 
 @end

--- a/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueTests.m
@@ -296,14 +296,14 @@
          dataWithContentsOfURL:[OCMArg any]
          options:0
          error:[OCMArg anyObjectRef]];
-        
-        
+
+
     } else {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 12000
         requests = @[
             [NSKeyedArchiver archivedDataWithRootObject:closeRequest],
             [NSKeyedArchiver archivedDataWithRootObject:openRequest],
-            [NSKeyedArchiver archivedDataWithRootObject:closeRequest]
+            [NSKeyedArchiver archivedDataWithRootObject:closeRequest]];
             nsdataMock = [OCMockObject mockForClass:[NSData class]];
             [[[nsdataMock expect]
               andReturn:[NSKeyedArchiver archivedDataWithRootObject:requests]]

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		4AB16368239E3A2700D42931 /* DispatchToIsolationQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB16367239E3A2700D42931 /* DispatchToIsolationQueueTests.m */; };
 		4D1683A62098C902008819E3 /* BranchSetIdentityRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D16837B2098C901008819E3 /* BranchSetIdentityRequestTests.m */; };
 		4D1683A72098C902008819E3 /* BranchCloseRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D16837C2098C901008819E3 /* BranchCloseRequestTests.m */; };
-		4D1683A82098C902008819E3 /* BNCServerRequestQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D16837D2098C901008819E3 /* BNCServerRequestQueueTests.m */; };
+		4D1683A82098C902008819E3 /* BNCServerRequestQueueOldTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D16837D2098C901008819E3 /* BNCServerRequestQueueOldTests.m */; };
 		4D1683AA2098C902008819E3 /* BranchOpenRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D16837F2098C901008819E3 /* BranchOpenRequestTests.m */; };
 		4D1683AC2098C902008819E3 /* BranchInstallRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D1683822098C901008819E3 /* BranchInstallRequestTests.m */; };
 		4D1683AE2098C902008819E3 /* BNCLinkDataTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D1683842098C901008819E3 /* BNCLinkDataTests.m */; };
@@ -227,6 +227,7 @@
 		5FB0AA6C231875B500A0F9EA /* BNCUserAgentCollector.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FB0AA6A231875B500A0F9EA /* BNCUserAgentCollector.m */; };
 		5FB38C802521234F00E9A85A /* BNCAppGroupsData.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FB38C7E2521234F00E9A85A /* BNCAppGroupsData.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5FB38C812521234F00E9A85A /* BNCAppGroupsData.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FB38C7F2521234F00E9A85A /* BNCAppGroupsData.m */; };
+		5FB6CC13264F0C7C0020E478 /* BNCServerRequestQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FB6CC12264F0C7C0020E478 /* BNCServerRequestQueueTests.m */; };
 		5FC4CF8C24860C440001E701 /* latd.json in Resources */ = {isa = PBXBuildFile; fileRef = 5FC4CF7E24860C320001E701 /* latd.json */; };
 		5FC4CF8D24860C440001E701 /* latd_missing_window.json in Resources */ = {isa = PBXBuildFile; fileRef = 5FC4CF7F24860C320001E701 /* latd_missing_window.json */; };
 		5FC4CF8E24860C440001E701 /* cpid.json in Resources */ = {isa = PBXBuildFile; fileRef = 5FC4CF8024860C320001E701 /* cpid.json */; };
@@ -357,7 +358,7 @@
 		4AB16367239E3A2700D42931 /* DispatchToIsolationQueueTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DispatchToIsolationQueueTests.m; sourceTree = "<group>"; };
 		4D16837B2098C901008819E3 /* BranchSetIdentityRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchSetIdentityRequestTests.m; sourceTree = "<group>"; };
 		4D16837C2098C901008819E3 /* BranchCloseRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchCloseRequestTests.m; sourceTree = "<group>"; };
-		4D16837D2098C901008819E3 /* BNCServerRequestQueueTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCServerRequestQueueTests.m; sourceTree = "<group>"; };
+		4D16837D2098C901008819E3 /* BNCServerRequestQueueOldTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCServerRequestQueueOldTests.m; sourceTree = "<group>"; };
 		4D16837E2098C901008819E3 /* BNCServerInterface.Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCServerInterface.Test.m; sourceTree = "<group>"; };
 		4D16837F2098C901008819E3 /* BranchOpenRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchOpenRequestTests.m; sourceTree = "<group>"; };
 		4D1683812098C901008819E3 /* Branch-SDK-Tests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Branch-SDK-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -541,6 +542,7 @@
 		5FB0AA6A231875B500A0F9EA /* BNCUserAgentCollector.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCUserAgentCollector.m; sourceTree = "<group>"; };
 		5FB38C7E2521234F00E9A85A /* BNCAppGroupsData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BNCAppGroupsData.h; sourceTree = "<group>"; };
 		5FB38C7F2521234F00E9A85A /* BNCAppGroupsData.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCAppGroupsData.m; sourceTree = "<group>"; };
+		5FB6CC12264F0C7C0020E478 /* BNCServerRequestQueueTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCServerRequestQueueTests.m; sourceTree = "<group>"; };
 		5FC4CF7E24860C320001E701 /* latd.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = latd.json; sourceTree = "<group>"; };
 		5FC4CF7F24860C320001E701 /* latd_missing_window.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = latd_missing_window.json; sourceTree = "<group>"; };
 		5FC4CF8024860C320001E701 /* cpid.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = cpid.json; sourceTree = "<group>"; };
@@ -717,7 +719,8 @@
 				4D1683902098C901008819E3 /* BNCLog.Test.m */,
 				4D1683A02098C901008819E3 /* BNCPreferenceHelperTests.m */,
 				4D16837E2098C901008819E3 /* BNCServerInterface.Test.m */,
-				4D16837D2098C901008819E3 /* BNCServerRequestQueueTests.m */,
+				5FB6CC12264F0C7C0020E478 /* BNCServerRequestQueueTests.m */,
+				4D16837D2098C901008819E3 /* BNCServerRequestQueueOldTests.m */,
 				4D16838F2098C901008819E3 /* BNCSystemObserver.Test.m */,
 				4D1683A12098C901008819E3 /* BNCTestCase.h */,
 				4D16838D2098C901008819E3 /* BNCTestCase.m */,
@@ -1548,6 +1551,7 @@
 				5FE694382405FA2700E3AEE2 /* BNCCallbackMapTests.m in Sources */,
 				5FDB04F424E6156800F2F267 /* BNCSKAdNetworkTests.m in Sources */,
 				4D1683BB2098C902008819E3 /* BranchShortUrlRequestTests.m in Sources */,
+				5FB6CC13264F0C7C0020E478 /* BNCServerRequestQueueTests.m in Sources */,
 				4D1683C32098C902008819E3 /* BranchLoadRewardsRequestTests.m in Sources */,
 				4D1683BA2098C902008819E3 /* BNCLog.Test.m in Sources */,
 				4D1683AE2098C902008819E3 /* BNCLinkDataTests.m in Sources */,
@@ -1563,7 +1567,7 @@
 				4D1683C22098C902008819E3 /* BranchUserCompletedActionTests.m in Sources */,
 				4D1683AA2098C902008819E3 /* BranchOpenRequestTests.m in Sources */,
 				4D1683B42098C902008819E3 /* BranchRedeemRewardsRequestTests.m in Sources */,
-				4D1683A82098C902008819E3 /* BNCServerRequestQueueTests.m in Sources */,
+				4D1683A82098C902008819E3 /* BNCServerRequestQueueOldTests.m in Sources */,
 				4D1683A62098C902008819E3 /* BranchSetIdentityRequestTests.m in Sources */,
 				4D1683BC2098C902008819E3 /* BranchDelegate.Test.m in Sources */,
 				4D1683B62098C902008819E3 /* BNCURLFilterTests.m in Sources */,


### PR DESCRIPTION
Since we added support for secure coding on newer versions of iOS, we found archiving on Keychain and the network queue was failing due to mismatched types. This PR fixes both those issues.

For keychain, we only store NSDate. The code has been updated to always expect NSDate.

For the network queue, there was a refactor to improve testability around archive and unarchive of the network queue. The main change is that we only allow some classes to be archived and retrieved.  For older versions of iOS and the SDK, we filter on archive and retrieval.