### PR TITLE
[SDK-2118] Added a method to set API URL

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
@@ -11,6 +11,7 @@
 #import "BNCSystemObserver.h"
 #import "BNCConfig.h"
 #import "BranchConstants.h"
+#import "Branch.h"
 
 @interface BNCAPIServerTest : XCTestCase
 
@@ -368,6 +369,44 @@
     NSString *expectedUrlPrefix= @"https://api3-eu.branch.io/v1/app-link-settings";
     
     XCTAssertTrue([url hasPrefix:expectedUrlPrefix]);
+}
+
+- (void)testDefaultAPIURL {
+    BNCServerAPI *serverAPI = [BNCServerAPI new];
+    XCTAssertNil(serverAPI.customAPIURL);
+    
+    NSString *storedUrl = [[BNCServerAPI sharedInstance] installServiceURL];
+    NSString *expectedUrl = [BNC_API_URL stringByAppendingString: @"/v1/install"];
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+}
+
+- (void)testSetAPIURL_Example {
+    NSString *url = @"https://www.example.com";
+    [Branch setAPIUrl:url];
+    
+    NSString *storedUrl = [[BNCServerAPI sharedInstance] installServiceURL];
+    NSString *expectedUrl = [url stringByAppendingString: @"/v1/install"];
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    [Branch setAPIUrl:BNC_API_URL];
+}
+
+- (void)testSetAPIURL_InvalidHttp {
+    NSString *url = @"Invalid://www.example.com";
+    [Branch setAPIUrl:url];
+
+    NSString *storedUrl = [[BNCServerAPI sharedInstance] installServiceURL];
+    NSString *expectedUrl = [BNC_API_URL stringByAppendingString: @"/v1/install"];
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+}
+
+- (void)testSetAPIURL_InvalidEmpty {
+    NSString *url = @"";
+    [Branch setAPIUrl:url];
+    
+    NSString *storedUrl = [[BNCServerAPI sharedInstance] installServiceURL];
+    NSString *expectedUrl = [BNC_API_URL stringByAppendingString: @"/v1/install"];
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
 }
 
 @end

--- a/Branch-TestBed/Branch-SDK-Tests/BNCPreferenceHelperTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCPreferenceHelperTests.m
@@ -199,34 +199,6 @@
     XCTAssert([filterDesc isEqualToString:valueDesc]);
 }
 
