### PR TITLE
Core 1589 share sheet configuration

### DIFF
--- a/Branch-SDK/BranchShareLink.h
+++ b/Branch-SDK/BranchShareLink.h
@@ -55,7 +55,7 @@ A delegate on the BranchShareLink can further configure the share experience. Fo
 parameters can be changed depending on the activity that the user selects.
 */
 
-@interface BranchShareLink : NSObject
+@interface BranchShareLink : NSObject <UIActivityItemSource>
 
 /**
 Creates a BranchShareLink object.
@@ -90,6 +90,9 @@ Presents a UIActivityViewController that shares the Branch link.
 // iOS 13+ fetches a preview header icon, text and domain name from this URL.
 // By default, we use the Branch bnc.lt link, but if you wish more control override it here.
 @property (nonatomic, strong, nullable) NSURL *placeholderURL;
+
+// iOS 13+ : LinkPresentation metadata for the preview header.
+@property (nonatomic, strong, nullable) LPLinkMetadata *lpMetaData;
 
 ///Share text for the item.  This is not the text in the iOS 13+ preview header.
 ///This text can be changed later when the `branchShareSheetWillShare:` delegate method is called.

--- a/Branch-SDK/BranchShareLink.h
+++ b/Branch-SDK/BranchShareLink.h
@@ -7,6 +7,7 @@
 //
 
 #import "BranchUniversalObject.h"
+#import <LinkPresentation/LinkPresentation.h>
 @class BranchShareLink;
 
 @protocol BranchShareLinkDelegate <NSObject>
@@ -123,4 +124,8 @@ Presents a UIActivityViewController that shares the Branch link.
 
 ///The delegate. See 'BranchShareLinkDelegate' above for a description.
 @property (nonatomic, weak)   id<BranchShareLinkDelegate>_Nullable delegate;
+
+@property void (^ _Nullable completion)(NSString * _Nullable activityType, BOOL completed);
+@property void (^ _Nullable completionError)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error);
+
 @end

--- a/Branch-SDK/BranchShareLink.h
+++ b/Branch-SDK/BranchShareLink.h
@@ -93,7 +93,7 @@ Presents a UIActivityViewController that shares the Branch link.
 @property (nonatomic, strong, nullable) NSURL *placeholderURL;
 
 // iOS 13+ : LinkPresentation metadata for the preview header.
-@property (nonatomic, strong, nullable) LPLinkMetadata *lpMetaData;
+@property (nonatomic, strong, nullable) LPLinkMetadata *lpMetaData API_AVAILABLE(ios(13.0));
 
 ///Share text for the item.  This is not the text in the iOS 13+ preview header.
 ///This text can be changed later when the `branchShareSheetWillShare:` delegate method is called.

--- a/Branch-SDK/BranchShareLink.m
+++ b/Branch-SDK/BranchShareLink.m
@@ -172,6 +172,12 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
         [_activityItems addObject:item];
     }
 
+    if (@available(iOS 13.0, *)) {
+        if (self.lpMetaData) {
+            [_activityItems addObject:self];
+        }
+    }
+ 
     return _activityItems;
 }
 
@@ -310,5 +316,21 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
     }
     return returnURL;
 }
+
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController  // called to determine data type. only the class of the return type is consulted. it should match what -itemForActivityType: returns later
+{
+    return @"";
+}
+
+- (nullable LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)activityViewController API_AVAILABLE(ios(13.0))
+{
+        return self.lpMetaData;
+}
+
+- (nullable id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(nullable UIActivityType)activityType   // called to fetch data after an activity is selected. you can return nil.
+{
+    return nil;
+}
+
 
 @end

--- a/Branch-SDK/BranchShareLink.m
+++ b/Branch-SDK/BranchShareLink.m
@@ -324,7 +324,7 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
 
 - (nullable LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)activityViewController API_AVAILABLE(ios(13.0))
 {
-        return self.lpMetaData;
+    return self.lpMetaData;
 }
 
 - (nullable id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(nullable UIActivityType)activityType   // called to fetch data after an activity is selected. you can return nil.

--- a/Branch-SDK/BranchShareLink.m
+++ b/Branch-SDK/BranchShareLink.m
@@ -101,6 +101,11 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
     if (completed && !error) {
         [[BranchEvent customEventWithName:BNCShareCompletedEvent contentItem:self.universalObject] logEvent];
     }
+    if (self.completion)
+        self.completion(self.activityType, completed);
+    else
+        if (self.completionError)
+            self.completionError(self.activityType, completed, error);
 }
 
 - (NSArray<UIActivityItemProvider*>*_Nonnull) activityItems {
@@ -194,6 +199,7 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
 
         shareViewController.completionWithItemsHandler =
             ^ (NSString *activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
+                self->_activityType = activityType;
                 [self shareDidComplete:completed activityError:activityError];
             };
 
@@ -203,6 +209,7 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
         #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         shareViewController.completionHandler =
             ^ (UIActivityType activityType, BOOL completed) {
+                self->_activityType = activityType;
                 [self shareDidComplete:completed activityError:nil];
             };
         #pragma clang diagnostic pop

--- a/Branch-SDK/BranchUniversalObject.h
+++ b/Branch-SDK/BranchUniversalObject.h
@@ -194,8 +194,6 @@ FOUNDATION_EXPORT BranchCondition _Nonnull BranchConditionRefurbished;
 /// @name Share Sheet Handling
 #if !TARGET_OS_TV
 
-- (nullable UIActivityItemProvider *)getBranchActivityItemWithLinkProperties:(nonnull BranchLinkProperties *)linkProperties;
-
 - (void)showShareSheetWithShareText:(nullable NSString *)shareText
                          completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
 

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -15,6 +15,7 @@
 #import "BranchLinkProperties.h"
 #import "LogOutputViewController.h"
 #import "AppDelegate.h"
+#import <LinkPresentation/LinkPresentation.h>
 
 extern AppDelegate* appDelegate;
 
@@ -338,7 +339,16 @@ static NSString *type = @"some type";
     shareLink.shareText = [NSString stringWithFormat:
         @"Shared from Branch-TestBed at %@.",
         [self.dateFormatter stringFromDate:[NSDate date]]];
-
+    
+    if (@available(iOS 13.0, *)) {
+        LPLinkMetadata *tempLinkMetatData = [[LPLinkMetadata alloc] init];
+        tempLinkMetatData.title = @"Branch URL";
+        UIImage *img = [UIImage imageNamed:@"Brand Assets"];
+        tempLinkMetatData.iconProvider = [[NSItemProvider alloc] initWithObject:img];
+        tempLinkMetatData.imageProvider = [[NSItemProvider alloc] initWithObject:img];
+        shareLink.lpMetaData = tempLinkMetatData;
+    }
+   
     [shareLink presentActivityViewControllerFromViewController:self anchor:sender];
 }
 


### PR DESCRIPTION
→ Added property *lpMetaData in BranchShareLink.
→ BranchShareLink class now conforms to UIActivityItemSource protocol
→ Removed getBranchActivityItemWithLinkProperties function from BranchUniversalObject class.
→ Updated function showShareSheetWithShareText to call BranchShareLink functions.

