### PR TITLE
Change `URLSession` delegate queue to have `background` QOS

### DIFF
--- a/Branch-SDK/BNCNetworkService.m
+++ b/Branch-SDK/BNCNetworkService.m
@@ -124,10 +124,7 @@
         self.sessionQueue = [NSOperationQueue new];
         self.sessionQueue.name = @"io.branch.sdk.network.queue";
         self.sessionQueue.maxConcurrentOperationCount = self.maximumConcurrentOperations;
-        if ([self.sessionQueue respondsToSelector:@selector(setQualityOfService:)]) {
-            // qualityOfService is iOS 8 and above.
-            self.sessionQueue.qualityOfService = NSQualityOfServiceUserInteractive;
-        }
+        self.sessionQueue.qualityOfService = NSQualityOfServiceBackground;
 
         _session =
             [NSURLSession sessionWithConfiguration:configuration


### PR DESCRIPTION
The current QOS of `userInteractive` is meant for interactive UI only. Network responses don't meet this bar and seem more suited to `background` which is meant for systems that the user is unaware of.

This also removes the runtime API check since the Branch SDK only supports iOS versions with the QOS API.

Fixes: https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/issues/1182