-- (void)testSetAPIURL_Example {
-    
-    NSString *url = @"https://www.example.com/";
-    [self.prefHelper setBranchAPIURL:url] ;
-    
-    NSString *urlStored = self.prefHelper.branchAPIURL ;
-    XCTAssert([url isEqualToString:urlStored]);
-}
-
-- (void)testSetAPIURL_InvalidHttp {
-    
-    NSString *url = @"Invalid://www.example.com/";
-    [self.prefHelper setBranchAPIURL:url] ;
-    
-    NSString *urlStored = self.prefHelper.branchAPIURL ;
-    XCTAssert(![url isEqualToString:urlStored]);
-    XCTAssert([urlStored isEqualToString:BNC_API_URL]);
-}
-
-- (void)testSetAPIURL_InvalidEmpty {
-    
-    [self.prefHelper setBranchAPIURL:@""] ;
-    
-    NSString *urlStored = self.prefHelper.branchAPIURL ;
-    XCTAssert(![urlStored isEqualToString:@""]);
-    XCTAssert([urlStored isEqualToString:BNC_API_URL]);
-}
-
 - (void)testSetCDNBaseURL_Example {
     
     NSString *url = @"https://www.example.com/";

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -36,7 +36,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     Branch *branch = [Branch getInstance];
     
     // Change the Branch base API URL
-    //[branch setAPIUrl:@"https://api3.branch.io"];
+    //[Branch setAPIUrl:@"https://api3.branch.io"];
     
     // test pre init support
     //[self testDispatchToIsolationQueue:branch]

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -34,7 +34,10 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
     // Branch.useTestBranchKey = YES;  // Make sure to comment this line out for production apps!!!
     Branch *branch = [Branch getInstance];
-        
+    
+    // Change the Branch base API URL
+    //[branch setAPIUrl:@"https://api3.branch.io"];
+    
     // test pre init support
     //[self testDispatchToIsolationQueue:branch]
 

--- a/BranchSDK/BNCPreferenceHelper.h
+++ b/BranchSDK/BNCPreferenceHelper.h
@@ -51,7 +51,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 @property (copy, nonatomic) NSString *lastSystemBuildVersion;
 @property (copy, nonatomic) NSString *browserUserAgentString;
 @property (copy, nonatomic) NSString *referringURL;
-@property (copy, nonatomic) NSString *branchAPIURL;
 @property (assign, nonatomic) BOOL limitFacebookTracking;
 @property (strong, nonatomic) NSDate *previousAppBuildDate;
 @property (assign, nonatomic, readwrite) BOOL disableAdNetworkCallouts;
@@ -77,7 +76,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 
 + (BNCPreferenceHelper *)sharedInstance;
 
-- (void)setBranchAPIURL:(NSString *)url;
 - (void)setPatternListURL:(NSString *)url;
 
 - (void)setRequestMetadataKey:(NSString *)key value:(NSObject *)value;

--- a/BranchSDK/BNCPreferenceHelper.m
+++ b/BranchSDK/BNCPreferenceHelper.m
@@ -26,7 +26,7 @@ static NSString * const BRANCH_PREFS_KEY_APP_VERSION = @"bnc_app_version";
 static NSString * const BRANCH_PREFS_KEY_LAST_RUN_BRANCH_KEY = @"bnc_last_run_branch_key";
 static NSString * const BRANCH_PREFS_KEY_LAST_STRONG_MATCH_DATE = @"bnc_strong_match_created_date";
 
-static NSString * const BRANCH_PREFS_KEY_API_URL = @"bnc_api_url";
+static NSString * const BRANCH_PREFS_KEY_CUSTOM_API_URL = @"bnc_custom_api_url";
 static NSString * const BRANCH_PREFS_KEY_PATTERN_LIST_URL = @"bnc_pattern_list_url";
 
 static NSString * const BRANCH_PREFS_KEY_RANDOMIZED_DEVICE_TOKEN = @"bnc_randomized_device_token";
@@ -160,24 +160,23 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
     if ([url hasPrefix:@"http://"] || [url hasPrefix:@"https://"] ){
         @synchronized (self) {
             _branchAPIURL = [url copy];
-            [self writeObjectToDefaults:BRANCH_PREFS_KEY_API_URL value:_branchAPIURL];
+            [self writeObjectToDefaults:BRANCH_PREFS_KEY_CUSTOM_API_URL value:_branchAPIURL];
         }
     } else {
         BNCLogWarning(@"Ignoring invalid custom API URL");
     }
 }
 
-// TODO: This method is not used with the Tracking domain change. See SDK-2118
 - (NSString *)branchAPIURL {
     @synchronized (self) {
         if (!_branchAPIURL) {
-            _branchAPIURL = [self readStringFromDefaults:BRANCH_PREFS_KEY_API_URL];
+            _branchAPIURL = [self readStringFromDefaults:BRANCH_PREFS_KEY_CUSTOM_API_URL];
         }
         
         // return the default URL in the event there's nothing in storage
         if (_branchAPIURL == nil || [_branchAPIURL isEqualToString:@""]) {
             _branchAPIURL = [BNC_API_URL copy];
-            [self writeObjectToDefaults:BRANCH_PREFS_KEY_API_URL value:_branchAPIURL];
+            [self writeObjectToDefaults:BRANCH_PREFS_KEY_CUSTOM_API_URL value:_branchAPIURL];
         }
 
         return _branchAPIURL;

--- a/BranchSDK/BNCPreferenceHelper.m
+++ b/BranchSDK/BNCPreferenceHelper.m
@@ -26,7 +26,6 @@ static NSString * const BRANCH_PREFS_KEY_APP_VERSION = @"bnc_app_version";
 static NSString * const BRANCH_PREFS_KEY_LAST_RUN_BRANCH_KEY = @"bnc_last_run_branch_key";
 static NSString * const BRANCH_PREFS_KEY_LAST_STRONG_MATCH_DATE = @"bnc_strong_match_created_date";
 
-static NSString * const BRANCH_PREFS_KEY_CUSTOM_API_URL = @"bnc_custom_api_url";
 static NSString * const BRANCH_PREFS_KEY_PATTERN_LIST_URL = @"bnc_pattern_list_url";
 
 static NSString * const BRANCH_PREFS_KEY_RANDOMIZED_DEVICE_TOKEN = @"bnc_randomized_device_token";
@@ -68,7 +67,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
     NSOperationQueue *_persistPrefsQueue;
     NSString         *_lastSystemBuildVersion;
     NSString         *_browserUserAgentString;
-    NSString         *_branchAPIURL;
     NSString         *_referringURL;
 }
 
@@ -155,33 +153,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
 }
 
 #pragma mark - API methods
