### PR TITLE
[SDK-1714][minor] - Added v2/qr-code parameters

### DIFF
--- a/Branch-SDK/BranchQRCode.h
+++ b/Branch-SDK/BranchQRCode.h
@@ -16,6 +16,22 @@ typedef NS_ENUM(NSInteger, BranchQRCodeImageFormat){
     BranchQRCodeImageFormatJPEG
 };
 
+typedef NS_ENUM(NSInteger, BranchQRCodePattern){
+    BranchQRCodePatternStandard = 1,
+    BranchQRCodePatternSquares = 2,
+    BranchQRCodePatternCircles = 3,
+    BranchQRCodePatternTriangles = 4,
+    BranchQRCodePatternDiamonds = 5,
+    BranchQRCodePatternHexagons = 6,
+    BranchQRCodePatternOctagons = 7,
+};
+
+typedef NS_ENUM(NSInteger, BranchQRCodeFinderPattern){
+    BranchQRCodeFinderPatternSquare = 1,
+    BranchQRCodeFinderPatternRoundedRectangle = 2,
+    BranchQRCodeFinderPatternCircle = 3,
+};
+
 @interface BranchQRCode : NSObject
 
 /// Primary color of the generated QR code itself.
@@ -30,6 +46,20 @@ typedef NS_ENUM(NSInteger, BranchQRCodeImageFormat){
 @property (nonatomic, copy, readwrite) NSNumber *margin;
 /// Format of the returned QR code. Can be a JPEG or PNG.
 @property (nonatomic, assign, readwrite) BranchQRCodeImageFormat imageFormat;
+/// The style of code pattern used to generate the QR code.
+@property (nonatomic, assign, readwrite) BranchQRCodePattern pattern;
+/// The style of finder pattern used to generate the QR code.
+@property (nonatomic, assign, readwrite) BranchQRCodeFinderPattern finderPattern;
+/// Color of the QR code's finder pattern.
+@property (nonatomic, strong, readwrite) UIColor *finderPatternColor;
+/// A URL of an image that will be added to the background of the QR code. Must be a PNG or JPEG.
+@property (nonatomic, copy, readwrite) NSString *backgroundImage;
+/// Adjusts the opacity of the background image from 1-99.
+@property (nonatomic, copy, readwrite) NSNumber *backgroundImageOpacity;
+/// A URL of an image to be used as the code-pattern itself on the QR Code.. Must be a PNG or JPEG.
+@property (nonatomic, copy, readwrite) NSString *patternImage;
+/// Color of the  interior part of a QR code’s finder pattern.
+@property (nonatomic, strong, readwrite) UIColor *finderEyeColor;
 
 /**
 Creates a Branch QR Code image. Returns the QR code as NSData.

--- a/Branch-SDK/BranchQRCode.m
+++ b/Branch-SDK/BranchQRCode.m
@@ -50,6 +50,18 @@
     _width = width;
 }
 
+- (void) setBackgroundImageOpacity:(NSNumber *)backgroundImageOpacity {
+    if (backgroundImageOpacity.intValue > 99) {
+        backgroundImageOpacity = @(99);
+        BNCLogWarning(@"Background image opacity was reduced to the maximum of 99.");
+    }
+    if (backgroundImageOpacity.intValue < 1) {
+        backgroundImageOpacity = @(1);
+        BNCLogWarning(@"Background image opacity was increased to the minimum of 1.");
+    }
+    _backgroundImageOpacity = backgroundImageOpacity;
+}
+
 - (void)getQRCodeAsData:(nullable BranchUniversalObject *)buo
          linkProperties:(nullable BranchLinkProperties *)lp
              completion:(void(^)(NSData * _Nullable qrCode, NSError * _Nullable error))completion {
@@ -60,18 +72,16 @@
     if (self.backgroundColor) { settings[@"background_color"] = [self hexStringForColor:self.backgroundColor]; }
     if (self.margin) { settings[@"margin"] = self.margin; }
     if (self.width) { settings[@"width"] = self.width; }
-    
+    if (self.centerLogo) { settings[@"center_logo_url"] = self.centerLogo; }
+    if (self.pattern) { settings[@"code_pattern"] = [[NSNumber alloc] initWithInt:(int)self.pattern]; }
+    if (self.finderPattern) { settings[@"finder_pattern"] = [[NSNumber alloc] initWithInt:(int)self.finderPattern]; }
+    if (self.finderPatternColor) { settings[@"finder_pattern_color"] = [self hexStringForColor:self.finderPatternColor]; }
+    if (self.backgroundImage) { settings[@"background_image_url"] = self.backgroundImage; }
+    if (self.patternImage) { settings[@"code_pattern_url"] = self.patternImage; }
+    if (self.backgroundImageOpacity) { settings[@"background_image_opacity"] = self.backgroundImageOpacity; }
+    if (self.finderEyeColor) { settings[@"finder_eye_color"] = [self hexStringForColor:self.finderEyeColor]; }
+
     settings[@"image_format"] = (self.imageFormat == BranchQRCodeImageFormatJPEG) ? @"JPEG" : @"PNG";
-    
-    if (self.centerLogo) {
-        NSData *data=[NSData dataWithContentsOfURL:[NSURL URLWithString: self.centerLogo]];
-        UIImage *image=[UIImage imageWithData:data];
-        if (image == nil) {
-            BNCLogWarning(@"QR code center logo was an invalid URL string.");
-        } else {
-            settings[@"center_logo_url"] = self.centerLogo;
-        }
-    }
     
     NSMutableDictionary *parameters = [NSMutableDictionary new];
     
@@ -121,7 +131,7 @@
     
     NSError *error;
     NSString *branchAPIURL = [BNC_API_BASE_URL copy];
-    NSString *urlString = [NSString stringWithFormat: @"%@/v1/qr-code", branchAPIURL];
+    NSString *urlString = [NSString stringWithFormat: @"%@/v2/qr-code", branchAPIURL];
     NSURL *url = [NSURL URLWithString: urlString];
     NSURLSession *session = [NSURLSession sharedSession];
     
@@ -251,11 +261,6 @@
 }
 #endif
 #endif
-
-- (BOOL)isValidUrl:(NSString *)urlString{
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:urlString]];
-    return [NSURLConnection canHandleRequest:request];
-}
 
 - (NSString *)hexStringForColor:(UIColor *)color {
     CGColorSpaceModel colorSpace = CGColorSpaceGetModel(CGColorGetColorSpace(color.CGColor));

--- a/Branch-TestBed/Branch-SDK-Tests/BranchQRCodeTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchQRCodeTests.m
@@ -27,6 +27,14 @@
     qrCode.centerLogo = @"https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg";
     qrCode.imageFormat = BranchQRCodeImageFormatPNG;
     
+    qrCode.pattern = BranchQRCodePatternCircles;
+    qrCode.finderPattern = BranchQRCodeFinderPatternCircle;
+    qrCode.finderPatternColor = UIColor.redColor;
+    qrCode.backgroundImage = @"https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg";
+    qrCode.backgroundImageOpacity = @20;
+    qrCode.patternImage = @"https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg";
+    qrCode.finderEyeColor = UIColor.orangeColor;
+    
     BranchUniversalObject *buo = [BranchUniversalObject new];
     BranchLinkProperties *lp = [BranchLinkProperties new];
     
@@ -38,7 +46,7 @@
     
     [self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {
         if (error) {
-            NSLog(@"Error Testing QR Code Cache: %@", error);
+            NSLog(@"Error Testing Normal QR Code Data With All Settings: %@", error);
             XCTFail();
         }
     }];
@@ -48,7 +56,6 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"Fetching QR Code"];
 
     BranchQRCode *qrCode = [BranchQRCode new];
-    
     BranchUniversalObject *buo = [BranchUniversalObject new];
     BranchLinkProperties *lp = [BranchLinkProperties new];
     
@@ -60,7 +67,7 @@
     
     [self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {
         if (error) {
-            NSLog(@"Error Testing QR Code Cache: %@", error);
+            NSLog(@"Error Testing Normal QR Code As Data With No Settings: %@", error);
             XCTFail();
         }
     }];
@@ -76,14 +83,13 @@
     BranchLinkProperties *lp = [BranchLinkProperties new];
     
     [qrCode getQRCodeAsData:buo linkProperties:lp completion:^(NSData * _Nonnull qrCode, NSError * _Nonnull error) {
-        XCTAssertNil(error);
-        XCTAssertNotNil(qrCode);
+        XCTAssertTrue([error.localizedFailureReason  isEqual: @"Unable to retrieve the image from the provided URL."]);
         [expectation fulfill];
     }];
     
     [self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {
         if (error) {
-            NSLog(@"Error Testing QR Code Cache: %@", error);
+            NSLog(@"Error Testing Normal QR Code With Invalid Logo URL: %@", error);
             XCTFail();
         }
     }];
@@ -105,7 +111,7 @@
     
     [self waitForExpectationsWithTimeout:10 handler:^(NSError *error) {
         if (error) {
-            NSLog(@"Error Testing QR Code Cache: %@", error);
+            NSLog(@"Error Testing Normal QR Code As Image: %@", error);
             XCTFail();
         }
     }];
@@ -133,7 +139,6 @@
         parameters[@"qr_code_settings"] = settings;
         parameters[@"data"] = [NSMutableDictionary new];
         parameters[@"branch_key"] = [Branch branchKey];
-        
         
         NSData *cachedQRCode = [[BNCQRCodeCache sharedInstance] checkQRCodeCache:parameters];
         

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -679,14 +679,11 @@ static inline void BNCPerformBlockOnMainThread(void (^ block)(void)) {
 
 - (IBAction)createQRCode:(id)sender {
     BranchQRCode *qrCode = [BranchQRCode new];
-    //qrCode.centerLogo = @"https://cdn.branch.io/branch-assets/1598575682753-og_image.png";
-    qrCode.codeColor = UIColor.blackColor;//[[UIColor new] initWithRed:0.1 green:0.8392 blue:0.8667 alpha:1.0];
-    qrCode.width = @700;
     qrCode.pattern = BranchQRCodePatternCircles;
     qrCode.finderPattern = BranchQRCodeFinderPatternCircle;
     qrCode.finderPatternColor = UIColor.redColor;
     qrCode.backgroundImage = @"https://cdn.branch.io/branch-assets/1598575682753-og_image.png";
-    qrCode.backgroundImageOpacity = @48;
+    qrCode.backgroundImageOpacity = @20;
     qrCode.patternImage = @"https://cdn.branch.io/branch-assets/1598575682753-og_image.png";
     qrCode.finderEyeColor = UIColor.orangeColor;
     

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -679,16 +679,28 @@ static inline void BNCPerformBlockOnMainThread(void (^ block)(void)) {
 
 - (IBAction)createQRCode:(id)sender {
     BranchQRCode *qrCode = [BranchQRCode new];
-    qrCode.centerLogo = @"https://cdn.branch.io/branch-assets/1598575682753-og_image.png";
-    qrCode.codeColor = [[UIColor new] initWithRed:0.1 green:0.8392 blue:0.8667 alpha:1.0];
+    //qrCode.centerLogo = @"https://cdn.branch.io/branch-assets/1598575682753-og_image.png";
+    qrCode.codeColor = UIColor.blackColor;//[[UIColor new] initWithRed:0.1 green:0.8392 blue:0.8667 alpha:1.0];
     qrCode.width = @700;
+    qrCode.pattern = BranchQRCodePatternCircles;
+    qrCode.finderPattern = BranchQRCodeFinderPatternCircle;
+    qrCode.finderPatternColor = UIColor.redColor;
+    qrCode.backgroundImage = @"https://cdn.branch.io/branch-assets/1598575682753-og_image.png";
+    qrCode.backgroundImageOpacity = @48;
+    qrCode.patternImage = @"https://cdn.branch.io/branch-assets/1598575682753-og_image.png";
+    qrCode.finderEyeColor = UIColor.orangeColor;
     
     BranchUniversalObject *buo = [BranchUniversalObject new];
     BranchLinkProperties *lp = [BranchLinkProperties new];
     
     [qrCode getQRCodeAsImage:buo linkProperties:lp completion:^(UIImage * _Nonnull qrCode, NSError * _Nonnull error) {
-        NSLog(@"Received QR Code Image: %@", qrCode);
+        if (error) {
+            NSLog(@"Error receiving QR Code Image: %@", error);
+            return;
+        }
         
+        NSLog(@"Received QR Code Image: %@", qrCode);
+
         dispatch_async(dispatch_get_main_queue(), ^{
 
             UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 200, 282)];


### PR DESCRIPTION
## Reference
SDK-1714 -- [iOS] Add support for v2/qr-code

## Summary
To support the new and improved `v2/qr-code` endpoint, a few parameters for QR code customization had to be added. This involved adding 2 new enums and 7 new properties to the `BranchQRCode.h` file. As well as updating `getQRCodeAsData()` in `BranchQRCode.m`. 
This change also removes the unused `isValidUrl()` function and removed the `dataWithContentsOfURL` check on image URLs as well because of a warning that shows up in iOS 16. 

The following properties were added:
- `pattern` for `code_pattern`
- `finderPattern` for `finder_pattern`
- `finderPatternColor` for`finder_pattern_color`
- `backgroundImage` for `background_image_url`
- `backgroundImageOpacity` for `background_image_opacity`
- `patternImage` for `code_pattern_url`
- `finderEyeColor` for `finder_eye_color`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The existing code was for `v1/qr-code` but `v2/qr-code` was recently released with some new features. For clients to utilize the new parameters, the SDK needed to be updated.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing Instructions
Create a QR code with the new parameters to ensure they're properly available. A good example/code snippet would be the `createQRcode()` function in the TestBed.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->
