### PR TITLE
Sdk 1671 - mark v1event methods deprecated

### DIFF
--- a/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch.h
@@ -970,7 +970,7 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  
  @param action The action string.
  */
-- (void)userCompletedAction:(nullable NSString *)action;
+- (void)userCompletedAction:(nullable NSString *)action __attribute__((deprecated(("Please use BranchEvent to track commerce events. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information."))));
 
 /**
  Send a user action to the server with additional state items. Some examples actions could be things like `viewed_personal_welcome`, `purchased_an_item`, etc.
@@ -982,7 +982,7 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  @param action The action string.
  @param state The additional state items associated with the action.
  */
-- (void)userCompletedAction:(nullable NSString *)action withState:(nullable NSDictionary *)state;
+- (void)userCompletedAction:(nullable NSString *)action withState:(nullable NSDictionary *)state __attribute__((deprecated(("Please use BranchEvent to track commerce events. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information."))));
 
 /**
  Send a user action to the server with additional state items. Some examples actions could be things like `viewed_personal_welcome`, `purchased_an_item`, etc.
@@ -997,7 +997,7 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  
  @deprecated Please use userCompletedAction:action:state instead
  */
-- (void)userCompletedAction:(nullable NSString *)action withState:(nullable NSDictionary *)state withDelegate:(nullable id)branchViewCallback __attribute__((deprecated(("This API is deprecated. Please use userCompletedAction:action:state instead."))));
+- (void)userCompletedAction:(nullable NSString *)action withState:(nullable NSDictionary *)state withDelegate:(nullable id)branchViewCallback __attribute__((deprecated(("Please use BranchEvent to track commerce events. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information."))));
 
 /**
  Sends a user commerce event to the server.
@@ -1019,7 +1019,7 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  */
 - (void) sendCommerceEvent:(BNCCommerceEvent*)commerceEvent
 				  metadata:(NSDictionary<NSString*,id>*)metadata
-			withCompletion:(void (^) (NSDictionary* _Nullable response, NSError* _Nullable error))completion __attribute__((deprecated(("Please use BranchEvent to track commerce events."))));
+			withCompletion:(void (^) (NSDictionary* _Nullable response, NSError* _Nullable error))completion __attribute__((deprecated(("Please use BranchEvent to track commerce events. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information."))));
 
 
 #pragma mark - Query methods

--- a/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch.m
@@ -1135,7 +1135,7 @@ static NSString *bnc_branchKey = nil;
 
 - (void)userCompletedAction:(NSString *)action withState:(NSDictionary *)state {
     
-    BNCLogWarning(@"'userCompletedAction' method has been deprecated. Please use BranchEvent for your event tracking use cases. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information.");
+    NSLog(@"'userCompletedAction' method has been deprecated. Please use BranchEvent for your event tracking use cases. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information.");
     
     if (!action) {
         return;
@@ -1167,7 +1167,7 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)sendCommerceEvent:(BNCCommerceEvent *)commerceEvent metadata:(NSDictionary*)metadata withCompletion:(void (^)(NSDictionary *, NSError *))completion {
-    BNCLogWarning(@"'sendCommerceEvent' method has been deprecated. Please use BranchEvent for your event tracking use cases. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information.");
+    NSLog(@"'sendCommerceEvent' method has been deprecated. Please use BranchEvent for your event tracking use cases. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information.");
     [self initSafetyCheck];
     dispatch_async(self.isolationQueue, ^(){
         BranchCommerceEventRequest *request = [[BranchCommerceEventRequest alloc] initWithCommerceEvent:commerceEvent metadata:metadata completion:completion];

--- a/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch.m
@@ -1134,6 +1134,9 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)userCompletedAction:(NSString *)action withState:(NSDictionary *)state {
+    
+    BNCLogWarning(@"'userCompletedAction' method has been deprecated. Please use BranchEvent for your event tracking use cases. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information.");
+    
     if (!action) {
         return;
     }
@@ -1164,6 +1167,7 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)sendCommerceEvent:(BNCCommerceEvent *)commerceEvent metadata:(NSDictionary*)metadata withCompletion:(void (^)(NSDictionary *, NSError *))completion {
+    BNCLogWarning(@"'sendCommerceEvent' method has been deprecated. Please use BranchEvent for your event tracking use cases. You can refer to https://help.branch.io/developers-hub/docs/tracking-commerce-content-lifecycle-and-custom-events for additional information.");
     [self initSafetyCheck];
     dispatch_async(self.isolationQueue, ^(){
         BranchCommerceEventRequest *request = [[BranchCommerceEventRequest alloc] initWithCommerceEvent:commerceEvent metadata:metadata completion:completion];


### PR DESCRIPTION
## Reference
SDK - 1671 [iOS] Mark v1/event methods as deprecated  

## Summary
Marked 'sendCommerceEvent' ans 'userCompletedAction' methods as deprecated. Added runtime warning messages using NSLog also when these methods are used

## Motivation
Remove v1/event method calls

## Type Of Change
- [ ] New feature (non-breaking change which adds functionality)

## Testing Instructions
* Compile TestBed App and check Build logs for deprecated methods warning.
* In Test bed, press buttons - 'Send Complex Event' and 'Send Commerce Event' and see if warning methods are printed.
* Check if logs are printed even if SDK logging is not enabled.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->
