### PR TITLE
SDK-1391 : Don't Delete response fields from shared preference if the…

### DIFF
--- a/Branch-SDK/BranchOpenRequest.m
+++ b/Branch-SDK/BranchOpenRequest.m
@@ -161,16 +161,22 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
     if ([userIdentity isKindOfClass:[NSNumber class]]) {
         userIdentity = [userIdentity stringValue];
     }
-
-    preferenceHelper.randomizedDeviceToken = data[BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN];
-    if (!preferenceHelper.randomizedDeviceToken) {
-        // fallback to deprecated name. Fingerprinting was removed long ago, hence the name change.
-        preferenceHelper.randomizedDeviceToken = data[@"device_fingerprint_id"];
-    }
     
-    preferenceHelper.userUrl = data[BRANCH_RESPONSE_KEY_USER_URL];
+    
+    if ([data objectForKey:BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN]) {
+        preferenceHelper.randomizedDeviceToken = data[BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN];
+        if (!preferenceHelper.randomizedDeviceToken) {
+            // fallback to deprecated name. Fingerprinting was removed long ago, hence the name change.
+            preferenceHelper.randomizedDeviceToken = data[@"device_fingerprint_id"];
+        }
+    }
+   
+    if (data[BRANCH_RESPONSE_KEY_USER_URL]) {
+        preferenceHelper.userUrl = data[BRANCH_RESPONSE_KEY_USER_URL];
+    }
     preferenceHelper.userIdentity = userIdentity;
-    preferenceHelper.sessionID = data[BRANCH_RESPONSE_KEY_SESSION_ID];
+    if ([data objectForKey:BRANCH_RESPONSE_KEY_SESSION_ID])
+        preferenceHelper.sessionID = data[BRANCH_RESPONSE_KEY_SESSION_ID];
     preferenceHelper.previousAppBuildDate = [BNCApplication currentApplication].currentBuildDate;
 
     

--- a/Branch-SDK/BranchSetIdentityRequest.m
+++ b/Branch-SDK/BranchSetIdentityRequest.m
@@ -52,8 +52,11 @@
     }
     
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
-    preferenceHelper.randomizedBundleToken = BNCStringFromWireFormat(response.data[BRANCH_RESPONSE_KEY_RANDOMIZED_BUNDLE_TOKEN]);
-    preferenceHelper.userUrl = response.data[BRANCH_RESPONSE_KEY_USER_URL];
+    if (response.data[BRANCH_RESPONSE_KEY_RANDOMIZED_BUNDLE_TOKEN])
+        preferenceHelper.randomizedBundleToken = BNCStringFromWireFormat(response.data[BRANCH_RESPONSE_KEY_RANDOMIZED_BUNDLE_TOKEN]);
+    if (response.data[BRANCH_RESPONSE_KEY_USER_URL]) {
+        preferenceHelper.userUrl = response.data[BRANCH_RESPONSE_KEY_USER_URL];
+    }
     preferenceHelper.userIdentity = self.userId;
     if (response.data[BRANCH_RESPONSE_KEY_SESSION_ID]) {
         preferenceHelper.sessionID = response.data[BRANCH_RESPONSE_KEY_SESSION_ID];

--- a/Branch-TestBed/Branch-SDK-Tests/BranchSetIdentityRequestTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchSetIdentityRequestTests.m
@@ -156,4 +156,26 @@ static NSString * const IDENTITY_TEST_USER_ID = @"foo_id";
     XCTAssertEqualObjects(preferenceHelper.installParams, RESPONSE_INSTALL_PARAMS);
 }
 
+
+- (void)testEmptyResponseFieldsAfterSetIdentity {
+    
+    BNCServerResponse *response = [[BNCServerResponse alloc] init];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    
+    __block NSInteger callbackCount = 0;
+    
+    BranchSetIdentityRequest *request = [[BranchSetIdentityRequest alloc] initWithUserId:IDENTITY_TEST_USER_ID callback:^(NSDictionary *params, NSError *error) {
+        callbackCount++;
+        XCTAssertNil(error);
+    }];
+    
+    response.data = @{};
+    [request processResponse:response error:nil];
+    
+    XCTAssertNotNil(preferenceHelper.randomizedDeviceToken);
+    XCTAssertNotNil(preferenceHelper.userUrl);
+    XCTAssertNotNil(preferenceHelper.sessionID);
+    XCTAssertNotNil(preferenceHelper.randomizedBundleToken);
+}
+
 @end


### PR DESCRIPTION
…y are empty

Updated class BranchOpenRequest and BranchSetIdentity to save session_id, randomized_bundle_token (identity_id), randomized_device_token (device_fingerprint_id) and
link, in shared preferences, only if they are non-empty.