### PR TITLE
[SDK-2032] Create dependabot-merger.yml

### DIFF
--- a/.github/workflows/dependabot-merger.yml
+++ b/.github/workflows/dependabot-merger.yml
@@ -11,13 +11,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Install GitHub CLI
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-          sudo apt-add-repository https://cli.github.com/packages
-          sudo apt update
-          sudo apt install gh
-
       - name: Authenticate GitHub CLI
         run: echo "${{ secrets.DEPENDABOT_MERGER_PAT }}" | gh auth login --with-token
 

--- a/.github/workflows/dependabot-merger.yml
+++ b/.github/workflows/dependabot-merger.yml
@@ -2,6 +2,7 @@ name: Merge Dependabot PRs
 on:
   schedule:
     - cron: '0 12 * * 5'  # Run this workflow every Friday at 12:00
+  workflow_dispatch:
 
 jobs:
   merge:
@@ -19,6 +20,13 @@ jobs:
 
       - name: Authenticate GitHub CLI
         run: echo "${{ secrets.DEPENDABOT_MERGER_PAT }}" | gh auth login --with-token
+
+      - name: Ensure test branch is up to date with master
+        run: |
+          git checkout master
+          git pull
+          git checkout dependabot-test-branch
+          git merge master
 
       - name: Get list of PRs from dependabot
         id: pr_list

--- a/.github/workflows/dependabot-merger.yml
+++ b/.github/workflows/dependabot-merger.yml
@@ -1,0 +1,34 @@
+name: Merge Dependabot PRs
+on:
+  schedule:
+    - cron: '0 12 * * 5'  # Run this workflow every Friday at 12:00
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+          sudo apt-add-repository https://cli.github.com/packages
+          sudo apt update
+          sudo apt install gh
+
+      - name: Authenticate GitHub CLI
+        run: echo "${{ secrets.DEPENDABOT_MERGER_PAT }}" | gh auth login --with-token
+
+      - name: Get list of PRs from dependabot
+        id: pr_list
+        run: |
+          echo "::set-output name=numbers::$(gh pr list --author 'dependabot[bot]' --state open --json number --jq '.[] .number')"
+          
+      - name: Merge PRs into test branch
+        run: |
+          IFS=' ' read -r -a array <<< "${{ steps.pr_list.outputs.numbers }}"
+          for PR_NUMBER in "${array[@]}"
+          do
+            gh pr merge $PR_NUMBER --merge --repo ${{ github.repository }} --branch dependabot-test-branch
+          done


### PR DESCRIPTION
## Reference
SDK-2032 -- Dependabot - Get caught up on dependabot PRs

## Summary
Created a new GHA that automatically takes the open dependabot PRs, and merge them into a separate for testing all at once. 

## Motivation
This will make it much easier to manage dependabot PR's by being able to easily test multiple of them at once. 

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Manually run the GHA and check the new dependabot-test-branch.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
