### PR TITLE
SDK-1711 fix crash on iOS 12 when using the pre-built xcframework

### DIFF
--- a/BranchSDK.xcodeproj/project.pbxproj
+++ b/BranchSDK.xcodeproj/project.pbxproj
@@ -1954,6 +1954,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.0.1;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					LinkPresentation,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1985,6 +1989,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.0.1;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					LinkPresentation,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2187,6 +2195,10 @@
 				);
 				MACH_O_TYPE = staticlib;
 				MARKETING_VERSION = 3.0.1;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					LinkPresentation,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchSDK;
 				PRODUCT_MODULE_NAME = BranchSDK;
 				PRODUCT_NAME = BranchSDK;
@@ -2222,6 +2234,10 @@
 				);
 				MACH_O_TYPE = staticlib;
 				MARKETING_VERSION = 3.0.1;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					LinkPresentation,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchSDK;
 				PRODUCT_MODULE_NAME = BranchSDK;
 				PRODUCT_NAME = BranchSDK;
@@ -2255,6 +2271,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.0.1;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					LinkPresentation,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchSDK;
 				PRODUCT_NAME = BranchSDK;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2286,6 +2306,10 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 3.0.1;
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					LinkPresentation,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.branch.BranchSDK;
 				PRODUCT_NAME = BranchSDK;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,11 @@ v.3.0.0
     - pre-iOS 10 locale support
     - Device carrier. This was used for fraud analysis, but is no longer available on new iOS versions.
 
+v.2.3.1
+This version is for a hotfix on Xamarin, it will not ship as a general iOS release.
+
+- SDK-2179 Fix LinkPresentation linker issue causing crash on Xamarin when run on iOS 12 or iOS 13. Thanks @LeadAssimilator.
+
 v.2.2.1
  
 Branch iOS SDK 2.2.1 adds parameter for current SKAN 4.0 Window in /v1/open and /v2/event requests.

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -107,7 +107,7 @@ if [[ $update ]]; then
     sed -i '' -e "/^[[:space:]]*s\.version/ {s/\".*\"/\"$version\"/; }" ../BranchSDK.podspec
   
     # Update framework version
-    sed -ie 's/MARKETING_VERSION = '"$prev_version"'/MARKETING_VERSION = '"$version"'/g' ../BranchSDK.xcodeproj/project.pbxproj
+    sed -i '' -e 's/MARKETING_VERSION = '"$prev_version"'/MARKETING_VERSION = '"$version"'/g' ../BranchSDK.xcodeproj/project.pbxproj
 fi
 
 


### PR DESCRIPTION
## Reference
SDK-1711 fix crash on iOS 12 when using the pre-built xcframework

## Summary
Copies fix for linker issue from the Xamarin hotfix

## Motivation
Xamarin uses the binary framework and is severely impacted by this crash.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Integrate a test app using the pre-built xcframework
Run app on iOS 12, notice crash.

When using the version built with this change, the app should not crash.

cc @BranchMetrics/saas-sdk-devs for visibility.
