### PR TITLE
SDK-1747 macCatalyst SKAN issue

### DIFF
--- a/BranchSDK/BNCSKAdNetwork.m
+++ b/BranchSDK/BNCSKAdNetwork.m
@@ -37,7 +37,7 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        if (@available(iOS 16.1, *)){
+        if (@available(iOS 16.1, macCatalyst 16.1, *)){
             // For SKAN 4.0, its 60 days = 3600.0 * 24.0 * 60 seconds
             self.maxTimeSinceInstall = 3600.0 * 24.0 * 60;
         } else {
@@ -70,7 +70,7 @@
 }
 
 - (void)registerAppForAdNetworkAttribution {
-    if (@available(iOS 14.0, *)) {
+    if (@available(iOS 14.0, macCatalyst 14.0, *)) {
         if ([self shouldAttemptSKAdNetworkCallout]) {
 
             // Equivalent call [SKAdNetwork registerAppForAdNetworkAttribution];
@@ -80,7 +80,7 @@
 }
 
 - (void)updateConversionValue:(NSInteger)conversionValue {
-    if (@available(iOS 14.0, *)) {
+    if (@available(iOS 14.0, macCatalyst 14.0, *)) {
         if ([self shouldAttemptSKAdNetworkCallout]) {
             
             // Equivalent call [SKAdNetwork updateConversionValue:conversionValue];
@@ -91,7 +91,7 @@
 
 - (void)updatePostbackConversionValue:(NSInteger)conversionValue
                     completionHandler:(void (^)(NSError *error))completion {
-    if (@available(iOS 15.4, *)) {
+    if (@available(iOS 15.4, macCatalyst 15.4, *)) {
         if ([self shouldAttemptSKAdNetworkCallout]) {
             
             // Equivalent call [SKAdNetwork updatePostbackConversionValue:completionHandler:];
@@ -105,9 +105,10 @@
                           coarseValue:(NSString *)coarseValue
                            lockWindow:(BOOL)lockWindow
                     completionHandler:(void (^)(NSError *error))completion {
-    if (@available(iOS 16.1, *)) {
+    if (@available(iOS 16.1, macCatalyst 16.1, *)) {
         if ([self shouldAttemptSKAdNetworkCallout]) {
             
+            // Equivalent call [SKAdNetwork updatePostbackConversionValue:coarseValue:lockWindow:completionHandler:];
             ((id (*)(id, SEL, NSInteger, NSString *, BOOL, void (^)(NSError *error)))[self.skAdNetworkClass methodForSelector:self.skAdNetworkUpdatePostbackConversionValueCoarseValueLockWindow])(self.skAdNetworkClass, self.skAdNetworkUpdatePostbackConversionValueCoarseValueLockWindow, fineValue, coarseValue, lockWindow, completion);
         }
     }

--- a/BranchSDK/BNCSystemObserver.m
+++ b/BranchSDK/BNCSystemObserver.m
@@ -63,6 +63,7 @@
     __block NSString *token = nil;
     
 #if !TARGET_OS_TV
+#if !TARGET_OS_MACCATALYST
     if (@available(iOS 14.3, *)) {
 
         // We are getting reports on iOS 14.5 that this API can hang, adding a short timeout for now.
@@ -83,6 +84,7 @@
             BNCLogDebug([NSString stringWithFormat:@"AppleAttributionToken request timed out"]);
         }
     }
+#endif
 #endif
     
     return token;


### PR DESCRIPTION
## Reference
SDK-1747 macCatalyst SKAN issue

## Summary
Although we do not officially support macCatalyst yet, we want to be as compatible as possible with it. This fixes an issue where the SKAN if available check did not include macCatalyst.

## Motivation
Fix potential crash on macCatalyst when running on macOS 13.0

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
Use on a catalyst app on macOS 13.0
Invoke the skAdNetworkUpdatePostbackConversionValueCoarseValueLockWindow call

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
