### PR TITLE
Use CocoaPods to get the current version from the podspec.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,12 +100,18 @@ jobs:
           # bundle exec pod trunk push Branch.podspec
           echo "TODO: This 👆"
       # 3. Create GitHub release. Also creates a tag.
+      - name: Get current version
+        id: get-version
+        run: |
+          bundle exec fastlane current_version
+          echo "Current version is $(cat fastlane/.version)."
+          echo "::set-output name=version::$(cat fastlane/.version)"
       - name: Create GitHub Release
         uses: actions/github-script@v4
         with:
           script: |
             const createRelease = require('./.github/custom-scripts/create-release');
-            const tagName = '${{ github.event.inputs.tag }}';
+            const tagName = '${{ steps.get-version.outputs.version }}';
             const sha = '${{ steps.commit-checksums.outputs.sha }}';
             await createRelease({
               core,
@@ -119,7 +125,7 @@ jobs:
         with:
           script: |
             const uploadAsset = require('./.github/custom-scripts/upload-asset');
-            const tagName = '${{ github.event.inputs.tag }}';
+            const tagName = '${{ steps.get-version.outputs.version }}';
 
             const { data } = await github.repos.getReleaseByTag({
               owner: context.repo.owner,
@@ -161,8 +167,8 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            console.log('Created release ${{ github.event.inputs.tag }}:');
-            console.log(` https://github.com/${context.repo.owner}/${context.repo.repo}/releases/${{ github.event.inputs.tag }}`);
+            console.log('Created release ${{ steps.get-version.outputs.version }}:');
+            console.log(` https://github.com/${context.repo.owner}/${context.repo.repo}/releases/${{ steps.get-version.outputs.version }}`);
       # 4. Trigger import workflow in ios-spm repo.
       - name: Export to ios-spm repository
         uses: actions/github-script@v4

--- a/fastlane/.gitignore
+++ b/fastlane/.gitignore
@@ -1,4 +1,4 @@
 report.*
 test_output
 README.md
-
+.version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,3 +32,10 @@ lane :version_bump do |opts|
   next_version = update_sdk_version opts
   sh 'git', 'commit', '-a', '-m', "[release] #{next_version}"
 end
+
+lane :current_version do
+  UI.message 'Generating fastlane/.version with podspec version'
+  File.open('.version', 'w') do |f|
+    f.puts current_pod_version
+  end
+end

--- a/fastlane/lib/helper/cocoapods_helper.rb
+++ b/fastlane/lib/helper/cocoapods_helper.rb
@@ -73,6 +73,14 @@ module CocoapodsHelper
 
     Dir.chdir(podfile_folder) { Fastlane::Action.sh(*command) }
   end
+
+  def current_pod_version
+    # Get current version from podspec
+    podspec = File.open('../Branch.podspec', 'r') do |f|
+      eval f.read
+    end
+    podspec.version
+  end
 end
 
 include CocoapodsHelper


### PR DESCRIPTION
The release.yml workflow doesn't take any parameters. During testing, I was supplying a `tag` parameter, but this doesn't need to be exposed here in the current workflow. This change ensures that whatever is in the podspec is used for the tag. The arrangement of these steps can be changed. For now, keeping version bump and release separate manual steps.

@BranchMetrics/core-team 