### PR TITLE
SDK 2051 remove api variations that confuse swift

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BranchUniversalObject.Test.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchUniversalObject.Test.m
@@ -172,45 +172,6 @@
     XCTAssertTrue([s bnc_isEqualToMaskedString:mask]);
 }
 
-- (void) testDeprecations {
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
-    BranchUniversalObject *buo = [BranchUniversalObject new];
-    buo.price = 10.00;
-    buo.currency = BNCCurrencyUSD;
-    buo.type = @"Purchase";
-    buo.contentIndexMode = BranchContentIndexModePublic;
-    buo.metadata = @{ @"Key1": @"Value1" };
-    buo.automaticallyListOnSpotlight = YES;
-
-    XCTAssertEqualObjects(buo.contentMetadata.price, [NSDecimalNumber decimalNumberWithString:@"10.00"]);
-    XCTAssertEqualObjects(buo.contentMetadata.currency, BNCCurrencyUSD);
-    XCTAssertEqualObjects(buo.contentMetadata.contentSchema, @"Purchase");
-    XCTAssertEqual(buo.locallyIndex, YES);
-    XCTAssertEqual(buo.publiclyIndex, YES);
-    XCTAssertEqualObjects(buo.contentMetadata.customMetadata, @{ @"Key1": @"Value1" } );
-
-    XCTAssertEqual(buo.price, 10.00);
-    XCTAssertEqualObjects(buo.currency, BNCCurrencyUSD);
-    XCTAssertEqualObjects(buo.type, @"Purchase");;
-    XCTAssertEqual(buo.contentIndexMode, BranchContentIndexModePublic);
-    XCTAssertEqualObjects(buo.metadata, @{ @"Key1": @"Value1" });
-    XCTAssertEqual(buo.automaticallyListOnSpotlight, YES);
-
-    buo.contentMetadata.customMetadata = (NSMutableDictionary*) @{ @"Key2": @"Value2" };
-    buo.contentMetadata.customMetadata[@"Key3"] = @"Value3";
-    [buo addMetadataKey:@"Key4" value:@"Value4"];
-    NSDictionary *d = @{
-        @"Key2": @"Value2",
-        @"Key3": @"Value3",
-        @"Key4": @"Value4",
-    };
-    XCTAssertEqualObjects(buo.metadata, d);
-
-    #pragma clang diagnostic pop
-}
-
 - (void) testDictionary {
     NSDictionary *d = nil;
     BranchUniversalObject *buo = [BranchUniversalObject new];

--- a/Branch-TestBed/Branch-SDK-Tests/BranchUniversalObject.Test.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchUniversalObject.Test.m
@@ -172,6 +172,45 @@
     XCTAssertTrue([s bnc_isEqualToMaskedString:mask]);
 }
 
