### PR TITLE
SDK-1664 update min iOS and tvOS versions to 11

### DIFF
--- a/Branch.podspec
+++ b/Branch.podspec
@@ -15,8 +15,8 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
   s.license          = 'MIT'
   s.author           = { "Branch" => "sdk-team@branch.io" }
   s.source           = { git: "https://github.com/BranchMetrics/ios-branch-deep-linking-attribution.git", tag: s.version.to_s }
-  s.ios.deployment_target = '9.0'
-  s.tvos.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
+  s.tvos.deployment_target = '11.0'
 
   s.ios.source_files = "Branch-SDK/*.{h,m}"
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@ v.1.44.0
 - SDK-1480 [iOS 16] UIPaste Support for NativeLink Flow 
     * Added API 'passPasteItemProviders'
     * Added class 'BranchPasteControl'
+- Requires Xcode 14+
+
 - Known Issues:
     * Integration with Carthage fails for tvOS.
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "Branch",
     platforms: [
-        .iOS(.v9),
-        .tvOS(.v9),
+        .iOS(.v11),
+        .tvOS(.v11),
     ],
     products: [
         .library(

--- a/carthage-files/BranchSDK.xcodeproj/project.pbxproj
+++ b/carthage-files/BranchSDK.xcodeproj/project.pbxproj
@@ -1377,7 +1377,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# config\nIOS_PATH=\"./build/ios/ios.xcarchive\"\nIOS_SIM_PATH=\"./build/ios/ios_sim.xcarchive\"\nXCFRAMEWORK_PATH=\"./build/Branch.xcframework\"\nCATALYST_PATH=\"./build/catalyst/catalyst.xcarchive\"\nSTATIC_LIB_SIM_PATH=\"./build/Branch.sim\"\nSTATIC_LIB_PATH=\"./build/Branch.a\"\n\n# delete previous build\nrm -rf \"./build\" \n\n# build iOS framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${IOS_PATH}\" \\\n    -sdk iphoneos \\\n    SKIP_INSTALL=NO \\\n    GCC_PREPROCESSOR_DEFINITIONS='${inherited} BRANCH_EXCLUDE_IDFA_CODE=1'\n    \n# build iOS simulator framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${IOS_SIM_PATH}\" \\\n    -sdk iphonesimulator \\\n    SKIP_INSTALL=NO \\\n    GCC_PREPROCESSOR_DEFINITIONS='${inherited} BRANCH_EXCLUDE_IDFA_CODE=1'\n\n# build Catalyst framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${CATALYST_PATH}\" \\\n    -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' \\\n    SKIP_INSTALL=NO \\\n    GCC_PREPROCESSOR_DEFINITIONS='${inherited} BRANCH_EXCLUDE_IDFA_CODE=1'\n    \n# package frameworks\nxcodebuild -create-xcframework \\\n    -framework \"${IOS_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -framework \"${IOS_SIM_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -framework \"${CATALYST_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -output \"${XCFRAMEWORK_PATH}\"\n\n# build a static fat library from the xcframework\n# this is used by xamarin\nTEMP_LIB_PATH=\"./build/Branch.sim\"\nLIBRARY_PATH=\"./build/Branch.a\"\n\n# create simulator library without m1\nlipo -output \"${TEMP_LIB_PATH}\" -remove arm64 \"${XCFRAMEWORK_PATH}/ios-arm64_i386_x86_64-simulator/Branch.framework/Branch\"\n\n# create a fat static library\nlipo \"${XCFRAMEWORK_PATH}/ios-arm64_armv7/Branch.framework/Branch\" \"${TEMP_LIB_PATH}\" -create -output \"${LIBRARY_PATH}\"\n";
+			shellScript = "# config\nIOS_PATH=\"./build/ios/ios.xcarchive\"\nIOS_SIM_PATH=\"./build/ios/ios_sim.xcarchive\"\nXCFRAMEWORK_PATH=\"./build/Branch.xcframework\"\nCATALYST_PATH=\"./build/catalyst/catalyst.xcarchive\"\nSTATIC_LIB_SIM_PATH=\"./build/Branch.sim\"\nSTATIC_LIB_PATH=\"./build/Branch.a\"\n\n# delete previous build\nrm -rf \"./build\" \n\n# build iOS framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${IOS_PATH}\" \\\n    -sdk iphoneos \\\n    SKIP_INSTALL=NO \\\n    GCC_PREPROCESSOR_DEFINITIONS='${inherited} BRANCH_EXCLUDE_IDFA_CODE=1'\n    \n# build iOS simulator framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${IOS_SIM_PATH}\" \\\n    -sdk iphonesimulator \\\n    SKIP_INSTALL=NO \\\n    GCC_PREPROCESSOR_DEFINITIONS='${inherited} BRANCH_EXCLUDE_IDFA_CODE=1'\n\n# build Catalyst framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${CATALYST_PATH}\" \\\n    -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' \\\n    SKIP_INSTALL=NO \\\n    GCC_PREPROCESSOR_DEFINITIONS='${inherited} BRANCH_EXCLUDE_IDFA_CODE=1'\n    \n# package frameworks\nxcodebuild -create-xcframework \\\n    -framework \"${IOS_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -framework \"${IOS_SIM_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -framework \"${CATALYST_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -output \"${XCFRAMEWORK_PATH}\"\n\n# build a static fat library from the xcframework\n# this is used by xamarin\nTEMP_LIB_PATH=\"./build/Branch.sim\"\nLIBRARY_PATH=\"./build/Branch.a\"\n\n# create simulator library without m1\nlipo -output \"${TEMP_LIB_PATH}\" -remove arm64 \"${XCFRAMEWORK_PATH}/ios-arm64_x86_64-simulator/Branch.framework/Branch\"\n\n# create a fat static library\nlipo \"${XCFRAMEWORK_PATH}/ios-arm64/Branch.framework/Branch\" \"${TEMP_LIB_PATH}\" -create -output \"${LIBRARY_PATH}\"\n";
 		};
 		5FD0FB1725CE4B93008200EE /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1394,7 +1394,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# config\nIOS_PATH=\"./build/ios/ios.xcarchive\"\nIOS_SIM_PATH=\"./build/ios/ios_sim.xcarchive\"\nCATALYST_PATH=\"./build/catalyst/catalyst.xcarchive\"\nXCFRAMEWORK_PATH=\"./build/Branch.xcframework\"\n\n# delete previous build\nrm -rf \"./build\" \n\n# build iOS framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${IOS_PATH}\" \\\n    -sdk iphoneos \\\n    SKIP_INSTALL=NO\n\n# build iOS simulator framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${IOS_SIM_PATH}\" \\\n    -sdk iphonesimulator \\\n    SKIP_INSTALL=NO\n    \n# build Catalyst framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${CATALYST_PATH}\" \\\n    -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' \\\n    SKIP_INSTALL=NO\n\n# package frameworks\nxcodebuild -create-xcframework \\\n    -framework \"${IOS_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -framework \"${IOS_SIM_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -framework \"${CATALYST_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -output \"${XCFRAMEWORK_PATH}\"\n    \n# build a static fat library from the xcframework\n# this is used by xamarin\nTEMP_LIB_PATH=\"./build/Branch.sim\"\nLIBRARY_PATH=\"./build/Branch.a\"\n\n# create simulator library without m1\nlipo -output \"${TEMP_LIB_PATH}\" -remove arm64 \"${XCFRAMEWORK_PATH}/ios-arm64_i386_x86_64-simulator/Branch.framework/Branch\"\n\n# create a fat static library\nlipo \"${XCFRAMEWORK_PATH}/ios-arm64_armv7/Branch.framework/Branch\" \"${TEMP_LIB_PATH}\" -create -output \"${LIBRARY_PATH}\"\n";
+			shellScript = "# config\nIOS_PATH=\"./build/ios/ios.xcarchive\"\nIOS_SIM_PATH=\"./build/ios/ios_sim.xcarchive\"\nCATALYST_PATH=\"./build/catalyst/catalyst.xcarchive\"\nXCFRAMEWORK_PATH=\"./build/Branch.xcframework\"\n\n# delete previous build\nrm -rf \"./build\" \n\n# build iOS framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${IOS_PATH}\" \\\n    -sdk iphoneos \\\n    SKIP_INSTALL=NO\n\n# build iOS simulator framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${IOS_SIM_PATH}\" \\\n    -sdk iphonesimulator \\\n    SKIP_INSTALL=NO\n    \n# build Catalyst framework\nxcodebuild archive \\\n    -scheme Branch-static \\\n    -archivePath \"${CATALYST_PATH}\" \\\n    -destination 'platform=macOS,arch=x86_64,variant=Mac Catalyst' \\\n    SKIP_INSTALL=NO\n\n# package frameworks\nxcodebuild -create-xcframework \\\n    -framework \"${IOS_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -framework \"${IOS_SIM_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -framework \"${CATALYST_PATH}/Products/Library/Frameworks/Branch.framework\" \\\n    -output \"${XCFRAMEWORK_PATH}\"\n    \n# build a static fat library from the xcframework\n# this is used by xamarin\nTEMP_LIB_PATH=\"./build/Branch.sim\"\nLIBRARY_PATH=\"./build/Branch.a\"\n\n# create simulator library without m1\nlipo -output \"${TEMP_LIB_PATH}\" -remove arm64 \"${XCFRAMEWORK_PATH}/ios-arm64_x86_64-simulator/Branch.framework/Branch\"\n\n# create a fat static library\nlipo \"${XCFRAMEWORK_PATH}/ios-arm64/Branch.framework/Branch\" \"${TEMP_LIB_PATH}\" -create -output \"${LIBRARY_PATH}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1734,7 +1734,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -1770,7 +1770,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};
@@ -1787,7 +1787,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Branch/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_DYLIB_INSTALL_NAME = "@rpath/Branch.framework/Branch";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
@@ -1816,7 +1816,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Branch/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_DYLIB_INSTALL_NAME = "@rpath/Branch.framework/Branch";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
@@ -1973,7 +1973,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Branch/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.44.0;
@@ -2000,7 +2000,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Branch/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MARKETING_VERSION = 1.44.0;

--- a/carthage-files/checksum.txt
+++ b/carthage-files/checksum.txt
@@ -1,2 +1,2 @@
 #checksum for Branch on Github
-03e74d6076c777217808572da5074f357fa119f5  Branch.zip
+483f7057c26e1b5b5302d4310483e78b7b68d8cc  Branch.zip

--- a/carthage-files/checksum_noidfa.txt
+++ b/carthage-files/checksum_noidfa.txt
@@ -1,2 +1,2 @@
 #checksum for Branch on Github
-47d2a6459ab74dd011a5a4991995a51df7224dce  Branch_noidfa.zip
+b0184caa0f6b080f23af335fa930a80351d9c149  Branch_noidfa.zip

--- a/carthage-files/checksum_static.txt
+++ b/carthage-files/checksum_static.txt
@@ -1,2 +1,2 @@
 #checksum for Branch on Github
-78821eef9f0a841f4b4dcd8f7fb8a6cc6fa65656  Branch_static.zip
+0f37d54624b21aa43b61c1c4cc4929766cf66d3e  Branch_static.zip

--- a/carthage-files/checksum_static_noidfa.txt
+++ b/carthage-files/checksum_static_noidfa.txt
@@ -1,2 +1,2 @@
 #checksum for Branch on Github
-ef983060b38928408de2342b912fec688bd38d50  Branch_static_noidfa.zip
+9c56d578e84a38bc102ed71e439ba4009a0dd827  Branch_static_noidfa.zip


### PR DESCRIPTION


## Reference
SDK-1664 release

## Summary
The new pasteboard code requires Xcode 14+


## Type Of Change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing Instructions
Xcode 14 ups the min version to iOS 11 and tvOS 11.
[] podspec min is 11
[] SPM min is 11
[] Branch.a fat binary build no longer looks for i386 and armv7