-
-- (void)setBranchAPIURL:(NSString *)url {
-    if ([url hasPrefix:@"http://"] || [url hasPrefix:@"https://"] ){
-        @synchronized (self) {
-            _branchAPIURL = [url copy];
-            [self writeObjectToDefaults:BRANCH_PREFS_KEY_CUSTOM_API_URL value:_branchAPIURL];
-        }
-    } else {
-        BNCLogWarning(@"Ignoring invalid custom API URL");
-    }
-}
-
-- (NSString *)branchAPIURL {
-    @synchronized (self) {
-        if (!_branchAPIURL) {
-            _branchAPIURL = [self readStringFromDefaults:BRANCH_PREFS_KEY_CUSTOM_API_URL];
-        }
-        
-        // return the default URL in the event there's nothing in storage
-        if (_branchAPIURL == nil || [_branchAPIURL isEqualToString:@""]) {
-            _branchAPIURL = [BNC_API_URL copy];
-            [self writeObjectToDefaults:BRANCH_PREFS_KEY_CUSTOM_API_URL value:_branchAPIURL];
-        }
-
-        return _branchAPIURL;
-    }
-}
 
 - (void)setPatternListURL:(NSString *)url {
     if ([url hasPrefix:@"http://"] || [url hasPrefix:@"https://"] ){

--- a/BranchSDK/BNCServerAPI.h
+++ b/BranchSDK/BNCServerAPI.h
@@ -33,6 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 // Used to enable unit tests without regard for ATT authorization status
 @property (nonatomic, assign, readwrite) BOOL automaticallyEnableTrackingDomain;
 
+@property (nonatomic, copy, readwrite, nullable) NSString *customAPIURL;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/BranchSDK/BNCServerAPI.m
+++ b/BranchSDK/BNCServerAPI.m
@@ -9,6 +9,7 @@
 #import "BNCSystemObserver.h"
 #import "BNCConfig.h"
 #import "BranchConstants.h"
+#import "BNCPreferenceHelper.h"
 
 @implementation BNCServerAPI
 
@@ -88,6 +89,12 @@
 }
 
 - (NSString *)getBaseURL {
+    //Check if user has set a custom API base URL
+    NSString *url = [[BNCPreferenceHelper sharedInstance] branchAPIURL];
+    if (url && ![url isEqualToString:BNC_API_URL]) {
+        return url;
+    }
+    
     if (self.automaticallyEnableTrackingDomain) {
         self.useTrackingDomain = [self optedIntoIDFA];
     }

--- a/BranchSDK/BNCServerAPI.m
+++ b/BranchSDK/BNCServerAPI.m
@@ -30,6 +30,7 @@
         self.useTrackingDomain = NO;
         self.useEUServers = NO;
         self.automaticallyEnableTrackingDomain = YES;
+        self.customAPIURL = NULL;
     }
     return self;
 }
