### PR TITLE
[SDK-2072] Automatically sync Readme docs version history page

### DIFF
--- a/.github/workflows/sync-readme-changelog.yml
+++ b/.github/workflows/sync-readme-changelog.yml
@@ -1,4 +1,4 @@
-name: Update Changelog on Readme.com
+name: Update Version History on ReadMe
 
 on:
   release:
@@ -13,7 +13,7 @@ jobs:
       id: update
       run: |
         # Get release name, body, and date from the release event
-        release_name="${{ github.event.release.name }}"
+        release_name="${{ github.event.release.tag_name }}"
         release_body="${{ github.event.release.body }}"
         release_date=$(date -d "${{ github.event.release.published_at }}" +"%Y-%B-%d")
 
@@ -45,13 +45,13 @@ jobs:
         channel-id: "CDFGXRM9S"
         payload: |
             {
-                "text": "New Release: Branch iOS SDK v${{ github.event.release.name }}",
+                "text": "New Release: Branch iOS SDK v${{ github.event.release.tag_name }}",
                 "blocks": [
                     {
                         "type": "header",
                         "text": {
                             "type": "plain_text",
-                            "text": ":rocket: New Release: Branch iOS SDK v${{ github.event.release.name }}",                            
+                            "text": ":rocket: New Release: Branch iOS SDK v${{ github.event.release.tag_name }}",                            
                             "emoji": true
                         }
                     },
@@ -62,9 +62,16 @@ jobs:
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": ":star: *What's New*:\n\n${{ github.event.release.body }}"
+                            "text": ":star: *What's New*"
                         }
                     },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ${{ toJSON(github.event.release.body) }}
+                        }
+                	},
                     {
                         "type": "divider"
                     },

--- a/.github/workflows/update-readme-changelog.yml
+++ b/.github/workflows/update-readme-changelog.yml
@@ -1,38 +1,59 @@
+#TODO: Replace v5.5.1 with main doc branch
+#TODO: Replace authorization token with a {{ secrets.readme_api_key_base64 }}
 name: Update Changelog on Readme.com
 
 on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      manual_release_name:
+        description: 'Release Name (X.X.X)'     
+        required: false
+      manual_release_body:
+        description: 'Release Body (Changelog))' 
+        required: false
+      manual_release_date:
+        description: 'Release Date (YYYY-MM-DD)'
+        required: false
 
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+    - name: Format and publish release notes to version history doc
+      run: |
+        # Get release name, body, and date either from manual input or from the release event
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            release_name="${{ github.event.inputs.manual_release_name }}"
+            release_body="${{ github.event.inputs.manual_release_body }}"
+            release_date="${{ github.event.inputs.manual_release_date }}"
+        else
+            release_name="${{ github.event.release.name }}"
+            release_body="${{ github.event.release.body }}"
+            release_date=$(date -d "${{ github.event.release.published_at }}" +"%Y-%B-%d")
+        fi
 
-    - name: Print release information
-      run: |
-        echo "Name: ${{ github.event.release.name }}"
-        echo "Description: ${{ github.event.release.body }}"
-    
-    - name: Format release notes
-      id: format
-      run: |
-        release_name="${{ github.event.release.name }}"
-        release_body="${{ github.event.release.body }}"
-        formatted_date=$(date +"%Y-%B-%d")
-        formatted_notes="## v$release_name\n\n**($formatted_date)**\n\n$release_body"
+        # Format release notes
+        formatted_notes="## v$release_name\n\n**($release_date)**\n\n$release_body"
         
-        echo -e "$formatted_notes"
-        echo "formatted_notes=$formatted_notes" >> $GITHUB_OUTPUT
+        # Get existing version history page
+        existing_content=$(curl --request GET \
+            --url https://dash.readme.com/api/v1/docs/ios-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic cmRtZV94bjhzOWg2MGQzM2UzZGI1MDkyNmMyYjY3MDk3YTQ0MzUyZTg0NGFhNDY1MDRlYWUzNTc5MGI4MDUxZWQ3ZDZiYWE3NDJhOg==" \
+            | jq -r '.body')
     
-    - name: Update ReadMe Documentation
-      uses: readmeio/rdme@v8
-      with:
-        key: ${{ secrets.README_API_KEY }}
-        version: "main"
-        doc: "ios-version-history"
-        prepend: ${{ steps.format.outputs.formatted_notes }}
+        # Prepend new release notes to existing content
+        new_content=$(echo -e "$formatted_notes\n\n$existing_content")
+        payload=$(jq -n --arg nc "$new_content" '{"body": $nc}')
+
+        # Update version history page with new release notes
+        curl --request PUT \
+            --url https://dash.readme.com/api/v1/docs/ios-version-history \
+            --header 'accept: application/json' \
+            --header "authorization: Basic cmRtZV94bjhzOWg2MGQzM2UzZGI1MDkyNmMyYjY3MDk3YTQ0MzUyZTg0NGFhNDY1MDRlYWUzNTc5MGI4MDUxZWQ3ZDZiYWE3NDJhOg==" \
+            --header 'content-type: application/json' \
+            --header 'x-readme-version: v5.5.1' \
+            --data "$payload"

