### PR TITLE
SDK-1663 revert thread queue change.

### DIFF
--- a/BranchSDK/BNCNetworkService.m
+++ b/BranchSDK/BNCNetworkService.m
@@ -124,7 +124,8 @@
         self.sessionQueue = [NSOperationQueue new];
         self.sessionQueue.name = @"io.branch.sdk.network.queue";
         self.sessionQueue.maxConcurrentOperationCount = self.maximumConcurrentOperations;
-        self.sessionQueue.qualityOfService = NSQualityOfServiceBackground;
+        // Most calls could be NSQualityOfServiceBackground, BUO showShareSheet needs NSQualityOfServiceUserInteractive to avoid priority inversion.
+        self.sessionQueue.qualityOfService = NSQualityOfServiceUserInteractive;
 
         _session =
             [NSURLSession sessionWithConfiguration:configuration


### PR DESCRIPTION
## Reference
SDK-1663 revert thead queue priority change

## Summary
Thread queue is returned to NSQualityOfServiceUserInteractive. This is cause the BUO showShareSheet is a UI call and needs to be a higher priority.

## Motivation
Avoid potential thread priority inversion.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
This is a reversion to previous behavior, however you can test by calling the BUO showShareSheet and verifying that Xcode does not flag the code.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
