### PR TITLE
GH-Issue-1212 Fix - Removed calls to callback from completion handler of updatePostbackConversionValue.

### DIFF
--- a/Branch-SDK/BranchEvent.m
+++ b/Branch-SDK/BranchEvent.m
@@ -80,8 +80,6 @@ BranchStandardEvent BranchStandardEventOptOut                 = @"OPT_OUT";
 	NSDictionary *dictionary = ([response.data isKindOfClass:[NSDictionary class]])
 		? (NSDictionary*) response.data : nil;
     
-    BOOL callCompletionHandler = YES;
-    
     if (dictionary && [dictionary[BRANCH_RESPONSE_KEY_UPDATE_CONVERSION_VALUE] isKindOfClass:NSNumber.class]) {
         NSNumber *conversionValue = (NSNumber *)dictionary[BRANCH_RESPONSE_KEY_UPDATE_CONVERSION_VALUE];
         // Regardless of SKAN opted-in in dashboard, we always get conversionValue, so adding check to find out if install/open response had "invoke_register_app" true
@@ -94,11 +92,7 @@ BranchStandardEvent BranchStandardEventOptOut                 = @"OPT_OUT";
                 BNCLogDebug([NSString stringWithFormat:@"SKAN 4.0 params - conversionValue:%@ coarseValue:%@, locked:%d, shouldCallPostback:%d, currentWindow:%d, firstAppLaunchTime: %@", conversionValue, coarseConversionValue, lockWin, shouldCallUpdatePostback, (int)[BNCPreferenceHelper sharedInstance].skanCurrentWindow, [BNCPreferenceHelper sharedInstance].firstAppLaunchTime]);
                 
                 if(shouldCallUpdatePostback){
-                    callCompletionHandler = NO;
                     [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue: conversionValue.longValue coarseValue:coarseConversionValue lockWindow:lockWin completionHandler:^(NSError * _Nullable error) {
-                        if (self.completion) {
-                            self.completion(dictionary, error);
-                        }
                         if (error) {
                             BNCLogError([NSString stringWithFormat:@"Update conversion value failed with error - %@", [error description]]);
                         } else {
@@ -109,11 +103,7 @@ BranchStandardEvent BranchStandardEventOptOut                 = @"OPT_OUT";
                 }
                 
             } else if (@available(iOS 15.4, *)) {
-                callCompletionHandler = NO;
                 [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue:conversionValue.intValue completionHandler: ^(NSError *error){
-                    if (self.completion) {
-                        self.completion(dictionary, error);
-                    }
                     if (error) {
                         BNCLogError([NSString stringWithFormat:@"Update conversion value failed with error - %@", [error description]]);
                     } else {
@@ -128,7 +118,7 @@ BranchStandardEvent BranchStandardEventOptOut                 = @"OPT_OUT";
         }
     }
     
-    if (self.completion && callCompletionHandler) {
+    if (self.completion) {
 		self.completion(dictionary, error);
     }
 }

--- a/Branch-SDK/BranchOpenRequest.m
+++ b/Branch-SDK/BranchOpenRequest.m
@@ -291,22 +291,14 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
         [[BNCAppGroupsData shared] saveAppClipData];
     }
     
-    BOOL callCalback = YES;
-    
     if ([data[BRANCH_RESPONSE_KEY_INVOKE_REGISTER_APP] isKindOfClass:NSNumber.class]) {
         NSNumber *invokeRegister = (NSNumber *)data[BRANCH_RESPONSE_KEY_INVOKE_REGISTER_APP];
         preferenceHelper.invokeRegisterApp = invokeRegister.boolValue;
         if (invokeRegister.boolValue && self.isInstall) {
             if (@available(iOS 16.1, *)){
-                callCalback = NO;
                 NSString *defaultCoarseConValue = [[BNCSKAdNetwork sharedInstance] getCoarseConversionValueFromDataResponse:@{}];
                 [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue:0 coarseValue:defaultCoarseConValue
                     lockWindow:NO completionHandler:^(NSError * _Nullable error) {
-                    
-                    if(self.callback){
-                        self.callback(YES, error);
-                    }
-                    
                     if (error) {
                         BNCLogError([NSString stringWithFormat:@"Update conversion value failed with error - %@", [error description]]);
                     } else {
@@ -314,12 +306,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
                     }
                 }];
             } else if (@available(iOS 15.4, *)){
-                callCalback = NO;
                 [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue:0 completionHandler:^(NSError * _Nullable error) {
-                    if(self.callback){
-                        self.callback(YES, error);
-                    }
-                    
                     if (error) {
                         BNCLogError([NSString stringWithFormat:@"Update conversion value failed with error - %@", [error description]]);
                     } else {
@@ -348,12 +335,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
                 BNCLogDebug([NSString stringWithFormat:@"SKAN 4.0 params - conversionValue:%@ coarseValue:%@, locked:%d, shouldCallPostback:%d, currentWindow:%d, firstAppLaunchTime: %@", conversionValue, coarseConversionValue, lockWin, shouldCallUpdatePostback, (int)preferenceHelper.skanCurrentWindow, preferenceHelper.firstAppLaunchTime]);
                 
                 if(shouldCallUpdatePostback){
-                    callCalback = NO;
                     [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue: conversionValue.longValue coarseValue:coarseConversionValue lockWindow:lockWin completionHandler:^(NSError * _Nullable error) {
-                        
-                        if(self.callback){
-                            self.callback(YES, error);
-                        }
                         
                         if (error) {
                             BNCLogError([NSString stringWithFormat:@"Update conversion value failed with error - %@", [error description]]);
@@ -363,12 +345,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
                     }];
                 }
             } else if (@available(iOS 15.4, *)) {
-                callCalback = NO;
                 [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue:conversionValue.intValue completionHandler: ^(NSError *error){
-                    
-                    if(self.callback){
-                        self.callback(YES, error);
-                    }
                     
                     if (error) {
                         BNCLogError([NSString stringWithFormat:@"Update conversion value failed with error - %@", [error description]]);
@@ -385,7 +362,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
     }
 
     
-    if (self.callback && callCalback) {
+    if (self.callback) {
         self.callback(YES, nil);
     }
 }


### PR DESCRIPTION

## Reference
https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/issues/1212 

## Summary
Updated classes BranchOpenRequest and BranchEvent to remove calls to callback from completion handler of updatePostbackConversionValue. If there is any SKAN error, it will be logged only.

## Motivation
Fix for bug GH-Issue-1212  

## Type Of Change
- [ X] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Test with an app which -
* Has SKAN Enabled.
* Calls following function with non-nil callback `- (void)initSessionWithLaunchOptions:(NSDictionary *)options andRegisterDeepLinkHandlerUsingBranchUniversalObject:(callbackWithBranchUniversalObject)callback ` 
* If SKAN fails and returns some error, above function should not fail.



<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->
