### PR TITLE
SDK-1908 Xcode 14.3 fix warnings about c functions missing void

### DIFF
--- a/BranchSDK/BNCLog.m
+++ b/BranchSDK/BNCLog.m
@@ -25,7 +25,7 @@ void BNCLogInternalError(NSString *message) {
 
 static BNCLogLevel bnc_LogDisplayLevel = BNCLogLevelWarning;
 
-BNCLogLevel BNCLogDisplayLevel() {
+BNCLogLevel BNCLogDisplayLevel(void) {
     BNCLogLevel level = bnc_LogDisplayLevel;
     return level;
 }

--- a/BranchSDK/BNCPreferenceHelper.m
+++ b/BranchSDK/BNCPreferenceHelper.m
@@ -1112,7 +1112,7 @@ NSURL* _Null_unspecified BNCCreateDirectoryForBranchURLWithSearchPath_Unthreaded
     return nil;
 }
 
-NSURL* _Nonnull BNCURLForBranchDirectory_Unthreaded() {
+NSURL* _Nonnull BNCURLForBranchDirectory_Unthreaded(void) {
     #if TARGET_OS_TV
     // tvOS only allows the caches or temp directory
     NSArray *kSearchDirectories = @[
@@ -1151,7 +1151,7 @@ NSURL* _Nonnull BNCURLForBranchDirectory_Unthreaded() {
     return branchURL;
 }
 
-NSURL* _Nonnull BNCURLForBranchDirectory() {
+NSURL* _Nonnull BNCURLForBranchDirectory(void) {
     static NSURL *urlForBranchDirectory = nil;
     static dispatch_once_t onceToken = 0;
     dispatch_once(&onceToken, ^ {

--- a/BranchSDK/NSError+Branch.m
+++ b/BranchSDK/NSError+Branch.m
@@ -10,7 +10,7 @@
 
 #import "NSError+Branch.h"
 
-__attribute__((constructor)) void BNCForceNSErrorCategoryToLoad() {
+__attribute__((constructor)) void BNCForceNSErrorCategoryToLoad(void) {
     // Nothing here, but forces linker to load the category.
 }
 

--- a/BranchSDK/NSString+Branch.m
+++ b/BranchSDK/NSString+Branch.m
@@ -10,7 +10,7 @@
 
 #import "NSString+Branch.h"
 
-__attribute__((constructor)) void BNCForceNSStringCategoryToLoad() {
+__attribute__((constructor)) void BNCForceNSStringCategoryToLoad(void) {
     //  Nothing here, but forces linker to load the category.
 }
 

--- a/BranchSDK/UIViewController+Branch.m
+++ b/BranchSDK/UIViewController+Branch.m
@@ -64,6 +64,6 @@
 
 @end
 
-__attribute__((constructor)) void BNCForceUIViewControllerCategoryToLoad() {
+__attribute__((constructor)) void BNCForceUIViewControllerCategoryToLoad(void) {
     //  Nothing here, but forces linker to load the category.
 }


### PR DESCRIPTION
## Reference
SDK-1908 Xcode 14.3 fix warnings about c functions with empty argument lists

## Summary
K&R pages 72-73. 

"Furthermore, if a function declaration does not include arguments, as in
`double atof();`
that too is taken to mean that nothing is to be assumed about the arguments of atof; all parameter checking is turned off. This special meaning of the empty argument list is intended to permit older C programs to compile with new compilers. But it's a bad idea to use it with new programs. If the function takes arguments, declare them; if it takes no arguments, use void."

Xcode is finally warning on it, and we shouldn't have written it that way in the first place.

## Motivation
Fix warnings

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
On Xcode 14.3 build an app with the released version of BranchSDK and you'll see warnings about empty C functions.
Rebuild with this branch and the warnings are no longer present.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
