### PR TITLE
Fix for GHA time out issue on tvOS 

### DIFF
--- a/SDKIntegrationTestApps/PostRelease-tvOSReleaseTest-Cocoapods/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/PostRelease-tvOSReleaseTest-Cocoapods/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
@@ -27,7 +27,7 @@ final class tvOSReleaseTestTests: XCTestCase {
           }
         Branch.setTrackingDisabled(false)
         let x = Branch.trackingDisabled()
-        assert( x == true)
+        assert( x == false)
     }
 
 

--- a/SDKIntegrationTestApps/PostRelease-tvOSReleaseTest-Cocoapods/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/PostRelease-tvOSReleaseTest-Cocoapods/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
@@ -25,11 +25,9 @@ final class tvOSReleaseTestTests: XCTestCase {
         Branch.getInstance().initSession(launchOptions: nil) { (params, error) in
               print(params as? [String: AnyObject] ?? {})
           }
-        Branch.setTrackingDisabled(true)
+        Branch.setTrackingDisabled(false)
         let x = Branch.trackingDisabled()
         assert( x == true)
-        Branch.setTrackingDisabled(false)
-        print("Test completed.")
     }
 
 

--- a/SDKIntegrationTestApps/tvOSReleaseTest-Cocoapods/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/tvOSReleaseTest-Cocoapods/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
@@ -25,11 +25,10 @@ final class tvOSReleaseTestTests: XCTestCase {
         Branch.getInstance().initSession(launchOptions: nil) { (params, error) in
               print(params as? [String: AnyObject] ?? {})
           }
-        Branch.setTrackingDisabled(true)
-        let x = Branch.trackingDisabled()
-        assert( x == true)
         Branch.setTrackingDisabled(false)
-        print("Test completed.")
+        let x = Branch.trackingDisabled()
+        assert( x == false)
+        
     }
 
 

--- a/SDKIntegrationTestApps/tvOSReleaseTest-Manual/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/tvOSReleaseTest-Manual/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
@@ -23,10 +23,9 @@ final class tvOSReleaseTestTests: XCTestCase {
     func testSetTrackingDisabled() throws {
         let sdk = BranchSDKTest()
         
-        sdk.disableTracking(status: true)
+        sdk.disableTracking(status: false)
         let x = sdk.trackingStatus()
-        assert( x == true)
-        sdk.disableTracking(status: true)
+        assert( x == false)
     }
 
 


### PR DESCRIPTION

## Reference
SDK-1964 -- iOS SDK GHAs sometimes waits indefinitely for tvOS simulators.
https://branch.atlassian.net/browse/SDK-1964

## Summary
Changed disable tracking to false. True was making integration tests to hang on GH runners for tvOS. Though its working fine locally. 

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Run GHA "Pre Release SDK Integration Tests". It should finish tests execution in  15-20 minutes
For fake/empty commits use following command - 
git commit --allow-empty -m "Trigger Build for testing"

cc @BranchMetrics/saas-sdk-devs for visibility.
