### PR TITLE
[SDK-1133] Remove generated release note

### DIFF
--- a/.github/custom-scripts/create-release.js
+++ b/.github/custom-scripts/create-release.js
@@ -1,55 +1,10 @@
-function getFirstLine(message) {
-  const index = message.indexOf('\n');
-  if (index === -1) {
-    return message;
-  }
-
-  return message.slice(0, index);
-}
-
-async function getBody({ github, core, context, target }) {
-  const res = await github.repos.getLatestRelease({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-  });
-
-  const latestRelease = res.data;
-  const diff = await github.repos.compareCommits({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
-    base: latestRelease.tag_name,
-    head: target,
-  });
-
-  const commits = diff.data.commits;
-  if (!commits.length) {
-    return 'No changes';
-  }
-
-  const format = (log) => `* ${log.title} (${log.hash}) ${log.name} <${log.email}>`;
-  const lines = commits.map((c) => {
-    const payload = {
-      title: getFirstLine(c.commit.message),
-      hash: c.sha.slice(0, 7),
-      name: c.commit.author.name,
-      email: c.commit.author.email,
-    };
-    return format(payload);
-  });
-
-  return lines.join('\n');
-}
-
 /**
  * Create Github Release given the version (provided by a tag)
  */
 async function createRelease({ context, core, github, sha, version }) {
   const title = `### Release Note (${version})`;
-  const body = await getBody({ github, core, context, target: sha });
+  const body = '[Insert ChangeLog update]';
   const releaseBody = `${title}\n\n${body}`;
-
-  // TODO: Update ChangeLog.md or perhaps take release body from manual
-  // ChangeLog updates.
 
   const release = {
     owner: context.repo.owner,


### PR DESCRIPTION
This will create a release with a note reading `[Insert ChangeLog update]`. This will be manually done by the maintainer after each release, having update the ChangeLog.txt manually (via PR) before the release.

We can also scoop the manual ChangeLog update out of the file, but the formatting will probably need attention.

The placeholder can be anything, including blank.