### PR TITLE
[SDK-1997] Update share sheet to use short links with tracking is disabled

### DIFF
--- a/BranchSDK/Branch.m
+++ b/BranchSDK/Branch.m
@@ -1729,61 +1729,50 @@ static NSString *bnc_branchKey = nil;
                      andParams:(NSDictionary *)params
                 ignoreUAString:(NSString *)ignoreUAString
              forceLinkCreation:(BOOL)forceLinkCreation {
-
+    
     NSString *shortURL = nil;
-
+    
     BNCLinkData *linkData =
-        [self prepareLinkDataFor:tags
-            andAlias:alias
-             andType:type
-    andMatchDuration:duration
-          andChannel:channel
-          andFeature:feature
-            andStage:stage
-         andCampaign:campaign
-           andParams:params
-      ignoreUAString:ignoreUAString];
-
+    [self prepareLinkDataFor:tags
+                    andAlias:alias
+                     andType:type
+            andMatchDuration:duration
+                  andChannel:channel
+                  andFeature:feature
+                    andStage:stage
+                 andCampaign:campaign
+                   andParams:params
+              ignoreUAString:ignoreUAString];
+    
     // If an ignore UA string is present, we always get a new url.
     // Otherwise, if we've already seen this request, use the cached version.
     if (!ignoreUAString && [self.linkCache objectForKey:linkData]) {
         shortURL = [self.linkCache objectForKey:linkData];
     } else {
         BranchShortUrlSyncRequest *req =
-            [[BranchShortUrlSyncRequest alloc]
-                initWithTags:tags
-                alias:alias
-                type:type
-                matchDuration:duration
-                channel:channel
-                feature:feature
-                stage:stage
-                campaign:campaign
-                params:params
-                linkData:linkData
-                linkCache:self.linkCache];
-
-        if (self.initializationStatus == BNCInitStatusInitialized) {
-            BNCLogDebug(@"Creating a custom URL synchronously.");
-            BNCServerResponse *serverResponse = [req makeRequest:self.serverInterface key:self.class.branchKey];
-            shortURL = [req processResponse:serverResponse];
-
-            // cache the link
-            if (shortURL) {
-                [self.linkCache setObject:shortURL forKey:linkData];
-            }
-        } else {
-            if (forceLinkCreation) {
-                if (self.class.branchKey) {
-                    return [BranchShortUrlSyncRequest createLinkFromBranchKey:self.class.branchKey
-                        tags:tags alias:alias type:type matchDuration:duration
-                            channel:channel feature:feature stage:stage params:params];
-                }
-            }
-            BNCLogError(@"Making a Branch request before init has succeeded!");
+        [[BranchShortUrlSyncRequest alloc]
+         initWithTags:tags
+         alias:alias
+         type:type
+         matchDuration:duration
+         channel:channel
+         feature:feature
+         stage:stage
+         campaign:campaign
+         params:params
+         linkData:linkData
+         linkCache:self.linkCache];
+        
+        BNCLogDebug(@"Creating a custom URL synchronously.");
+        BNCServerResponse *serverResponse = [req makeRequest:self.serverInterface key:self.class.branchKey];
+        shortURL = [req processResponse:serverResponse];
+        
+        // cache the link
+        if (shortURL) {
+            [self.linkCache setObject:shortURL forKey:linkData];
         }
     }
-
+    
     return shortURL;
 }
 


### PR DESCRIPTION
## Reference
SDK-1997 -- Update share sheet methods to still create a short link when tracking is disabled

## Summary
Update the share sheet methods to still generate short links when tracking is disabled instead of long links. By removing the initialization status check, the SDK will make a `v1/url` call instead of constructing a long link.

## Motivation
Currently, `getShortUrl()` already can be used to create a short link when tracking is disabled, but the share sheet methods would still create a long link. This brings parity between the two and overall improves the share sheet behavior.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Trying to share a link via the share sheet and using BranchShareLink while tracking is disabled and enabled.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
