### PR TITLE
[SDK-1168] Added getLongAppLinkURLWithParams()

### DIFF
--- a/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch.h
@@ -1292,6 +1292,19 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  */
 - (NSString *)getLongURLWithParams:(nullable NSDictionary *)params andChannel:(nullable NSString *)channel andTags:(nullable NSArray *)tags andFeature:(nullable NSString *)feature andStage:(nullable NSString *)stage andAlias:(nullable NSString *)alias;
 
+/**
+ Get a long app.link url with specified params, tags, feature, stage, and alias. The usage type will default to unlimited.
+
+ @param params Dictionary of parameters to include in the link.
+ @param channel The channel for the link. Examples could be Facebook, Twitter, SMS, etc, depending on where it will be shared.
+ @param tags An array of tags to associate with this link, useful for tracking.
+ @param feature The feature this is utilizing. Examples could be Sharing, Referring, Inviting, etc.
+ @param stage The stage used for the generated link, indicating what part of a funnel the user is in.
+ @param alias The alias for a link.
+ @warning This can fail if the alias is already taken.
+ */
+- (NSString *)getLongAppLinkURLWithParams:(NSDictionary *)params andChannel:(nullable NSString *)channel andTags:(NSArray *)tags andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias;
+
 #pragma mark - Short Url Async methods
 
 ///----------------------------------------

--- a/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch.m
@@ -131,7 +131,7 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 @property (strong, nonatomic) BNCServerInterface *serverInterface;
 @property (strong, nonatomic) BNCServerRequestQueue *requestQueue;
 @property (strong, nonatomic) dispatch_semaphore_t processing_sema;
-@property (assign, nonatomic)    NSInteger networkCount;
+@property (assign, nonatomic) NSInteger networkCount;
 @property (assign, nonatomic) BNCInitStatus initializationStatus;
 @property (assign, nonatomic) BOOL shouldAutomaticallyDeepLink;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
@@ -1423,6 +1423,10 @@ static NSString *bnc_branchKey = nil;
     return [self generateLongURLWithParams:params andChannel:nil andTags:nil andFeature:feature andStage:stage andAlias:alias];
 }
 
+- (NSString *)getLongAppLinkURLWithParams:(NSDictionary *)params andChannel:(nullable NSString *)channel andTags:(NSArray *)tags andFeature:(NSString *)feature andStage:(NSString *)stage andAlias:(NSString *)alias {
+    return [self generateLongAppLinkURLWithParams:params andChannel:channel andTags:tags andFeature:feature andStage:stage andAlias:alias];
+}
+
 #pragma mark - Discoverable content methods
 #if !TARGET_OS_TV
 
@@ -1740,6 +1744,27 @@ static NSString *bnc_branchKey = nil;
     NSString *baseLongUrl = [NSString stringWithFormat:@"%@/a/%@", BNC_LINK_URL, self.class.branchKey];
 
     return [self longUrlWithBaseUrl:baseLongUrl params:params tags:tags feature:feature
+        channel:nil stage:stage alias:alias duration:0 type:BranchLinkTypeUnlimitedUse];
+}
+
+- (NSString *)generateLongAppLinkURLWithParams:(NSDictionary *)params
+                                    andChannel:(NSString *)channel
+                                       andTags:(NSArray *)tags
+                                    andFeature:(NSString *)feature
+                                      andStage:(NSString *)stage
+                                      andAlias:(NSString *)alias {
+    
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    NSString *baseUrl;
+    
+    if (preferenceHelper.userUrl) {
+        NSString *fullUserUrl = [preferenceHelper sanitizedMutableBaseURL:preferenceHelper.userUrl];
+        baseUrl = [fullUserUrl componentsSeparatedByString:@"?"].firstObject;
+    } else {
+        baseUrl = [[NSMutableString alloc] initWithFormat:@"%@/a/%@?", BNC_LINK_URL, self.class.branchKey];
+    }
+    
+    return [self longUrlWithBaseUrl:baseUrl params:params tags:tags feature:feature
         channel:nil stage:stage alias:alias duration:0 type:BranchLinkTypeUnlimitedUse];
 }
 

