### PR TITLE
Remove ref to branch "UpdateBrowserStackEnvVariable" in GHA

### DIFF
--- a/.github/workflows/automation-trigger-test.yml
+++ b/.github/workflows/automation-trigger-test.yml
@@ -72,7 +72,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: BranchMetrics/qentelli-saas-sdk-testing-automation
-          ref: UpdateBrowserStackEnvVariable
           token: ${{ secrets.BRANCHLET_ACCESS_TOKEN_PUBLIC }}
       - name: Set up JDK 11
         uses: actions/setup-java@v3


### PR DESCRIPTION


## Summary
Removed ref to branch "UpdateBrowserStackEnvVariable" in GHA for appium automation.
Previous [pull request](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/pull/1313) was from an old branch so during merging to master it didnt pick up the line where code was deleted.

## Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Check all appium tests are passed and verify from GHA logs, source code was checked out from master branch.

cc @BranchMetrics/saas-sdk-devs for visibility.
