### PR TITLE
fixed incorrect automatic merge filter

### DIFF
--- a/.github/workflows/dependabot-merger.yml
+++ b/.github/workflows/dependabot-merger.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get list of PRs from dependabot
         id: pr_list
         run: |
-          PR_LIST=$(gh pr list --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"' | grep dependabot)
+          PR_LIST=$(gh pr list --json number,author,headRefName --jq '.[] | select( .author.is_bot == true and .author.login == "app/dependabot" ) | "\(.number) \(.headRefName)"')
           PR_LIST=$(echo "$PR_LIST" | tr -d '\r')
           if [ -z "$PR_LIST" ]; then
             echo "No PRs from dependabot found."


### PR DESCRIPTION
## Reference
N/A

## Summary
This PR fixes an overly permissive grep that would allow an attacker to automatically merge PRs by impersonating dependabot. This PR and fix will be pulled into the new dependabot testing branch automatically by the vuln it's fixing. The new filter strictly enforces that `app/dependabot` is the PR author.

## Motivation
Landing unreviewed potentially hostile code is dangerous.

## Type Of Change
- [x] **Security** Bug fix 

## Testing Instructions
This was tested by first creating a PR on a branch containing the word "dependabot". Manually running the filter command
in the original workflow confirmed that the PR would be automerged as part of a dependabot automerge.

Vulnerable filter: https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/blob/75381d35f8a36eae2ecd2160d65bf3f3a674ce9e/.github/workflows/dependabot-merger.yml#L37C1-L37C11

Testing PR: https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/pull/1284
**Note that PR 1284 is selected to be automerged.**
```
gh pr list --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"' | grep dependabot
1284 do-not-merge-dependabot1
1280 dependabot/github_actions/actions/setup-node-3.8.1
1263 dependabot/github_actions/actions/stale-8
```

cc @BranchMetrics/saas-sdk-devs for visibility.


