### PR TITLE
SDK-2141 update privacy manifest with EU domain

### DIFF
--- a/BranchSDK/PrivacyInfo.xcprivacy
+++ b/BranchSDK/PrivacyInfo.xcprivacy
@@ -6,7 +6,8 @@
 	<true/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array>
-		<string>https://api-safetrack.branch.io</string>
+		<string>api-safetrack.branch.io</string>
+		<string>api-safetrack-eu.branch.io</string>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>

--- a/Framework/PrivacyInfo.xcprivacy
+++ b/Framework/PrivacyInfo.xcprivacy
@@ -6,7 +6,8 @@
 	<true/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array>
-		<string>https://api-safetrack.branch.io</string>
+		<string>api-safetrack.branch.io</string>
+		<string>api-safetrack-eu.branch.io</string>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>


### PR DESCRIPTION
## Reference
SDK-2141 update privacy manifest with EU domain

## Summary
Add the EU domain to the privacy manifest.
Remove "https://" from the entry as the examples don't include it. This did not appear to cause issues, but we should be consistent with Apple's documentation.

## Motivation
Add the EU domain to the privacy manifest

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