@@ -78,6 +79,10 @@
 
 // Linking endpoints are not used for Ads tracking
 - (NSString *)getBaseURLForLinkingEndpoints {
+    if (self.customAPIURL) {
+        return self.customAPIURL;
+    }
+    
     NSString * urlString;
     if (self.useEUServers){
         urlString = BNC_EU_API_URL;
@@ -90,9 +95,8 @@
 
 - (NSString *)getBaseURL {
     //Check if user has set a custom API base URL
-    NSString *url = [[BNCPreferenceHelper sharedInstance] branchAPIURL];
-    if (url && ![url isEqualToString:BNC_API_URL]) {
-        return url;
+    if (self.customAPIURL) {
+        return self.customAPIURL;
     }
     
     if (self.automaticallyEnableTrackingDomain) {

--- a/BranchSDK/BNCServerAPI.m
+++ b/BranchSDK/BNCServerAPI.m
@@ -30,7 +30,7 @@
         self.useTrackingDomain = NO;
         self.useEUServers = NO;
         self.automaticallyEnableTrackingDomain = YES;
-        self.customAPIURL = NULL;
+        self.customAPIURL = nil;
     }
     return self;
 }

--- a/BranchSDK/Branch.h
+++ b/BranchSDK/Branch.h
@@ -579,7 +579,7 @@ extern NSString * __nonnull const BNCSpotlightFeature;
 Sets a custom base URL for all calls to the Branch API.
 @param url  Base URL that the Branch API will use.
 */
-- (void)setAPIUrl:(NSString *)url;
++ (void)setAPIUrl:(NSString *)url;
 
 /**
  setDebug is deprecated and all functionality has been disabled.

--- a/BranchSDK/Branch.h
+++ b/BranchSDK/Branch.h
@@ -576,6 +576,12 @@ extern NSString * __nonnull const BNCSpotlightFeature;
 - (void)useEUEndpoints;
 
 /**
+Sets a custom base URL for all calls to the Branch API.
+@param url  Base URL that the Branch API will use.
+*/
+- (void)setAPIUrl:(NSString *)url;
+
+/**
  setDebug is deprecated and all functionality has been disabled.
  
  If you wish to enable logging, please invoke enableLogging.

--- a/BranchSDK/Branch.m
+++ b/BranchSDK/Branch.m
@@ -426,6 +426,10 @@ static NSString *bnc_branchKey = nil;
     [BNCServerAPI sharedInstance].useEUServers = YES;
 }
 
+- (void)setAPIUrl:(NSString *)url {
+    [[BNCPreferenceHelper sharedInstance] setBranchAPIURL:url];
+}
+
 - (void)setDebug {
     NSLog(@"Branch setDebug is deprecated and all functionality has been disabled. "
           "If you wish to enable logging, please invoke enableLogging. "

--- a/BranchSDK/Branch.m
+++ b/BranchSDK/Branch.m
@@ -426,8 +426,12 @@ static NSString *bnc_branchKey = nil;
     [BNCServerAPI sharedInstance].useEUServers = YES;
 }
 
-- (void)setAPIUrl:(NSString *)url {
-    [[BNCPreferenceHelper sharedInstance] setBranchAPIURL:url];
++ (void)setAPIUrl:(NSString *)url {
+    if ([url hasPrefix:@"http://"] || [url hasPrefix:@"https://"] ){
+        [BNCServerAPI sharedInstance].customAPIURL = url;
+    } else {
+        BNCLogWarning(@"Ignoring invalid custom API URL");
+    }
 }
 
 - (void)setDebug {

--- a/BranchSDK/BranchPluginSupport.h
+++ b/BranchSDK/BranchPluginSupport.h
@@ -15,12 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (BranchPluginSupport *)instance;
 
 /**
-Sets a custom base URL for all calls to the Branch API.
-@param url  Base URL that the Branch API will use.
-*/
-+ (void)setAPIUrl:(NSString *)url;
-
-/**
 Sets a custom CDN base URL.
 @param url Base URL for CDN endpoints.
 */

--- a/BranchSDK/BranchPluginSupport.m
+++ b/BranchSDK/BranchPluginSupport.m
@@ -54,7 +54,6 @@
 
 #pragma mark - Server URL methods
 
-// With the change to support Apple's tracking domain feature, this API no longer works. See SDK-2118
 // Overrides base API URL
 + (void)setAPIUrl:(NSString *)url {
     [[BNCPreferenceHelper sharedInstance] setBranchAPIURL:url];

--- a/BranchSDK/BranchPluginSupport.m
+++ b/BranchSDK/BranchPluginSupport.m
@@ -54,11 +54,6 @@
 
 #pragma mark - Server URL methods
 
-// Overrides base API URL
-+ (void)setAPIUrl:(NSString *)url {
-    [[BNCPreferenceHelper sharedInstance] setBranchAPIURL:url];
-}
-
 // Overrides base CDN URL
 + (void)setCDNBaseUrl:(NSString *)url {
     [[BNCPreferenceHelper sharedInstance] setPatternListURL:url];


### PR DESCRIPTION
## Reference
SDK-2118 -- Added a method to set API URL

## Summary
Added a new method to the Branch class for setting the API base URL to a custom value. This also includes adding a check to the `getBaseURL` method to check for a custom URL. 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To allow clients to provide custom API URLs and gain parity with our Android SDK.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Call the `setAPIURL` method in the AppDelegate and observe the change.
```
Branch *branch = [Branch getInstance];
[branch setAPIUrl:@"https://api2.branch.io"];
```
<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
