### PR TITLE
SDK-1625 Protect BNCDeviceInfo

### DIFF
--- a/Branch-SDK/BranchPluginSupport.m
+++ b/Branch-SDK/BranchPluginSupport.m
@@ -28,28 +28,29 @@
 
 
 - (NSDictionary<NSString *, NSString *> *)deviceDescription {
-    BNCDeviceInfo *deviceInfo = [BNCDeviceInfo getInstance];
-    [deviceInfo checkAdvertisingIdentifier];
-    
     NSMutableDictionary<NSString *, NSString *> *dictionary = [NSMutableDictionary new];
-        
-    [dictionary bnc_safeSetObject:deviceInfo.osName forKey:@"os"];
-    [dictionary bnc_safeSetObject:deviceInfo.osVersion forKey:@"os_version"];
-    [dictionary bnc_safeSetObject:deviceInfo.environment forKey:@"environment"];
-    [dictionary bnc_safeSetObject:deviceInfo.vendorId forKey:@"idfv"];
-    [dictionary bnc_safeSetObject:deviceInfo.advertiserId forKey:@"idfa"];
-    [dictionary bnc_safeSetObject:deviceInfo.optedInStatus forKey:@"opted_in_status"];
-    [dictionary bnc_safeSetObject:[BNCPreferenceHelper sharedInstance].userIdentity forKey:@"developer_identity"];
-    [dictionary bnc_safeSetObject:deviceInfo.country forKey:@"country"];
-    [dictionary bnc_safeSetObject:deviceInfo.language forKey:@"language"];
-    [dictionary bnc_safeSetObject:deviceInfo.localIPAddress forKey:@"local_ip"];
-    [dictionary bnc_safeSetObject:deviceInfo.brandName forKey:@"brand"];
-    [dictionary bnc_safeSetObject:deviceInfo.applicationVersion forKey:@"app_version"];
-    [dictionary bnc_safeSetObject:deviceInfo.modelName forKey:@"model"];
-    [dictionary bnc_safeSetObject:deviceInfo.screenScale.stringValue forKey:@"screen_dpi"];
-    [dictionary bnc_safeSetObject:deviceInfo.screenHeight.stringValue forKey:@"screen_height"];
-    [dictionary bnc_safeSetObject:deviceInfo.screenWidth.stringValue forKey:@"screen_width"];
+    BNCDeviceInfo *deviceInfo = [BNCDeviceInfo getInstance];
     
+    @synchronized (deviceInfo) {
+        [deviceInfo checkAdvertisingIdentifier];
+            
+        [dictionary bnc_safeSetObject:deviceInfo.osName forKey:@"os"];
+        [dictionary bnc_safeSetObject:deviceInfo.osVersion forKey:@"os_version"];
+        [dictionary bnc_safeSetObject:deviceInfo.environment forKey:@"environment"];
+        [dictionary bnc_safeSetObject:deviceInfo.vendorId forKey:@"idfv"];
+        [dictionary bnc_safeSetObject:deviceInfo.advertiserId forKey:@"idfa"];
+        [dictionary bnc_safeSetObject:deviceInfo.optedInStatus forKey:@"opted_in_status"];
+        [dictionary bnc_safeSetObject:[BNCPreferenceHelper sharedInstance].userIdentity forKey:@"developer_identity"];
+        [dictionary bnc_safeSetObject:deviceInfo.country forKey:@"country"];
+        [dictionary bnc_safeSetObject:deviceInfo.language forKey:@"language"];
+        [dictionary bnc_safeSetObject:deviceInfo.localIPAddress forKey:@"local_ip"];
+        [dictionary bnc_safeSetObject:deviceInfo.brandName forKey:@"brand"];
+        [dictionary bnc_safeSetObject:deviceInfo.applicationVersion forKey:@"app_version"];
+        [dictionary bnc_safeSetObject:deviceInfo.modelName forKey:@"model"];
+        [dictionary bnc_safeSetObject:deviceInfo.screenScale.stringValue forKey:@"screen_dpi"];
+        [dictionary bnc_safeSetObject:deviceInfo.screenHeight.stringValue forKey:@"screen_height"];
+        [dictionary bnc_safeSetObject:deviceInfo.screenWidth.stringValue forKey:@"screen_width"];
+    }
     return dictionary;
 }
 


### PR DESCRIPTION
## Reference
SDK-1625
INTENG-15831

## Summary
Updated BranchPluginSupport to safely use BNCDeviceInfo. This mirrors the code within BNCDeviceInfo itself.

## Motivation
Reports of a rare crash in this area code when using Adobe Launch iOS.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
The crash is fairly rare, the only reliable repro we've seen is using AdobeLaunch iOS on a real device running an older version of iOS. We suspect this is due to a threading issue where BNCDeviceInfo is being mutated from multiple threads.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->
