### PR TITLE
SDK-1893 add an extra safety check and logging when calling SKAN

### DIFF
--- a/BranchSDK/BNCSKAdNetwork.m
+++ b/BranchSDK/BNCSKAdNetwork.m
@@ -10,6 +10,7 @@
 #import "BNCApplication.h"
 #import "BNCPreferenceHelper.h"
 #import "BranchConstants.h"
+#import "BNCLog.h"
 
 @interface BNCSKAdNetwork()
 
@@ -71,8 +72,9 @@
 
 - (void)registerAppForAdNetworkAttribution {
     if (@available(iOS 14.0, macCatalyst 14.0, *)) {
-        if ([self shouldAttemptSKAdNetworkCallout]) {
-
+        if ([self shouldAttemptSKAdNetworkCallout] && [self.skAdNetworkClass respondsToSelector:self.skAdNetworkRegisterAppForAdNetworkAttribution]) {
+            BNCLogDebug(@"Calling registerAppForAdNetworkAttribution");
+            
             // Equivalent call [SKAdNetwork registerAppForAdNetworkAttribution];
             ((id (*)(id, SEL))[self.skAdNetworkClass methodForSelector:self.skAdNetworkRegisterAppForAdNetworkAttribution])(self.skAdNetworkClass, self.skAdNetworkRegisterAppForAdNetworkAttribution);
         }
@@ -81,7 +83,8 @@
 
 - (void)updateConversionValue:(NSInteger)conversionValue {
     if (@available(iOS 14.0, macCatalyst 14.0, *)) {
-        if ([self shouldAttemptSKAdNetworkCallout]) {
+        if ([self shouldAttemptSKAdNetworkCallout] && [self.skAdNetworkClass respondsToSelector:self.skAdNetworkUpdateConversionValue]) {
+            BNCLogDebug([NSString stringWithFormat:@"Calling updateConversionValue:%ld", (long)conversionValue]);
             
             // Equivalent call [SKAdNetwork updateConversionValue:conversionValue];
             ((id (*)(id, SEL, NSInteger))[self.skAdNetworkClass methodForSelector:self.skAdNetworkUpdateConversionValue])(self.skAdNetworkClass, self.skAdNetworkUpdateConversionValue, conversionValue);
@@ -89,11 +92,11 @@
     }
 }
 
-- (void)updatePostbackConversionValue:(NSInteger)conversionValue
-                    completionHandler:(void (^)(NSError *error))completion {
+- (void)updatePostbackConversionValue:(NSInteger)conversionValue completionHandler:(void (^)(NSError *error))completion {
     if (@available(iOS 15.4, macCatalyst 15.4, *)) {
-        if ([self shouldAttemptSKAdNetworkCallout]) {
-            
+        if ([self shouldAttemptSKAdNetworkCallout] && [self.skAdNetworkClass respondsToSelector:self.skAdNetworkUpdatePostbackConversionValue]) {
+            BNCLogDebug([NSString stringWithFormat:@"Calling updatePostbackConversionValue:%ld completionHandler:completion", (long)conversionValue]);
+
             // Equivalent call [SKAdNetwork updatePostbackConversionValue:completionHandler:];
             ((id (*)(id, SEL, NSInteger,void (^)(NSError *error)))[self.skAdNetworkClass methodForSelector:self.skAdNetworkUpdatePostbackConversionValue])(self.skAdNetworkClass, self.skAdNetworkUpdatePostbackConversionValue, conversionValue, completion);
         }
@@ -106,8 +109,9 @@
                            lockWindow:(BOOL)lockWindow
                     completionHandler:(void (^)(NSError *error))completion {
     if (@available(iOS 16.1, macCatalyst 16.1, *)) {
-        if ([self shouldAttemptSKAdNetworkCallout]) {
-            
+        if ([self shouldAttemptSKAdNetworkCallout] && [self.skAdNetworkClass respondsToSelector:self.skAdNetworkUpdatePostbackConversionValueCoarseValueLockWindow]) {
+            BNCLogDebug([NSString stringWithFormat:@"Calling updatePostbackConversionValue:%ld coarseValue:%@ lockWindow:%d completionHandler:completion", (long)fineValue, coarseValue, lockWindow]);
+
             // Equivalent call [SKAdNetwork updatePostbackConversionValue:coarseValue:lockWindow:completionHandler:];
             ((id (*)(id, SEL, NSInteger, NSString *, BOOL, void (^)(NSError *error)))[self.skAdNetworkClass methodForSelector:self.skAdNetworkUpdatePostbackConversionValueCoarseValueLockWindow])(self.skAdNetworkClass, self.skAdNetworkUpdatePostbackConversionValueCoarseValueLockWindow, fineValue, coarseValue, lockWindow, completion);
         }


### PR DESCRIPTION
## Reference
SDK-1893 add an extra safety check and logging when calling SKAN

## Summary
Added a respondToSelector check on all SKAN calls and a debug log message

## Motivation
Help debug production issues. We've gotten a report of a rare unreproducible crash, adding an extra safety check just in case.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