--- a/.github/workflows/update-readme-changelog.yml
+++ b/.github/workflows/update-readme-changelog.yml
@@ -5,7 +5,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
@@ -14,9 +13,26 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Get release notes
-      id: get_release_notes
-      run: echo "::set-output name=release_notes::$(jq -r .release.body $GITHUB_EVENT_PATH)"
-
-    - name: Print release notes
-      run: echo "Release notes; ${{ steps.get_release_notes.outputs.release_notes }}"
+    - name: Print release information
+      run: |
+        echo "Name: ${{ github.event.release.name }}"
+        echo "Description: ${{ github.event.release.body }}"
+    
+    - name: Format release notes
+      id: format
+      run: |
+        release_name="${{ github.event.release.name }}"
+        release_body="${{ github.event.release.body }}"
+        formatted_date=$(date +"%Y-%B-%d")
+        formatted_notes="## v$release_name\n\n**($formatted_date)**\n\n$release_body"
+        
+        echo -e "$formatted_notes"
+        echo "formatted_notes=$formatted_notes" >> $GITHUB_OUTPUT
+    
+    - name: Update ReadMe Documentation
+      uses: readmeio/rdme@v8
+      with:
+        key: ${{ secrets.README_API_KEY }}
+        version: "main"
+        doc: "ios-version-history"
+        prepend: ${{ steps.format.outputs.formatted_notes }}

--- a/.github/workflows/update-readme-changelog.yml
+++ b/.github/workflows/update-readme-changelog.yml
@@ -1,0 +1,22 @@
+name: Update Changelog on Readme.com
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Get release notes
+      id: get_release_notes
+      run: echo "::set-output name=release_notes::$(jq -r .release.body $GITHUB_EVENT_PATH)"
+
+    - name: Print release notes
+      run: echo "Release notes; ${{ steps.get_release_notes.outputs.release_notes }}"

--- a/.github/workflows/update-readme-changelog.yml
+++ b/.github/workflows/update-readme-changelog.yml
@@ -1,21 +1,8 @@
-#TODO: Replace v5.5.1 with main doc branch
-#TODO: Replace authorization token with a {{ secrets.readme_api_key_base64 }}
 name: Update Changelog on Readme.com
 
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      manual_release_name:
-        description: 'Release Name (X.X.X)'     
-        required: false
-      manual_release_body:
-        description: 'Release Body (Changelog))' 
-        required: false
-      manual_release_date:
-        description: 'Release Date (YYYY-MM-DD)'
-        required: false
 
 jobs:
   update-changelog:
@@ -23,17 +10,12 @@ jobs:
 
     steps:
     - name: Format and publish release notes to version history doc
+      id: update
       run: |
-        # Get release name, body, and date either from manual input or from the release event
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            release_name="${{ github.event.inputs.manual_release_name }}"
-            release_body="${{ github.event.inputs.manual_release_body }}"
-            release_date="${{ github.event.inputs.manual_release_date }}"
-        else
-            release_name="${{ github.event.release.name }}"
-            release_body="${{ github.event.release.body }}"
-            release_date=$(date -d "${{ github.event.release.published_at }}" +"%Y-%B-%d")
-        fi
+        # Get release name, body, and date from the release event
+        release_name="${{ github.event.release.name }}"
+        release_body="${{ github.event.release.body }}"
+        release_date=$(date -d "${{ github.event.release.published_at }}" +"%Y-%B-%d")
 
         # Format release notes
         formatted_notes="## v$release_name\n\n**($release_date)**\n\n$release_body"
@@ -42,7 +24,7 @@ jobs:
         existing_content=$(curl --request GET \
             --url https://dash.readme.com/api/v1/docs/ios-version-history \
             --header 'accept: application/json' \
-            --header "authorization: Basic cmRtZV94bjhzOWg2MGQzM2UzZGI1MDkyNmMyYjY3MDk3YTQ0MzUyZTg0NGFhNDY1MDRlYWUzNTc5MGI4MDUxZWQ3ZDZiYWE3NDJhOg==" \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
             | jq -r '.body')
     
         # Prepend new release notes to existing content
@@ -53,7 +35,57 @@ jobs:
         curl --request PUT \
             --url https://dash.readme.com/api/v1/docs/ios-version-history \
             --header 'accept: application/json' \
-            --header "authorization: Basic cmRtZV94bjhzOWg2MGQzM2UzZGI1MDkyNmMyYjY3MDk3YTQ0MzUyZTg0NGFhNDY1MDRlYWUzNTc5MGI4MDUxZWQ3ZDZiYWE3NDJhOg==" \
+            --header "authorization: Basic ${{ secrets.readme_api_key_base64 }}" \
             --header 'content-type: application/json' \
-            --header 'x-readme-version: v5.5.1' \
             --data "$payload"
+
+    - name: Announce New Release in Slack
+      uses: slackapi/slack-github-action@v1.24.0
+      with:
+        channel-id: "CDFGXRM9S"
+        payload: |
+            {
+                "text": "New Release: Branch iOS SDK v${{ github.event.release.name }}",
+                "blocks": [
+                    {
+                        "type": "header",
+                        "text": {
+                            "type": "plain_text",
+                            "text": ":rocket: New Release: Branch iOS SDK v${{ github.event.release.name }}",                            
+                            "emoji": true
+                        }
+                    },
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ":star: *What's New*:\n\n${{ github.event.release.body }}"
+                        }
+                    },
+                    {
+                        "type": "divider"
+                    },
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "text": {
+                                    "type": "plain_text",
+                                    "text": ":git: GitHub Release",
+                                    "emoji": true
+                                },
+                                "value": "github",
+                                "action_id": "github",
+                                "url": "${{ github.event.release.html_url }}"
+                            }
+                        ]
+                    }
+                ]
+            }
+    env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_SDK_BOT_TOKEN }}
+          


### PR DESCRIPTION
## Reference
SDK-2072 -- Help Docs automate Readme changelogs

## Summary
Created a GitHub action that runs whenever a release is created. It takes the release name and description, then updates the public docs version history at https://help.branch.io/developers-hub/docs/ios-version-history.
Lastly, the action sends a slack message in the #sdk channel to broadcast the new release.

## Motivation
To streamline and speed up the release process even more while keeping out docs up to date.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
