### PR TITLE
[SDK-1131] Remove prerelease flag.

### DIFF
--- a/.github/custom-scripts/create-release.js
+++ b/.github/custom-scripts/create-release.js
@@ -48,6 +48,9 @@ async function createRelease({ context, core, github, sha, version }) {
   const body = await getBody({ github, core, context, target: sha });
   const releaseBody = `${title}\n\n${body}`;
 
+  // TODO: Update ChangeLog.md or perhaps take release body from manual
+  // ChangeLog updates.
+
   const release = {
     owner: context.repo.owner,
     repo: context.repo.repo,

--- a/.github/custom-scripts/create-release.js
+++ b/.github/custom-scripts/create-release.js
@@ -56,7 +56,7 @@ async function createRelease({ context, core, github, sha, version }) {
     name: version,
     body: releaseBody,
     draft: false,
-    prelease: true,
+    prelease: false,
   };
 
   await github.repos.createRelease(release);


### PR DESCRIPTION
This actually wasn't working anyway. It was producing full releases, as if `prerelease: false` had been specified. I manually changed the `1.4.0-test.1` release to prerelease afterward.

This flag can be exposed in a later iteration. For now, this workflow should produce full releases.

@BranchMetrics/core-team 