### PR TITLE
SDK-1437 snap partner parameters

### DIFF
--- a/Branch-SDK/BNCPartnerParameters.h
+++ b/Branch-SDK/BNCPartnerParameters.h
@@ -19,7 +19,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 // FB partner parameters, see FB documentation for details
 // Values that do not look like a valid SHA-256 hash are ignored
-- (void)addFaceBookParameterWithName:(NSString *)name value:(NSString *)value;
+- (void)addFacebookParameterWithName:(NSString *)name value:(NSString *)value;
+
+// Snap partner parameters, see Snap documentation for details
+// Values that do not look like a valid SHA-256 hash are ignored
+- (void)addSnapParameterWithName:(NSString *)name value:(NSString *)value;
 
 - (void)clearAllParameters;
 

--- a/Branch-SDK/BNCPartnerParameters.m
+++ b/Branch-SDK/BNCPartnerParameters.m
@@ -7,6 +7,7 @@
 //
 
 #import "BNCPartnerParameters.h"
+#import "BNCLog.h"
 
 @interface BNCPartnerParameters()
 @property (nonatomic, strong, readwrite) NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, NSString *> *> *parameters;
@@ -53,7 +54,7 @@
     if ([self sha256HashSanityCheckValue:value]) {
         [self addParameterWithName:name value:value partnerName:@"fb"];
     } else {
-        // TODO: log a warning that the parameter looks invalid and will be ignored. Do not log the value as it may be PII that was inadvertently passed in.
+        BNCLogWarning(@"Partner parameter does not appear to be SHA256 hashed. Dropping the parameter.");
     }
 }
 
@@ -61,7 +62,7 @@
     if ([self sha256HashSanityCheckValue:value]) {
         [self addParameterWithName:name value:value partnerName:@"snap"];
     } else {
-        // TODO: log a warning that the parameter looks invalid and will be ignored. Do not log the value as it may be PII that was inadvertently passed in.
+        BNCLogWarning(@"Partner parameter does not appear to be SHA256 hashed. Dropping the parameter.");
     }
 }
 

--- a/Branch-SDK/BNCPartnerParameters.m
+++ b/Branch-SDK/BNCPartnerParameters.m
@@ -49,9 +49,17 @@
     [parametersForPartner setObject:value forKey:name];
 }
 
