### PR TITLE
[SDK-1528] Add developer_identity to v1/open requests

### DIFF
--- a/Branch-SDK/BNCPreferenceHelper.m
+++ b/Branch-SDK/BNCPreferenceHelper.m
@@ -709,7 +709,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
          // Don't clear these
          self.randomizedDeviceToken = nil;
          self.randomizedBundleToken = nil;
-         self.userIdentity = nil;
          */
         self.sessionID = nil;
         self.linkClickIdentifier = nil;
@@ -726,6 +725,7 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
         self.previousAppBuildDate = nil;
         self.requestMetadataDictionary = nil;
         self.lastStrongMatchDate = nil;
+        self.userIdentity = nil;
     }
 }
 

--- a/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/BNCServerInterface.m
@@ -400,6 +400,7 @@
         preparedParams[@"randomized_bundle_token"] = nil;
         preparedParams[@"identity"] = nil;
         preparedParams[@"update"] = nil;
+        preparedParams[@"developer_identity"] = nil;
     }
     NSData *postData = [BNCEncodingUtils encodeDictionaryToJsonData:preparedParams];
     NSString *postLength = [NSString stringWithFormat:@"%lu", (unsigned long)[postData length]];
@@ -472,6 +473,11 @@
             }
         }
     }
+    
+    if ([self.requestEndpoint containsString:@"/v1/open"]) {
+        [fullParamDict bnc_safeSetObject:[BNCPreferenceHelper sharedInstance].userIdentity forKey:@"developer_identity"];
+    }
+    
     return fullParamDict;
 }
 

--- a/Branch-SDK/BNCServerInterface.m
+++ b/Branch-SDK/BNCServerInterface.m
@@ -400,7 +400,6 @@
         preparedParams[@"randomized_bundle_token"] = nil;
         preparedParams[@"identity"] = nil;
         preparedParams[@"update"] = nil;
-        preparedParams[@"developer_identity"] = nil;
     }
     NSData *postData = [BNCEncodingUtils encodeDictionaryToJsonData:preparedParams];
     NSString *postLength = [NSString stringWithFormat:@"%lu", (unsigned long)[postData length]];
@@ -475,7 +474,7 @@
     }
     
     if ([self.requestEndpoint containsString:@"/v1/open"]) {
-        [fullParamDict bnc_safeSetObject:[BNCPreferenceHelper sharedInstance].userIdentity forKey:@"developer_identity"];
+        [fullParamDict bnc_safeSetObject:[BNCPreferenceHelper sharedInstance].userIdentity forKey:@"identity"];
     }
     
     return fullParamDict;


### PR DESCRIPTION
- Adds the `developer_identity field` to v1/open requests under the `identity` parameter. Also clears `developer_identity` when logging out or disabling tracking.

https://branch.atlassian.net/browse/SDK-1528