### PR TITLE
SDK-1613 update version to 2.0.0. Update changelog

### DIFF
--- a/BranchSDK.podspec
+++ b/BranchSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "BranchSDK"
-  s.version          = "1.45.2"
+  s.version          = "2.0.0"
   s.summary          = "Create an HTTP URL for any piece of content in your app"
   s.description      = <<-DESC
 - Want the highest possible conversions on your sharing feature?
@@ -34,5 +34,5 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
 
   s.frameworks = 'CoreServices', 'SystemConfiguration'
   s.weak_framework = 'LinkPresentation'
-  s.ios.frameworks = 'WebKit', 'iAd', 'CoreTelephony'
+  s.ios.frameworks = 'WebKit', 'CoreTelephony'
 end

--- a/BranchSDK/BNCConfig.m
+++ b/BranchSDK/BNCConfig.m
@@ -11,4 +11,4 @@
 NSString * const BNC_API_BASE_URL    = @"https://api2.branch.io";
 NSString * const BNC_API_VERSION     = @"v1";
 NSString * const BNC_LINK_URL        = @"https://bnc.lt";
-NSString * const BNC_SDK_VERSION     = @"1.45.2";
+NSString * const BNC_SDK_VERSION     = @"2.0.0";

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,15 @@
 Branch iOS SDK Change Log
 
+v.2.0.0
+Branch iOS SDK 2.0.0 fixes longstanding issues with the umbrella header and project layout.
+Although the code is largely unchanged, this changes the SDK name from Branch to BranchSDK.
+
+Clients will need to update all import statements from `import Branch` to `import BranchSDK`.
+
+- SDK-1329 - SDK umbrella header fix
+- SDK-1758 - Add gbraid timestamps to calls
+- SDK-1663 - Revert thread queue priority to avoid a potential priority inversion
+
 v.1.45.2
 - SDK-1741 Fix SKAN error handling on iOS 15.4
 


### PR DESCRIPTION
## Reference
SDK-1613 prep 2.0.0 release

## Summary
Increase version to 2.0.0
Update changelog
Remove iAd from cocoapods as it's slated to be deprecated by Apple

## Motivation

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