-- (void)addFaceBookParameterWithName:(NSString *)name value:(NSString *)value {
+- (void)addFacebookParameterWithName:(NSString *)name value:(NSString *)value {
     if ([self sha256HashSanityCheckValue:value]) {
         [self addParameterWithName:name value:value partnerName:@"fb"];
+    } else {
+        // TODO: log a warning that the parameter looks invalid and will be ignored. Do not log the value as it may be PII that was inadvertently passed in.
+    }
+}
+
+- (void)addSnapParameterWithName:(NSString *)name value:(NSString *)value {
+    if ([self sha256HashSanityCheckValue:value]) {
+        [self addParameterWithName:name value:value partnerName:@"snap"];
     } else {
         // TODO: log a warning that the parameter looks invalid and will be ignored. Do not log the value as it may be PII that was inadvertently passed in.
     }

--- a/Branch-SDK/Branch.h
+++ b/Branch-SDK/Branch.h
@@ -711,6 +711,14 @@ typedef NS_ENUM(NSUInteger, BranchCreditHistoryOrder) {
  */
 - (void)addFacebookPartnerParameterWithName:(NSString *)name value:(NSString *)value;
 
+/*
+ Add a Partner Parameter for Snap.
+ Once set, this parameter is attached to install, opens and events until cleared or the app restarts.
+ 
+ See Snap's documentation for details on valid parameters
+ */
+- (void)addSnapPartnerParameterWithName:(NSString *)name value:(NSString *)value;
+
 /**
  Clears all Partner Parameters
  */

--- a/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch.m
@@ -510,6 +510,8 @@ static NSString *bnc_branchKey = nil;
         if (!!currentSetting == !!disabled)
             return;
         if (disabled) {
+            [[BNCPartnerParameters shared] clearAllParameters];
+            
             // Set the flag (which also clears the settings):
             [BNCPreferenceHelper sharedInstance].trackingDisabled = YES;
             Branch *branch = Branch.getInstance;
@@ -1020,11 +1022,15 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)addFacebookPartnerParameterWithName:(NSString *)name value:(NSString *)value {
-    [[BNCPartnerParameters shared] addFacebookParameterWithName:name value:value];
+    if (![Branch trackingDisabled]) {
+        [[BNCPartnerParameters shared] addFacebookParameterWithName:name value:value];
+    }
 }
 
 - (void)addSnapPartnerParameterWithName:(NSString *)name value:(NSString *)value {
-    [[BNCPartnerParameters shared] addSnapParameterWithName:name value:value];
+    if (![Branch trackingDisabled]) {
+        [[BNCPartnerParameters shared] addSnapParameterWithName:name value:value];
+    }
 }
 
 #pragma mark - Pre-initialization support

--- a/Branch-SDK/Branch.m
+++ b/Branch-SDK/Branch.m
@@ -1020,7 +1020,11 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)addFacebookPartnerParameterWithName:(NSString *)name value:(NSString *)value {
-    [[BNCPartnerParameters shared] addFaceBookParameterWithName:name value:value];
+    [[BNCPartnerParameters shared] addFacebookParameterWithName:name value:value];
+}
+
+- (void)addSnapPartnerParameterWithName:(NSString *)name value:(NSString *)value {
+    [[BNCPartnerParameters shared] addSnapParameterWithName:name value:value];
 }
 
 #pragma mark - Pre-initialization support

--- a/Branch-TestBed/Branch-SDK-Tests/BNCPartnerParametersTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCPartnerParametersTests.m
@@ -108,53 +108,61 @@
 }
 
 - (void)testJsonFBParameterEmpty {
-    [self.partnerParams addFaceBookParameterWithName:@"em" value:@""];
+    [self.partnerParams addFacebookParameterWithName:@"em" value:@""];
     NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
     XCTAssertTrue([@"{}" isEqualToString:jsonString]);
 }
 
 - (void)testJsonFBParameterShort {
-    [self.partnerParams addFaceBookParameterWithName:@"em" value:@"0123456789ABCDEF0123456789ABCDEF1234567890abcdef1234567890abcde"];
+    [self.partnerParams addFacebookParameterWithName:@"em" value:@"0123456789ABCDEF0123456789ABCDEF1234567890abcdef1234567890abcde"];
     NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
     XCTAssertTrue([@"{}" isEqualToString:jsonString]);
 }
 
 - (void)testJsonFBParameterPhoneNumberIsIgnored {
-    [self.partnerParams addFaceBookParameterWithName:@"em" value:@"1-555-555-5555"];
+    [self.partnerParams addFacebookParameterWithName:@"em" value:@"1-555-555-5555"];
     NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
     XCTAssertTrue([@"{}" isEqualToString:jsonString]);
 }
 
 - (void)testJsonFBParameterEmailIsIgnored {
-    [self.partnerParams addFaceBookParameterWithName:@"em" value:@"test@branch.io"];
+    [self.partnerParams addFacebookParameterWithName:@"em" value:@"test@branch.io"];
     NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
     XCTAssertTrue([@"{}" isEqualToString:jsonString]);
 }
 
 - (void)testJsonFBParameterBase64EncodedIsIgnored {
     // 123456789012345678901234567890123456789012345678 -> MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4
-    [self.partnerParams addFaceBookParameterWithName:@"em" value:@"MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4"];
+    [self.partnerParams addFacebookParameterWithName:@"em" value:@"MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4"];
     NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
     XCTAssertTrue([@"{}" isEqualToString:jsonString]);
 }
 
 - (void)testJsonFBParameterHashedValue {
-    [self.partnerParams addFaceBookParameterWithName:@"em" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
+    [self.partnerParams addFacebookParameterWithName:@"em" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
     NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
     XCTAssertTrue([@"{\"fb\":{\"em\":\"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088\"}}" isEqualToString:jsonString]);
 }
 
 - (void)testJsonFBParameterExample {
-    [self.partnerParams addFaceBookParameterWithName:@"em" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
-    [self.partnerParams addFaceBookParameterWithName:@"ph" value:@"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b"];
+    [self.partnerParams addFacebookParameterWithName:@"em" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
+    [self.partnerParams addFacebookParameterWithName:@"ph" value:@"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b"];
     NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
     
     XCTAssertTrue([@"{\"fb\":{\"ph\":\"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b\",\"em\":\"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088\"}}" isEqualToString:jsonString]);
 }
 
+- (void)testJsonSnapParameterExample {
+    [self.partnerParams addSnapParameterWithName:@"hashed_email_address" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
+    [self.partnerParams addSnapParameterWithName:@"hashed_phone_number" value:@"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b"];
+    NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
+    
+    XCTAssertTrue([@"{\"snap\":{\"hashed_phone_number\":\"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b\",\"hashed_email_address\":\"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088\"}}" isEqualToString:jsonString]);
+}
+
 - (void)testJsonFBParameterClear {
-    [self.partnerParams addFaceBookParameterWithName:@"em" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
-    [self.partnerParams addFaceBookParameterWithName:@"ph" value:@"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b"];
+    [self.partnerParams addFacebookParameterWithName:@"em" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
+    [self.partnerParams addFacebookParameterWithName:@"ph" value:@"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b"];
     [self.partnerParams clearAllParameters];
     
     NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];

--- a/Branch-TestBed/Branch-SDK-Tests/BNCPartnerParametersTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCPartnerParametersTests.m
@@ -160,9 +160,24 @@
     XCTAssertTrue([@"{\"snap\":{\"hashed_phone_number\":\"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b\",\"hashed_email_address\":\"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088\"}}" isEqualToString:jsonString]);
 }
 
-- (void)testJsonFBParameterClear {
+
+- (void)testJsonMultipleParameterExample {
     [self.partnerParams addFacebookParameterWithName:@"em" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
     [self.partnerParams addFacebookParameterWithName:@"ph" value:@"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b"];
+    [self.partnerParams addSnapParameterWithName:@"hashed_email_address" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
+    [self.partnerParams addSnapParameterWithName:@"hashed_phone_number" value:@"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b"];
+    NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
+    
+    NSString *expectedJsonString = @"{\"snap\":{\"hashed_phone_number\":\"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b\",\"hashed_email_address\":\"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088\"},\"fb\":{\"ph\":\"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b\",\"em\":\"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088\"}}";
+    
+    XCTAssertTrue([expectedJsonString isEqualToString:jsonString]);
+}
+
+- (void)testParameterClear {
+    [self.partnerParams addFacebookParameterWithName:@"em" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
+    [self.partnerParams addFacebookParameterWithName:@"ph" value:@"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b"];
+    [self.partnerParams addSnapParameterWithName:@"hashed_email_address" value:@"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088"];
+    [self.partnerParams addSnapParameterWithName:@"hashed_phone_number" value:@"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b"];
     [self.partnerParams clearAllParameters];
     
     NSString *jsonString = [self jsonStringFromDictionary:[self.partnerParams parameterJson]];
@@ -187,6 +202,8 @@
     XCTAssertTrue([@"{\"fb\":{\"ph\":\"b90598b67534f00b1e3e68e8006631a40d24fba37a3a34e2b84922f1f0b3b29b\",\"em\":\"11234e56af071e9c79927651156bd7a10bca8ac34672aba121056e2698ee7088\"}}" isEqualToString:jsonString]);
 }
 
+// There is an assumption that this code always results in the same string for the same json data.
+// This appears to be true, but I haven't found documentation to confirm it.
 - (NSString *)jsonStringFromDictionary:(NSDictionary *)dictionary {
     NSError *error;
     NSData *json = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&error];


### PR DESCRIPTION
## Reference
SDK-1437 Snap partner parameter support

## Summary
Some clients wish to attach hashed Snap partner parameters to Branch events. 

## Type Of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing Instructions
There is a new API for adding Snap partner parameters, `addSnapPartnerParameter`. Once set, the parameter will be included in future Branch events. Note the value must look like a valid hash, or the Branch SDK will silently drop it.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
