### PR TITLE
Add missing `LinkPresentation` dep to podspec

### DIFF
--- a/Branch.podspec
+++ b/Branch.podspec
@@ -32,5 +32,6 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
 	"Branch-SDK/BranchShareLink.{h,m}"
 
   s.frameworks = 'CoreServices', 'SystemConfiguration'
+  s.weak_framework = 'LinkPresentation'
   s.ios.frameworks = 'WebKit', 'iAd', 'CoreTelephony'
 end


### PR DESCRIPTION
https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/pull/1122 added the dependence on `LinkPresentation`. This adds it so `weak_framework` since it's only available in iOS 13.0 and up.