### PR TITLE
the SDK state clear happened with the old close call

### DIFF
--- a/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
+++ b/Branch-TestBed/Branch-TestBed/Branch-TestBed-Info.plist
@@ -54,7 +54,7 @@
 	<key>branch_key</key>
 	<dict>
 		<key>live</key>
-		<string>key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv</string>
+		<string>key_live_hcnegAumkH7Kv18M8AOHhfgiohpXq5tB</string>
 		<key>test</key>
 		<string>key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc</string>
 	</dict>

--- a/BranchSDK/Branch.m
+++ b/BranchSDK/Branch.m
@@ -1738,6 +1738,7 @@ static NSString *bnc_branchKey = nil;
 
 - (void)applicationWillResignActive {
     if (!Branch.trackingDisabled) {
+        self.initializationStatus = BNCInitStatusUninitialized;
         [self.requestQueue persistImmediately];
         [BranchOpenRequest setWaitNeededForOpenResponseLock];
         BNCLogDebugSDK(@"Application resigned active.");


### PR DESCRIPTION
## Reference
INTENG-19489 fix organic warm open

## Summary
SDK init status was cleared by the close call, with it's removal we need to clear it elsewhere to maintain previous behavior.

## Motivation
Restore previous behavior around organic opens.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
1. Run a test app with the debugger attached.
2. See install or open on app run.
3. Background the app.
4. Foreground the app. Notice no network call to init.

Repeat with this change, and step 4 will have a network call to init.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
