### PR TITLE
Adds macCatalyst guards for missing availability checks

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCPasteboardTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCPasteboardTests.m
@@ -157,7 +157,7 @@
 // This test fails intermittently when executed with other tests - depending upon the order in which its executed
 - (void) testPassPasteControl {
 #if !TARGET_OS_TV
-    if (@available(iOS 16.0, *)) {
+    if (@available(iOS 16.0, macCatalyst 16.0, *)) {
         
         long long timeStamp = ([[NSDate date] timeIntervalSince1970] - 5*60)*1000; // 5 minute earlier timestamp
         NSString *urlString = [NSString stringWithFormat:@"https://bnctestbed-alternate.app.link/9R7MbTmnRtb?__branch_flow_type=viewapp&__branch_flow_id=1105940563590163783&__branch_mobile_deepview_type=1&nl_opt_in=1&_cpts=%lld", timeStamp];

--- a/Branch-TestBed/Branch-SDK-Tests/BNCSKAdNetworkTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCSKAdNetworkTests.m
@@ -47,7 +47,7 @@
 
 - (void)testDefaultMaxTimeout {
     NSTimeInterval days;
-    if (@available(iOS 16.1, *)) {
+    if (@available(iOS 16.1, macCatalyst 16.1, *)) {
         days = 3600.0 * 24.0 * 60.0; // one day
     } else {
         days = 3600.0 * 24.0; // one day
@@ -66,7 +66,7 @@
 
 - (void)testPostbackCall {
     
-    if (@available(iOS 16.1, *)) {
+    if (@available(iOS 16.1, macCatalyst 16.1, *)) {
         self.skAdNetwork.maxTimeSinceInstall = 3600.0 * 24.0 * 60.0; 
     } else {
         self.skAdNetwork.maxTimeSinceInstall = 3600.0 * 24.0; // one day
@@ -94,7 +94,7 @@
 
 - (void)testSKAN4ParamsDefaultValues {
     
-    if (@available(iOS 16.1, *)) {
+    if (@available(iOS 16.1, macCatalyst 16.1, *)) {
         NSString *coarseValue = [[BNCSKAdNetwork sharedInstance] getCoarseConversionValueFromDataResponse:@{}];
         XCTAssertTrue([coarseValue isEqualToString:@"low"]);
         
@@ -108,7 +108,7 @@
 
 - (void)testSKAN4ParamsValues {
     
-    if (@available(iOS 16.1, *)) {
+    if (@available(iOS 16.1, macCatalyst 16.1, *)) {
         
         NSDictionary *response = @{@"update_conversion_value": @16, @"coarse_key": @"high", @"locked": @YES, @"ascending_only":@NO };
         BNCSKAdNetwork *adNetwork = [BNCSKAdNetwork sharedInstance];

--- a/Branch-TestBed/Branch-SDK-Tests/BranchShareLinkTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchShareLinkTests.m
@@ -23,7 +23,7 @@
     
     BranchShareLink *bsl = [[BranchShareLink alloc] initWithUniversalObject:buo linkProperties:lp];
     
-    if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, macCatalyst 13.0, *)) {
         NSURL *imageURL = [NSURL URLWithString:@"https://cdn.branch.io/branch-assets/1598575682753-og_image.png"];
         NSData *imageData = [NSData dataWithContentsOfURL:imageURL];
         UIImage *iconImage = [UIImage imageWithData:imageData];

--- a/Branch-TestBed/Branch-TestBed/PasteControlViewController.m
+++ b/Branch-TestBed/Branch-TestBed/PasteControlViewController.m
@@ -26,7 +26,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000
-    if (@available(iOS 16.0, *)) {
+    if (@available(iOS 16.0, macCatalyst 16.0, *)) {
         
         CGRect rectPC = CGRectMake(0, 0, _applePasteControlView.frame.size.width, _applePasteControlView.frame.size.height);
         UIPasteControl *pc = [[UIPasteControl alloc] initWithFrame:rectPC];
@@ -43,14 +43,14 @@
 }
 
 - (void)pasteItemProviders:(NSArray<NSItemProvider *> *)itemProviders {
-    if (@available(iOS 16, *)) {
+    if (@available(iOS 16, macCatalyst 16.0, *)) {
         [[Branch getInstance] passPasteItemProviders:itemProviders];
     }
 }
 
 - (BOOL)canPasteItemProviders:(NSArray<NSItemProvider *> *)itemProviders {
     for (NSItemProvider* item in itemProviders)
-        if (@available(iOS 14.0, *)) {
+        if (@available(iOS 14.0, macCatalyst 14.0, *)) {
             if ( [item hasItemConformingToTypeIdentifier: UTTypeURL.identifier] )
                 return true;
         }

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -73,7 +73,7 @@ bool hasSetPartnerParams = false;
     [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(hideKeyboard)];
     [self.tableView addGestureRecognizer:gestureRecognizer];
     
-    if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, macCatalyst 13.0, *)) {
         activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
     } else {
         activityIndicator = [[UIActivityIndicatorView alloc] init];
@@ -128,24 +128,24 @@ bool hasSetPartnerParams = false;
     
     if ([Branch trackingDisabled]) {
         [self.disableTrackingButton setTitle:@"Enable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, *)) {
+        if (@available(iOS 13.0, macCatalyst 13.0, *)) {
             [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.fill"] forState:UIControlStateNormal];
         }
     } else {
         [self.disableTrackingButton setTitle:@"Disable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, *)) {
+        if (@available(iOS 13.0, macCatalyst 13.0, *)) {
             [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.slash.fill"] forState:UIControlStateNormal];
         }
     }
     
     if (hasSetPartnerParams) {
         [self.setParnerParamsButton setTitle:@"Clear Partner Params" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, *)) {
+        if (@available(iOS 13.0, macCatalyst 13.0, *)) {
             [self.setParnerParamsButton setImage:[UIImage systemImageNamed:@"folder.badge.minus"] forState:UIControlStateNormal];
         }
     } else {
         [self.setParnerParamsButton setTitle:@"Set Partner Params" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, *)) {
+        if (@available(iOS 13.0, macCatalyst 13.0, *)) {
             [self.setParnerParamsButton setImage:[UIImage systemImageNamed:@"folder.badge.plus"] forState:UIControlStateNormal];
         }
     }
@@ -388,7 +388,7 @@ bool hasSetPartnerParams = false;
                            @"Shared from Branch-TestBed at %@.",
                            [self.dateFormatter stringFromDate:[NSDate date]]];
     
-    if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, macCatalyst 13.0, *)) {
         LPLinkMetadata *tempLinkMetatData = [[LPLinkMetadata alloc] init];
         tempLinkMetatData.title = @"Branch URL";
         UIImage *img = [UIImage imageNamed:@"Brand Assets"];
@@ -794,7 +794,7 @@ static inline void BNCPerformBlockOnMainThread(void (^ block)(void)) {
         [self showAlert:@"Cleared Partner Parameters" withDescription:@""];
         hasSetPartnerParams = false;
         [self.setParnerParamsButton setTitle:@"Set Partner Params" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, *)) {
+        if (@available(iOS 13.0, macCatalyst 13.0, *)) {
             [self.setParnerParamsButton setImage:[UIImage systemImageNamed:@"folder.badge.plus"] forState:UIControlStateNormal];
         }
     } else {
@@ -804,7 +804,7 @@ static inline void BNCPerformBlockOnMainThread(void (^ block)(void)) {
         [self showAlert:@"Set Partner Parameters" withDescription:@""];
         hasSetPartnerParams = true;
         [self.setParnerParamsButton setTitle:@"Clear Partner Params" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, *)) {
+        if (@available(iOS 13.0, macCatalyst 13.0, *)) {
             [self.setParnerParamsButton setImage:[UIImage systemImageNamed:@"folder.badge.minus"] forState:UIControlStateNormal];
         }
     }
@@ -831,13 +831,13 @@ static inline void BNCPerformBlockOnMainThread(void (^ block)(void)) {
     if ([title isEqualToString:@"Disable Tracking"]) {
         [Branch setTrackingDisabled:YES];
         [self.disableTrackingButton setTitle:@"Enable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, *)) {
+        if (@available(iOS 13.0, macCatalyst 13.0, *)) {
             [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.fill"] forState:UIControlStateNormal];
         }
     } else {
         [Branch setTrackingDisabled:NO];
         [self.disableTrackingButton setTitle:@"Disable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, *)) {
+        if (@available(iOS 13.0, macCatalyst 13.0, *)) {
             [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.slash.fill"] forState:UIControlStateNormal];
         }
     }
@@ -888,7 +888,7 @@ static inline void BNCPerformBlockOnMainThread(void (^ block)(void)) {
     
     BranchShareLink *bsl = [[BranchShareLink alloc] initWithUniversalObject:buo linkProperties:lp];
     
-    if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, macCatalyst 13.0, *)) {
         [bsl addLPLinkMetadata:@"LPLinkMetadata Link" icon:iconImg];
     }
     

--- a/BranchSDK/BNCServerInterface.m
+++ b/BranchSDK/BNCServerInterface.m
@@ -576,7 +576,7 @@
     //NSTimeInterval maxTimeSinceInstall = 60.0;
     NSTimeInterval maxTimeSinceInstall = 0;
     
-    if (@available(iOS 16.1, *)) {
+    if (@available(iOS 16.1, macCatalyst 16.1, *)) {
         maxTimeSinceInstall = 3600.0 * 24.0 * 60; // For SKAN 4.0, The user has 60 days to launch the app.
     } else {
         maxTimeSinceInstall = 3600.0 * 24.0 * 30;

--- a/BranchSDK/BNCSystemObserver.m
+++ b/BranchSDK/BNCSystemObserver.m
@@ -38,7 +38,7 @@
     
 #if !TARGET_OS_TV
 #if !TARGET_OS_MACCATALYST
-    if (@available(iOS 14.3, *)) {
+    if (@available(iOS 14.3, macCatalyst 14.3, *)) {
 
         // We are getting reports on iOS 14.5 that this API can hang, adding a short timeout for now.
         dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);

--- a/BranchSDK/Branch.m
+++ b/BranchSDK/Branch.m
@@ -977,7 +977,7 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)setSKAdNetworkCalloutMaxTimeSinceInstall:(NSTimeInterval)maxTimeInterval {
-    if (@available(iOS 16.1, *)) {
+    if (@available(iOS 16.1, macCatalyst 16.1, *)) {
         BNCLogDebug(@"This is no longer supported for iOS 16.1+ - SKAN4.0");
     } else {
         [BNCSKAdNetwork sharedInstance].maxTimeSinceInstall = maxTimeInterval;

--- a/BranchSDK/BranchEvent.m
+++ b/BranchSDK/BranchEvent.m
@@ -88,7 +88,7 @@ BranchStandardEvent BranchStandardEventOptOut                 = @"OPT_OUT";
         NSNumber *conversionValue = (NSNumber *)dictionary[BRANCH_RESPONSE_KEY_UPDATE_CONVERSION_VALUE];
         // Regardless of SKAN opted-in in dashboard, we always get conversionValue, so adding check to find out if install/open response had "invoke_register_app" true
         if (conversionValue && [BNCPreferenceHelper sharedInstance].invokeRegisterApp) {
-            if (@available(iOS 16.1, *)){
+            if (@available(iOS 16.1, macCatalyst 16.1, *)){
                 NSString * coarseConversionValue = [[BNCSKAdNetwork sharedInstance] getCoarseConversionValueFromDataResponse:dictionary] ;
                 BOOL lockWin = [[BNCSKAdNetwork sharedInstance] getLockedStatusFromDataResponse:dictionary];
                 BOOL shouldCallUpdatePostback = [[BNCSKAdNetwork sharedInstance] shouldCallPostbackForDataResponse:dictionary];
@@ -105,7 +105,7 @@ BranchStandardEvent BranchStandardEventOptOut                 = @"OPT_OUT";
                     }];
                 }
                 
-            } else if (@available(iOS 15.4, *)) {
+            } else if (@available(iOS 15.4, macCatalyst 15.4, *)) {
                 [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue:conversionValue.intValue completionHandler: ^(NSError *error){
                     if (error) {
                         BNCLogError([NSString stringWithFormat:@"Update conversion value failed with error - %@", [error description]]);

--- a/BranchSDK/BranchInstallRequest.m
+++ b/BranchSDK/BranchInstallRequest.m
@@ -58,7 +58,7 @@
     
     if ([BNCPasteboard sharedInstance].checkOnInstall) {
         NSURL *pasteboardURL = nil;
-        if (@available(iOS 16.0, *)) {
+        if (@available(iOS 16.0, macCatalyst 16.0, *)) {
             NSString *localURLString = [[BNCPreferenceHelper sharedInstance] localUrl];
             if(localURLString){
                 pasteboardURL = [[NSURL alloc] initWithString:localURLString];

--- a/BranchSDK/BranchOpenRequest.m
+++ b/BranchSDK/BranchOpenRequest.m
@@ -95,7 +95,7 @@
         [self safeSetValue:partnerParameters forKey:BRANCH_REQUEST_KEY_PARTNER_PARAMETERS onDict:params];
     }
         
-    if (@available(iOS 16.0, *)) {
+    if (@available(iOS 16.0, macCatalyst 16.0, *)) {
         NSString *localURLString = [[BNCPreferenceHelper sharedInstance] localUrl];
         if(localURLString){
             NSURL *localURL = [[NSURL alloc] initWithString:localURLString];
@@ -290,7 +290,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
         NSNumber *invokeRegister = (NSNumber *)data[BRANCH_RESPONSE_KEY_INVOKE_REGISTER_APP];
         preferenceHelper.invokeRegisterApp = invokeRegister.boolValue;
         if (invokeRegister.boolValue && self.isInstall) {
-            if (@available(iOS 16.1, *)){
+            if (@available(iOS 16.1, macCatalyst 16.1, *)){
                 NSString *defaultCoarseConValue = [[BNCSKAdNetwork sharedInstance] getCoarseConversionValueFromDataResponse:@{}];
                 [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue:0 coarseValue:defaultCoarseConValue
                     lockWindow:NO completionHandler:^(NSError * _Nullable error) {
@@ -300,7 +300,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
                         BNCLogDebug([NSString stringWithFormat:@"Update conversion value was successful for INSTALL Event"]);
                     }
                 }];
-            } else if (@available(iOS 15.4, *)){
+            } else if (@available(iOS 15.4, macCatalyst 15.4, *)){
                 [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue:0 completionHandler:^(NSError * _Nullable error) {
                     if (error) {
                         BNCLogError([NSString stringWithFormat:@"Update conversion value failed with error - %@", [error description]]);
@@ -322,7 +322,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
         NSNumber *conversionValue = (NSNumber *)data[BRANCH_RESPONSE_KEY_UPDATE_CONVERSION_VALUE];
         // Regardless of SKAN opted-in in dashboard, we always get conversionValue, so adding check to find out if install/open response had "invoke_register_app" true
         if (conversionValue && preferenceHelper.invokeRegisterApp ) {
-            if (@available(iOS 16.1, *)){
+            if (@available(iOS 16.1, macCatalyst 16.1, *)){
                 NSString* coarseConversionValue = [[BNCSKAdNetwork sharedInstance] getCoarseConversionValueFromDataResponse:data] ;
                 BOOL lockWin = [[BNCSKAdNetwork sharedInstance] getLockedStatusFromDataResponse:data];
                 BOOL shouldCallUpdatePostback = [[BNCSKAdNetwork sharedInstance] shouldCallPostbackForDataResponse:data];
@@ -338,7 +338,7 @@ typedef NS_ENUM(NSInteger, BNCUpdateState) {
                         }
                     }];
                 }
-            } else if (@available(iOS 15.4, *)) {
+            } else if (@available(iOS 15.4, macCatalyst 15.4, *)) {
                 [[BNCSKAdNetwork sharedInstance] updatePostbackConversionValue:conversionValue.intValue completionHandler: ^(NSError *error){
                     if (error) {
                         BNCLogError([NSString stringWithFormat:@"Update conversion value failed with error - %@", [error description]]);

--- a/BranchSDK/BranchShareLink.m
+++ b/BranchSDK/BranchShareLink.m
@@ -180,7 +180,7 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
         [_activityItems addObject:item];
     }
 
-    if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, macCatalyst 13.0, *)) {
         if (self.lpMetaData) {
             [_activityItems addObject:self];
         }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -104,7 +104,7 @@ v.1.40.0
 
 ```objective-c
     // LPLinkMetadata example
-    if (@available(iOS 13.0, *)) {
+    if (@available(iOS 13.0, macCatalyst 13.0, *)) {
         LPLinkMetadata *tempLinkMetatData = [[LPLinkMetadata alloc] init];
         tempLinkMetatData.title = @"Branch URL";
         UIImage *img = [UIImage imageNamed:@"Brand Assets"];


### PR DESCRIPTION
## Summary
Adds macCatalyst guards for availability checks that are at or above 13.0 (version Catalyst was introduced in).

## Motivation
We use Branch in a Catalyst app, and we've had crashes before when using APIs that are not properly guarded, forcing us to do a fork and make the changes in our copy of Branch.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

cc @BranchMetrics/saas-sdk-devs for visibility.