--- a/Branch-SDK/BranchShareLink.m
+++ b/Branch-SDK/BranchShareLink.m
@@ -149,8 +149,17 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
         self.shareURL = self.placeholderURL;
     } else {
         
-        // use short link as the placeholder url. This is just used for the preview and will be thrown away.
-        self.shareURL = [self createShortLink];
+        // use a long app.link url as the placeholder url
+        NSString *URLString =
+        [[Branch getInstance]
+         getLongAppLinkURLWithParams:self.serverParameters
+         andChannel:self.linkProperties.channel
+         andTags:self.linkProperties.tags
+         andFeature:self.linkProperties.feature
+         andStage:self.linkProperties.stage
+         andAlias:self.linkProperties.alias];
+                
+        self.shareURL = [[NSURL alloc] initWithString:URLString];
     }
     
     if (self.returnURL) {
@@ -274,36 +283,6 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
 
     // Else activityItem.itemType == BranchShareActivityItemTypeURL
 
-    return [self createShortLink];
-}
-
-- (BOOL) returnURL {
-    BOOL returnURL = YES;
-    if ([UIDevice currentDevice].systemVersion.doubleValue >= 11.0 &&
-        [UIDevice currentDevice].systemVersion.doubleValue  < 11.2 &&
-        [self.activityType isEqualToString:UIActivityTypeCopyToPasteboard]) {
-        returnURL = NO;
-    }
-    return returnURL;
-}
-
-- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController  // called to determine data type. only the class of the return type is consulted. it should match what -itemForActivityType: returns later
-{
-    return @"";
-}
-
-- (nullable LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)activityViewController API_AVAILABLE(ios(13.0))
-{
-    return self.lpMetaData;
-}
-
-- (nullable id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(nullable UIActivityType)activityType   // called to fetch data after an activity is selected. you can return nil.
-{
-    return nil;
-}
-
-- (id) createShortLink {
-    
     // Because Facebook et al immediately scrape URLs, we add an additional parameter to the
     // existing list, telling the backend to ignore the first click.
     
@@ -335,8 +314,31 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
             forceLinkCreation:YES];
     self.shareURL = [NSURL URLWithString:URLString];
     return (self.returnURL) ? self.shareURL :self.shareURL.absoluteString;
-    
 }
 
+- (BOOL) returnURL {
+    BOOL returnURL = YES;
+    if ([UIDevice currentDevice].systemVersion.doubleValue >= 11.0 &&
+        [UIDevice currentDevice].systemVersion.doubleValue  < 11.2 &&
+        [self.activityType isEqualToString:UIActivityTypeCopyToPasteboard]) {
+        returnURL = NO;
+    }
+    return returnURL;
+}
+
+- (id)activityViewControllerPlaceholderItem:(UIActivityViewController *)activityViewController  // called to determine data type. only the class of the return type is consulted. it should match what -itemForActivityType: returns later
+{
+    return @"";
+}
+
+- (nullable LPLinkMetadata *)activityViewControllerLinkMetadata:(UIActivityViewController *)activityViewController API_AVAILABLE(ios(13.0))
+{
+    return self.lpMetaData;
+}
+
+- (nullable id)activityViewController:(UIActivityViewController *)activityViewController itemForActivityType:(nullable UIActivityType)activityType   // called to fetch data after an activity is selected. you can return nil.
+{
+    return nil;
+}
 
 @end


### PR DESCRIPTION
Created a method that returns a long URL with app.link. This is used to properly show the app.link URL, link title, and link image in the Share Sheet preview

It fetches the user's app.link from preferenceHelper.userUrl, then shortens it to just the *.app.link. If one isn't available, then the usual bnc.lt long URL is generated like before.