+- (void) testDeprecations {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+    BranchUniversalObject *buo = [BranchUniversalObject new];
+    buo.price = 10.00;
+    buo.currency = BNCCurrencyUSD;
+    buo.type = @"Purchase";
+    buo.contentIndexMode = BranchContentIndexModePublic;
+    buo.metadata = @{ @"Key1": @"Value1" };
+    buo.automaticallyListOnSpotlight = YES;
+
+    XCTAssertEqualObjects(buo.contentMetadata.price, [NSDecimalNumber decimalNumberWithString:@"10.00"]);
+    XCTAssertEqualObjects(buo.contentMetadata.currency, BNCCurrencyUSD);
+    XCTAssertEqualObjects(buo.contentMetadata.contentSchema, @"Purchase");
+    XCTAssertEqual(buo.locallyIndex, YES);
+    XCTAssertEqual(buo.publiclyIndex, YES);
+    XCTAssertEqualObjects(buo.contentMetadata.customMetadata, @{ @"Key1": @"Value1" } );
+
+    XCTAssertEqual(buo.price, 10.00);
+    XCTAssertEqualObjects(buo.currency, BNCCurrencyUSD);
+    XCTAssertEqualObjects(buo.type, @"Purchase");;
+    XCTAssertEqual(buo.contentIndexMode, BranchContentIndexModePublic);
+    XCTAssertEqualObjects(buo.metadata, @{ @"Key1": @"Value1" });
+    XCTAssertEqual(buo.automaticallyListOnSpotlight, YES);
+
+    buo.contentMetadata.customMetadata = (NSMutableDictionary*) @{ @"Key2": @"Value2" };
+    buo.contentMetadata.customMetadata[@"Key3"] = @"Value3";
+    [buo addMetadataKey:@"Key4" value:@"Value4"];
+    NSDictionary *d = @{
+        @"Key2": @"Value2",
+        @"Key3": @"Value3",
+        @"Key4": @"Value4",
+    };
+    XCTAssertEqualObjects(buo.metadata, d);
+
+    #pragma clang diagnostic pop
+}
+
 - (void) testDictionary {
     NSDictionary *d = nil;
     BranchUniversalObject *buo = [BranchUniversalObject new];

--- a/BranchSDK/BranchShareLink.h
+++ b/BranchSDK/BranchShareLink.h
@@ -125,7 +125,6 @@ Presents a UIActivityViewController that shares the Branch link.
 ///The delegate. See 'BranchShareLinkDelegate' above for a description.
 @property (nonatomic, weak)   id<BranchShareLinkDelegate>_Nullable delegate;
 
-@property void (^ _Nullable completion)(NSString * _Nullable activityType, BOOL completed);
 @property void (^ _Nullable completionError)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error);
 
 /**

--- a/BranchSDK/BranchShareLink.m
+++ b/BranchSDK/BranchShareLink.m
@@ -103,11 +103,9 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
     if (completed && !error) {
         [[BranchEvent customEventWithName:BNCShareCompletedEvent contentItem:self.universalObject] logEvent];
     }
-    if (self.completion)
-        self.completion(self.activityType, completed);
-    else
-        if (self.completionError)
-            self.completionError(self.activityType, completed, error);
+    if (self.completionError) {
+        self.completionError(self.activityType, completed, error);
+    }
 }
 
 - (NSArray<UIActivityItemProvider*>*_Nonnull) activityItems {
@@ -116,19 +114,14 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
     }
 
     // Make sure we can share
-
-    if (!(self.universalObject.canonicalIdentifier ||
-          self.universalObject.canonicalUrl ||
-          self.universalObject.title)) {
+    if (!(self.universalObject.canonicalIdentifier || self.universalObject.canonicalUrl || self.universalObject.title)) {
         BNCLogWarning(@"A canonicalIdentifier, canonicalURL, or title are required to uniquely"
                " identify content. In order to not break the end user experience with sharing,"
                " Branch SDK will proceed to create a URL, but content analytics may not properly"
                " include this URL.");
     }
     
-    self.serverParameters =
-        [[self.universalObject getParamsForServerRequestWithAddedLinkProperties:self.linkProperties]
-            mutableCopy];
+    self.serverParameters = [[self.universalObject getParamsForServerRequestWithAddedLinkProperties:self.linkProperties] mutableCopy];
     if (self.linkProperties.matchDuration) {
         self.serverParameters[BRANCH_REQUEST_KEY_URL_DURATION] = @(self.linkProperties.matchDuration);
     }

--- a/BranchSDK/BranchUniversalObject.h
+++ b/BranchSDK/BranchUniversalObject.h
@@ -112,20 +112,56 @@ FOUNDATION_EXPORT BranchCondition _Nonnull BranchConditionRefurbished;
 @property (nonatomic, nullable, copy) NSString *title;
 @property (nonatomic, nullable, copy) NSString *contentDescription;
 @property (nonatomic, nullable, copy) NSString *imageUrl;
-@property (nonatomic, strong, nullable) NSArray<NSString *> *keywords;
-@property (nonatomic, strong, nullable) NSDate *creationDate;
-@property (nonatomic, strong, nullable) NSDate *expirationDate;
-@property (nonatomic, assign) BOOL locallyIndex; //!< Index on Spotlight.
-@property (nonatomic, assign) BOOL publiclyIndex; //!< Index on Google, Branch, etc.
+@property (nonatomic, strong, nullable) NSArray<NSString*> *keywords;
+@property (nonatomic, strong, nullable) NSDate   *creationDate;
+@property (nonatomic, strong, nullable) NSDate   *expirationDate;
+@property (nonatomic, assign)           BOOL      locallyIndex;     //!< Index on Spotlight.
+@property (nonatomic, assign)           BOOL      publiclyIndex;    //!< Index on Google, Branch, etc.
 
 @property (nonatomic, strong, nonnull) BranchContentMetadata *contentMetadata;
 
+///@name Deprecated Properties
+
+@property (nonatomic, strong, nullable)
+    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.customMetadata` instead."))))
+    NSDictionary *metadata;
+
+- (void)addMetadataKey:(nonnull NSString *)key value:(nonnull NSString *)value
+    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.customMetadata` instead."))));
+
+@property (nonatomic, strong, nullable)
+    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.contentSchema` instead."))))
+    NSString *type;
+
+@property (nonatomic, assign)
+    __attribute__((deprecated(("Use `BranchUniversalObject.locallyIndex and BranchUniversalObject.publiclyIndex` instead."))))
+    BranchContentIndexMode contentIndexMode;
+
+@property (nonatomic, strong, nullable)
+    __attribute__((deprecated(("Not used due to iOS 10.0 Spotlight changes."))))
+    NSString *spotlightIdentifier;
+
+@property (nonatomic, assign)
+    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.price` instead."))))
+    CGFloat price;
+
+@property (nonatomic, strong, nullable)
+    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.currency` instead."))))
+    NSString *currency;
+
+@property (nonatomic, assign)
+    __attribute__((deprecated(("Use `BranchUniversalObject.locallyIndex` instead."))))
+    BOOL automaticallyListOnSpotlight;
+
+
 /// @name Log a User Content View Event
+
 
 - (void)registerView;
 - (void)registerViewWithCallback:(void (^_Nullable)(NSDictionary * _Nullable params, NSError * _Nullable error))callback;
 
 /// @name Short Links
+
 
 /// Returns a Branch short URL to the content item with the passed link properties.
 - (nullable NSString *)getShortUrlWithLinkProperties:(nonnull BranchLinkProperties *)linkProperties;
@@ -148,12 +184,19 @@ FOUNDATION_EXPORT BranchCondition _Nonnull BranchConditionRefurbished;
 /// @name Share Sheet Handling
 #if !TARGET_OS_TV
 
-- (void)showShareSheetWithShareText:(nullable NSString *)shareText completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
+- (void)showShareSheetWithShareText:(nullable NSString *)shareText
+                         completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
 
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
                             andShareText:(nullable NSString *)shareText
                       fromViewController:(nullable UIViewController *)viewController
-                     completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError * _Nullable error))completion;
+                              completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
+
+/// Returns with activityError as well
+- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
+                            andShareText:(nullable NSString *)shareText
+                      fromViewController:(nullable UIViewController *)viewController
+                     completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion;
 
 // iPad
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
@@ -162,30 +205,41 @@ FOUNDATION_EXPORT BranchCondition _Nonnull BranchConditionRefurbished;
                                   anchor:(nullable UIBarButtonItem *)anchor
                               completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
 
+// Returns with activityError as well
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
                             andShareText:(nullable NSString *)shareText
                       fromViewController:(nullable UIViewController *)viewController
                                   anchor:(nullable UIBarButtonItem *)anchor
-                     completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError * _Nullable error))completion;
+                     completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion;
 
 
 /// @name List items on Spotlight
 
+
 - (void)listOnSpotlight;
 - (void)listOnSpotlightWithCallback:(void (^_Nullable)(NSString * _Nullable url, NSError * _Nullable error))callback;
 
-- (void)listOnSpotlightWithLinkProperties:(BranchLinkProperties*_Nullable)linkproperties callback:(void (^_Nullable)(NSString * _Nullable url, NSError * _Nullable error))completion;
+- (void)listOnSpotlightWithIdentifierCallback:(void (^_Nullable)(NSString * _Nullable url,
+                                                                 NSString * _Nullable spotlightIdentifier,
+                                                                 NSError * _Nullable error))spotlightCallback
+    __attribute__((deprecated((
+    "iOS 10 has changed how Spotlight indexing works and we’ve updated the SDK to reflect this. "
+    "Please see https://dev.branch.io/features/spotlight-indexing/overview/ for instructions on migration."))));
+
+- (void)listOnSpotlightWithLinkProperties:(BranchLinkProperties*_Nullable)linkproperties
+                                 callback:(void (^_Nullable)(NSString * _Nullable url,
+                                                            NSError * _Nullable error))completion;
 
 - (void)removeFromSpotlightWithCallback:(void (^_Nullable)(NSError * _Nullable error))completion;
 
 #endif
 
-- (NSDictionary * _Nonnull)getDictionaryWithCompleteLinkProperties:(BranchLinkProperties * _Nonnull)linkProperties;
-- (NSDictionary * _Nonnull)getParamsForServerRequestWithAddedLinkProperties:(BranchLinkProperties * _Nonnull)linkProperties;
+- (NSDictionary*_Nonnull)getDictionaryWithCompleteLinkProperties:(BranchLinkProperties*_Nonnull)linkProperties;
+- (NSDictionary*_Nonnull)getParamsForServerRequestWithAddedLinkProperties:(BranchLinkProperties*_Nonnull)linkProperties;
 
 /// Convenience method for initSession methods that return BranchUniversalObject, but can be used safely by anyone.
-- (NSMutableDictionary * _Nonnull) dictionary;
-+ (BranchUniversalObject * _Nonnull) objectWithDictionary:(NSDictionary * _Null_unspecified)dictionary;
+- (NSMutableDictionary*_Nonnull) dictionary;
++ (BranchUniversalObject*_Nonnull) objectWithDictionary:(NSDictionary*_Null_unspecified)dictionary;
 
-- (NSString * _Nonnull) description;
+- (NSString*_Nonnull) description;
 @end

--- a/BranchSDK/BranchUniversalObject.h
+++ b/BranchSDK/BranchUniversalObject.h
@@ -190,22 +190,9 @@ FOUNDATION_EXPORT BranchCondition _Nonnull BranchConditionRefurbished;
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
                             andShareText:(nullable NSString *)shareText
                       fromViewController:(nullable UIViewController *)viewController
-                              completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
-
-/// Returns with activityError as well
-- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
-                            andShareText:(nullable NSString *)shareText
-                      fromViewController:(nullable UIViewController *)viewController
                      completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion;
 
-// iPad
-- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
-                            andShareText:(nullable NSString *)shareText
-                      fromViewController:(nullable UIViewController *)viewController
-                                  anchor:(nullable UIBarButtonItem *)anchor
-                              completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
-
-// Returns with activityError as well
+// iPad needs an anchor
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
                             andShareText:(nullable NSString *)shareText
                       fromViewController:(nullable UIViewController *)viewController

--- a/BranchSDK/BranchUniversalObject.h
+++ b/BranchSDK/BranchUniversalObject.h
@@ -112,56 +112,20 @@ FOUNDATION_EXPORT BranchCondition _Nonnull BranchConditionRefurbished;
 @property (nonatomic, nullable, copy) NSString *title;
 @property (nonatomic, nullable, copy) NSString *contentDescription;
 @property (nonatomic, nullable, copy) NSString *imageUrl;
-@property (nonatomic, strong, nullable) NSArray<NSString*> *keywords;
-@property (nonatomic, strong, nullable) NSDate   *creationDate;
-@property (nonatomic, strong, nullable) NSDate   *expirationDate;
-@property (nonatomic, assign)           BOOL      locallyIndex;     //!< Index on Spotlight.
-@property (nonatomic, assign)           BOOL      publiclyIndex;    //!< Index on Google, Branch, etc.
+@property (nonatomic, strong, nullable) NSArray<NSString *> *keywords;
+@property (nonatomic, strong, nullable) NSDate *creationDate;
+@property (nonatomic, strong, nullable) NSDate *expirationDate;
+@property (nonatomic, assign) BOOL locallyIndex; //!< Index on Spotlight.
+@property (nonatomic, assign) BOOL publiclyIndex; //!< Index on Google, Branch, etc.
 
 @property (nonatomic, strong, nonnull) BranchContentMetadata *contentMetadata;
 
-///@name Deprecated Properties
-
-@property (nonatomic, strong, nullable)
-    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.customMetadata` instead."))))
-    NSDictionary *metadata;
-
-- (void)addMetadataKey:(nonnull NSString *)key value:(nonnull NSString *)value
-    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.customMetadata` instead."))));
-
-@property (nonatomic, strong, nullable)
-    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.contentSchema` instead."))))
-    NSString *type;
-
-@property (nonatomic, assign)
-    __attribute__((deprecated(("Use `BranchUniversalObject.locallyIndex and BranchUniversalObject.publiclyIndex` instead."))))
-    BranchContentIndexMode contentIndexMode;
-
-@property (nonatomic, strong, nullable)
-    __attribute__((deprecated(("Not used due to iOS 10.0 Spotlight changes."))))
-    NSString *spotlightIdentifier;
-
-@property (nonatomic, assign)
-    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.price` instead."))))
-    CGFloat price;
-
-@property (nonatomic, strong, nullable)
-    __attribute__((deprecated(("Use `BranchUniversalObject.contentMetadata.currency` instead."))))
-    NSString *currency;
-
-@property (nonatomic, assign)
-    __attribute__((deprecated(("Use `BranchUniversalObject.locallyIndex` instead."))))
-    BOOL automaticallyListOnSpotlight;
-
-
 /// @name Log a User Content View Event
-
 
 - (void)registerView;
 - (void)registerViewWithCallback:(void (^_Nullable)(NSDictionary * _Nullable params, NSError * _Nullable error))callback;
 
 /// @name Short Links
-
 
 /// Returns a Branch short URL to the content item with the passed link properties.
 - (nullable NSString *)getShortUrlWithLinkProperties:(nonnull BranchLinkProperties *)linkProperties;
@@ -184,19 +148,12 @@ FOUNDATION_EXPORT BranchCondition _Nonnull BranchConditionRefurbished;
 /// @name Share Sheet Handling
 #if !TARGET_OS_TV
 
-- (void)showShareSheetWithShareText:(nullable NSString *)shareText
-                         completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
+- (void)showShareSheetWithShareText:(nullable NSString *)shareText completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
 
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
                             andShareText:(nullable NSString *)shareText
                       fromViewController:(nullable UIViewController *)viewController
-                              completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
-
-/// Returns with activityError as well
-- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
-                            andShareText:(nullable NSString *)shareText
-                      fromViewController:(nullable UIViewController *)viewController
-                     completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion;
+                     completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError * _Nullable error))completion;
 
 // iPad
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
@@ -205,41 +162,30 @@ FOUNDATION_EXPORT BranchCondition _Nonnull BranchConditionRefurbished;
                                   anchor:(nullable UIBarButtonItem *)anchor
                               completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
 
-// Returns with activityError as well
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
                             andShareText:(nullable NSString *)shareText
                       fromViewController:(nullable UIViewController *)viewController
                                   anchor:(nullable UIBarButtonItem *)anchor
-                     completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion;
+                     completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError * _Nullable error))completion;
 
 
 /// @name List items on Spotlight
 
-
 - (void)listOnSpotlight;
 - (void)listOnSpotlightWithCallback:(void (^_Nullable)(NSString * _Nullable url, NSError * _Nullable error))callback;
 
-- (void)listOnSpotlightWithIdentifierCallback:(void (^_Nullable)(NSString * _Nullable url,
-                                                                 NSString * _Nullable spotlightIdentifier,
-                                                                 NSError * _Nullable error))spotlightCallback
-    __attribute__((deprecated((
-    "iOS 10 has changed how Spotlight indexing works and we’ve updated the SDK to reflect this. "
-    "Please see https://dev.branch.io/features/spotlight-indexing/overview/ for instructions on migration."))));
-
-- (void)listOnSpotlightWithLinkProperties:(BranchLinkProperties*_Nullable)linkproperties
-                                 callback:(void (^_Nullable)(NSString * _Nullable url,
-                                                            NSError * _Nullable error))completion;
+- (void)listOnSpotlightWithLinkProperties:(BranchLinkProperties*_Nullable)linkproperties callback:(void (^_Nullable)(NSString * _Nullable url, NSError * _Nullable error))completion;
 
 - (void)removeFromSpotlightWithCallback:(void (^_Nullable)(NSError * _Nullable error))completion;
 
 #endif
 
-- (NSDictionary*_Nonnull)getDictionaryWithCompleteLinkProperties:(BranchLinkProperties*_Nonnull)linkProperties;
-- (NSDictionary*_Nonnull)getParamsForServerRequestWithAddedLinkProperties:(BranchLinkProperties*_Nonnull)linkProperties;
+- (NSDictionary * _Nonnull)getDictionaryWithCompleteLinkProperties:(BranchLinkProperties * _Nonnull)linkProperties;
+- (NSDictionary * _Nonnull)getParamsForServerRequestWithAddedLinkProperties:(BranchLinkProperties * _Nonnull)linkProperties;
 
 /// Convenience method for initSession methods that return BranchUniversalObject, but can be used safely by anyone.
-- (NSMutableDictionary*_Nonnull) dictionary;
-+ (BranchUniversalObject*_Nonnull) objectWithDictionary:(NSDictionary*_Null_unspecified)dictionary;
+- (NSMutableDictionary * _Nonnull) dictionary;
++ (BranchUniversalObject * _Nonnull) objectWithDictionary:(NSDictionary * _Null_unspecified)dictionary;
 
-- (NSString*_Nonnull) description;
+- (NSString * _Nonnull) description;
 @end

--- a/BranchSDK/BranchUniversalObject.h
+++ b/BranchSDK/BranchUniversalObject.h
@@ -185,20 +185,18 @@ FOUNDATION_EXPORT BranchCondition _Nonnull BranchConditionRefurbished;
 #if !TARGET_OS_TV
 
 - (void)showShareSheetWithShareText:(nullable NSString *)shareText
-                         completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion;
+                         completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion;
 
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
                             andShareText:(nullable NSString *)shareText
                       fromViewController:(nullable UIViewController *)viewController
                      completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion;
 
-// iPad needs an anchor
 - (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
                             andShareText:(nullable NSString *)shareText
                       fromViewController:(nullable UIViewController *)viewController
                                   anchor:(nullable UIBarButtonItem *)anchor
                      completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion;
-
 
 /// @name List items on Spotlight
 

--- a/BranchSDK/BranchUniversalObject.m
+++ b/BranchSDK/BranchUniversalObject.m
@@ -392,55 +392,26 @@ BranchCondition _Nonnull BranchConditionRefurbished   = @"REFURBISHED";
 #if !TARGET_OS_TV
 
 - (void)showShareSheetWithShareText:(NSString *)shareText
-                         completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion {
-    [self showShareSheetWithLinkProperties:nil andShareText:shareText fromViewController:nil completion:completion];
-}
-
-- (void)showShareSheetWithLinkProperties:(BranchLinkProperties *)linkProperties
-                            andShareText:(NSString *)shareText
-                      fromViewController:(UIViewController *)viewController
-                              completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion {
-    [self showShareSheetWithLinkProperties:linkProperties andShareText:shareText
-        fromViewController:viewController anchor:nil completion:completion orCompletionWithError:nil];
+                         completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion {
+    [self showShareSheetWithLinkProperties:nil andShareText:shareText fromViewController:nil completionWithError:completion];
 }
 
 - (void)showShareSheetWithLinkProperties:(BranchLinkProperties *)linkProperties
                             andShareText:(NSString *)shareText
                       fromViewController:(UIViewController *)viewController
                      completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion {
-    [self showShareSheetWithLinkProperties:linkProperties andShareText:shareText
-        fromViewController:viewController anchor:nil completion:nil orCompletionWithError:completion];
-}
-
-- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
-                            andShareText:(nullable NSString *)shareText
-                      fromViewController:(nullable UIViewController *)viewController
-                                  anchor:(nullable id)anchor
-                              completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion {
-    [self showShareSheetWithLinkProperties:linkProperties andShareText:shareText
-        fromViewController:viewController anchor:anchor completion:completion orCompletionWithError:nil];
-}
-
-- (void)showShareSheetWithLinkProperties:(nullable BranchLinkProperties *)linkProperties
-                            andShareText:(nullable NSString *)shareText
-                      fromViewController:(nullable UIViewController *)viewController
-                                  anchor:(nullable id)anchor
-                     completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion {
-    [self showShareSheetWithLinkProperties:linkProperties andShareText:shareText
-        fromViewController:viewController anchor:anchor completion:nil orCompletionWithError:completion];
+    [self showShareSheetWithLinkProperties:linkProperties andShareText:shareText fromViewController:viewController anchor:nil completionWithError:completion];
 }
 
 - (void)showShareSheetWithLinkProperties:(BranchLinkProperties *)linkProperties
                             andShareText:(NSString *)shareText
                       fromViewController:(UIViewController *)viewController
                                   anchor:(nullable id)anchorViewOrButtonItem
-                              completion:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed))completion
-                   orCompletionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completionError {
+                   completionWithError:(void (^ _Nullable)(NSString * _Nullable activityType, BOOL completed, NSError*_Nullable error))completion {
     
     BranchShareLink *shareLink = [[BranchShareLink alloc] initWithUniversalObject:self linkProperties:linkProperties];
     shareLink.shareText = shareText;
-    shareLink.completion = completion;
-    shareLink.completionError = completionError;
+    shareLink.completionError = completion;
     [shareLink presentActivityViewControllerFromViewController:viewController anchor:anchorViewOrButtonItem];
 }
 
@@ -464,8 +435,7 @@ BranchCondition _Nonnull BranchConditionRefurbished   = @"REFURBISHED";
     BOOL publiclyIndexable;
     if (self.contentIndexMode == BranchContentIndexModePrivate) {
         publiclyIndexable = NO;
-    }
-    else {
+    } else {
         publiclyIndexable = YES;
     }
     
@@ -500,17 +470,15 @@ BranchCondition _Nonnull BranchConditionRefurbished   = @"REFURBISHED";
         }];
 }
 
-- (void) removeFromSpotlightWithCallback:(void (^_Nullable)(NSError * _Nullable error))completion{
+- (void)removeFromSpotlightWithCallback:(void (^_Nullable)(NSError * _Nullable error))completion {
     if (self.locallyIndex) {
-        [[Branch getInstance] removeSearchableItemWithBranchUniversalObject:self
-                                                                   callback:^(NSError *error) {
-                                                                       if (completion) {
-                                                                           completion(error);
-                                                                       }
-                                                                   }];
+        [[Branch getInstance] removeSearchableItemWithBranchUniversalObject:self callback:^(NSError *error) {
+            if (completion) {
+                completion(error);
+            }
+        }];
     } else {
-        NSError *error = [NSError branchErrorWithCode:BNCSpotlightPublicIndexError
-                                     localizedMessage:@"Publically indexed cannot be removed from Spotlight"];
+        NSError *error = [NSError branchErrorWithCode:BNCSpotlightPublicIndexError localizedMessage:@"Publically indexed cannot be removed from Spotlight"];
         if (completion) completion(error);
     }
 }


### PR DESCRIPTION
## Reference
SDK-2051 remove Objective-C APIs that confuse Xcode's Swift compatibility

## Summary
NSError's within callback blocks are converted to exceptions in Swift. This causes unusual behavior when two methods differ only by a NSError in the callback. 

Removed problem public APIs, also added an NSError to one version that did not have one. This is a public API change.

## Motivation
Improve usability for Swift developers.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing Instructions
Attempt to use these APIs in a Swift app, the NSErrors should be converted to exceptions correctly.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
