### PR TITLE
SDK-1802 fix warning on tvOS.

### DIFF
--- a/BranchSDK/BranchEvent.m
+++ b/BranchSDK/BranchEvent.m
@@ -82,6 +82,7 @@ BranchStandardEvent BranchStandardEventOptOut                 = @"OPT_OUT";
 	NSDictionary *dictionary = ([response.data isKindOfClass:[NSDictionary class]])
 		? (NSDictionary*) response.data : nil;
     
+#if !TARGET_OS_TV
     if (dictionary && [dictionary[BRANCH_RESPONSE_KEY_UPDATE_CONVERSION_VALUE] isKindOfClass:NSNumber.class]) {
         NSNumber *conversionValue = (NSNumber *)dictionary[BRANCH_RESPONSE_KEY_UPDATE_CONVERSION_VALUE];
         // Regardless of SKAN opted-in in dashboard, we always get conversionValue, so adding check to find out if install/open response had "invoke_register_app" true
@@ -116,6 +117,7 @@ BranchStandardEvent BranchStandardEventOptOut                 = @"OPT_OUT";
             }
         }
     }
+#endif
     
     if (self.completion) {
 		self.completion(dictionary, error);

--- a/BranchSDK/BranchOpenRequest.m
+++ b/BranchSDK/BranchOpenRequest.m
@@ -299,6 +299,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
         [[BNCAppGroupsData shared] saveAppClipData];
     }
     
+#if !TARGET_OS_TV
     if ([data[BRANCH_RESPONSE_KEY_INVOKE_REGISTER_APP] isKindOfClass:NSNumber.class]) {
         NSNumber *invokeRegister = (NSNumber *)data[BRANCH_RESPONSE_KEY_INVOKE_REGISTER_APP];
         preferenceHelper.invokeRegisterApp = invokeRegister.boolValue;
@@ -364,7 +365,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
             }
         }
     }
-
+#endif
     
     if (self.callback) {
         self.callback(YES, nil);


### PR DESCRIPTION
## Reference
SDK-1802 fix warning on tvOS

## Summary
We marked the method used to call SKAdnetwork as iOS 16.1+ which is causing warnings on tvOS. First tvOS does not support SKAdnetwork, second our method calls SKAdnetwork via selectors so it will do nothing on tvOS anyways.

## Motivation
Warnings fix

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
When integrating with a tvOS app you should not see warnings

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
