### PR TITLE
[SDK-2084] Create new callback for NSData in BNCCallbacks

### DIFF
--- a/BranchSDK/BNCCallbacks.h
+++ b/BranchSDK/BNCCallbacks.h
@@ -20,3 +20,4 @@ typedef void (^callbackWithStatus) (BOOL changed, NSError * _Nullable error);
 typedef void (^callbackWithList) (NSArray * _Nullable list, NSError * _Nullable error);
 typedef void (^callbackWithUrlAndSpotlightIdentifier) (NSString * _Nullable url, NSString * _Nullable spotlightIdentifier, NSError * _Nullable error);
 typedef void (^callbackWithBranchUniversalObject) (BranchUniversalObject * _Nullable universalObject, BranchLinkProperties * _Nullable linkProperties, NSError * _Nullable error);
+typedef void (^callbackWithData) (NSData * _Nullable data, NSError * _Nullable error);


### PR DESCRIPTION
## Reference
SDK-2084 -- Create new callback for NSData in BNCCallbacks

## Summary
A new callback, `callbackWithData`, has been added to BNCCallbacks to support QR codes in Unity. 

## Motivation
For the Unity SDK to use the QR code methods, a new callback with NSData is required. The changes have already been made one the Unity side, so now the iOS SDK just needs to be updated so it can be referenced. 

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Confirm there were no unintended changes from this.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
