### PR TITLE
INTENG-19264 and INTENG-19577 bug fixes

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCRequestFactoryTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCRequestFactoryTests.m
@@ -25,7 +25,7 @@
 
 - (void)testInitWithBranchKeyNil {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:nil];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForInstallWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     
     // key is omitted when nil
@@ -34,7 +34,7 @@
 
 - (void)testInitWithBranchKeyEmpty {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@""];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForInstallWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     
     // empty string is allowed
@@ -43,14 +43,14 @@
 
 - (void)testInitWithBranchKey {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForInstallWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     XCTAssertTrue([@"key_abcd" isEqualToString:[json objectForKey:@"branch_key"]]);
 }
 
 - (void)testDataForInstall {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForInstallWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     
     XCTAssertTrue([@"key_abcd" isEqualToString:[json objectForKey:@"branch_key"]]);
@@ -64,7 +64,7 @@
 
 - (void)testDataForOpen {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForOpen];
+    NSDictionary *json = [factory dataForOpenWithURLString:@"https://branch.io"];
     XCTAssertNotNil(json);
     
     XCTAssertTrue([@"key_abcd" isEqualToString:[json objectForKey:@"branch_key"]]);
@@ -182,13 +182,13 @@
 
 - (void)testDataForShortURL {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForShortURLWithLinkDataDictionary:@{}.mutableCopy isSpotlightRequest:NO];
     XCTAssertNotNil(json);
 }
 
 - (void)testDataForLATD {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd"];
-    NSDictionary *json = [factory dataForInstall];
+    NSDictionary *json = [factory dataForLATDWithDataDictionary:@{}.mutableCopy];
     XCTAssertNotNil(json);
 }
 

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -76,7 +76,7 @@
     return Branch.trackingDisabled;
 }
 
-- (NSDictionary *)dataForInstall {
+- (NSDictionary *)dataForInstallWithURLString:(NSString *)urlString {
     NSMutableDictionary *json = [NSMutableDictionary new];
     
     // All requests
@@ -100,6 +100,10 @@
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
+    if (urlString) {
+        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+    }
+    
     [self addAppleAttributionTokenToJSON:json];
 
     // Install Only
@@ -116,7 +120,7 @@
     return json;
 }
 
-- (NSDictionary *)dataForOpen {
+- (NSDictionary *)dataForOpenWithURLString:(NSString *)urlString {
     NSMutableDictionary *json = [NSMutableDictionary new];
     
     // All requests
@@ -142,6 +146,10 @@
     [self addPartnerParametersToJSON:json];
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
+    
+    if (urlString) {
+        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+    }
     
     // Usually sent with install, but retry on open if it didn't get sent
     [self addAppleAttributionTokenToJSON:json];
@@ -279,7 +287,6 @@
 
     [self safeSetValue:self.preferenceHelper.linkClickIdentifier forKey:BRANCH_REQUEST_KEY_LINK_IDENTIFIER onDict:json];
     [self safeSetValue:self.preferenceHelper.spotlightIdentifier forKey:BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER onDict:json];
-    [self safeSetValue:self.preferenceHelper.universalLinkUrl forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
     [self safeSetValue:self.preferenceHelper.initialReferrer forKey:BRANCH_REQUEST_KEY_INITIAL_REFERRER onDict:json];
     
     // This was only on opens before, cause it can't exist on install.

--- a/Sources/BranchSDK/BNCServerRequestQueue.m
+++ b/Sources/BranchSDK/BNCServerRequestQueue.m
@@ -161,56 +161,17 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
     }
 }
 
-- (BOOL)removeInstallOrOpen {
+- (BranchOpenRequest *)findExistingInstallOrOpen {
     @synchronized (self) {
         for (NSUInteger i = 0; i < self.queue.count; i++) {
             BNCServerRequest *request = [self.queue objectAtIndex:i];
-            // Install extends open, so only need to check open.
+
+            // Install subclasses open, so only need to check open
             if ([request isKindOfClass:[BranchOpenRequest class]]) {
-                [[BranchLogger shared] logDebug:@"Removing open request."];
-                ((BranchOpenRequest *)request).callback = nil;
-                [self remove:request];
-                return YES;
+                return (BranchOpenRequest *)request;
             }
         }
-        return NO;
-    }
-}
-
-- (BranchOpenRequest *)moveInstallOrOpenToFront:(NSInteger)networkCount {
-    @synchronized (self) {
-
-        BOOL requestAlreadyInProgress = networkCount > 0;
-
-        BNCServerRequest *openOrInstallRequest;
-        for (NSUInteger i = 0; i < self.queue.count; i++) {
-            BNCServerRequest *req = [self.queue objectAtIndex:i];
-            if ([req isKindOfClass:[BranchOpenRequest class]]) {
-                
-                // Already in front, nothing to do
-                if (i == 0 || (i == 1 && requestAlreadyInProgress)) {
-                    return (BranchOpenRequest *)req;
-                }
-
-                // Otherwise, pull this request out and stop early
-                openOrInstallRequest = [self removeAt:i];
-                break;
-            }
-        }
-        
-        if (!openOrInstallRequest) {
-            [[BranchLogger shared] logError:@"No install or open request in queue while trying to move it to the front." error:nil];
-            return nil;
-        }
-        
-        if (!requestAlreadyInProgress || !self.queue.count) {
-            [self insert:openOrInstallRequest at:0];
-        }
-        else {
-            [self insert:openOrInstallRequest at:1];
-        }
-        
-        return (BranchOpenRequest *)openOrInstallRequest;
+        return nil;
     }
 }
 

--- a/Sources/BranchSDK/BranchInstallRequest.m
+++ b/Sources/BranchSDK/BranchInstallRequest.m
@@ -20,7 +20,7 @@
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:key];
-    NSDictionary *params = [factory dataForInstall];
+    NSDictionary *params = [factory dataForInstallWithURLString:self.urlString];
 
     [serverInterface postRequest:params url:[[BNCServerAPI sharedInstance] installServiceURL] key:key callback:callback];
 }

--- a/Sources/BranchSDK/BranchOpenRequest.m
+++ b/Sources/BranchSDK/BranchOpenRequest.m
@@ -47,7 +47,7 @@
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:key];
-    NSDictionary *params = [factory dataForOpen];
+    NSDictionary *params = [factory dataForOpenWithURLString:self.urlString];
 
     [serverInterface postRequest:params
         url:[[BNCServerAPI sharedInstance] openServiceURL]
@@ -140,13 +140,9 @@
     }
 
     NSString *referringURL = nil;
-    if (preferenceHelper.universalLinkUrl.length) {
-        referringURL = preferenceHelper.universalLinkUrl;
-    }
-    else if (preferenceHelper.externalIntentURI.length) {
-        referringURL = preferenceHelper.externalIntentURI;
-    }
-    else {
+    if (self.urlString.length > 0) {
+        referringURL = self.urlString;
+    } else {
         NSDictionary *sessionDataDict = [BNCEncodingUtils decodeJsonStringToDictionary:sessionData];
         NSString *link = sessionDataDict[BRANCH_RESPONSE_KEY_BRANCH_REFERRING_LINK];
         if ([link isKindOfClass:[NSString class]]) {

--- a/Sources/BranchSDK/Private/BNCRequestFactory.h
+++ b/Sources/BranchSDK/Private/BNCRequestFactory.h
@@ -23,8 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithBranchKey:(NSString *)key NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
-- (NSDictionary *)dataForInstall;
-- (NSDictionary *)dataForOpen;
+- (NSDictionary *)dataForInstallWithURLString:(nullable NSString *)urlString;
+- (NSDictionary *)dataForOpenWithURLString:(nullable NSString *)urlString;
 
 // Event data is passed in
 - (NSDictionary *)dataForEventWithEventDictionary:(NSMutableDictionary *)dictionary;

--- a/Sources/BranchSDK/Private/BranchOpenRequest.h
+++ b/Sources/BranchSDK/Private/BranchOpenRequest.h
@@ -11,6 +11,9 @@
 
 @interface BranchOpenRequest : BNCServerRequest
 
+// URL that triggered this install or open event
+@property (nonatomic, copy, readwrite) NSString *urlString;
+
 @property (nonatomic, copy) callbackWithStatus callback;
 
 + (void) waitForOpenResponseLock;

--- a/Sources/BranchSDK/Public/BNCServerRequestQueue.h
+++ b/Sources/BranchSDK/Public/BNCServerRequestQueue.h
@@ -22,8 +22,8 @@
 - (NSInteger)queueDepth;
 
 - (BOOL)containsInstallOrOpen;
-- (BOOL)removeInstallOrOpen;
-- (BranchOpenRequest *)moveInstallOrOpenToFront:(NSInteger)networkCount;
+
+- (BranchOpenRequest *)findExistingInstallOrOpen;
 
 - (void)persistEventually;
 - (void)persistImmediately;

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -740,28 +740,6 @@ Sets a custom base URL for all calls to the Branch API.
 - (void)disableAdNetworkCallouts:(BOOL)disableCallouts;
 
 /**
- Specify that Branch should NOT use an invisible SFSafariViewController to attempt cookie-based matching upon install.
- If you call this method, we will fall back to using our pool of cookie-IDFA pairs for matching.
- */
-- (void)disableCookieBasedMatching __attribute__((deprecated(("Feature removed.  Did not work on iOS 11+"))));
-
-/**
- TL;DR: If you're using a version of the Facebook SDK that prevents application:didFinishLaunchingWithOptions: from
- returning YES/true when a Universal Link is clicked, you should enable this option.
-
- Long explanation: in application:didFinishLaunchingWithOptions: you should choose one of the following:
-
- 1. Always `return YES;`, and do *not* invoke `[[Branch getInstance] accountForFacebookSDKPreventingAppLaunch];`
- 2. Allow the Facebook SDK to determine whether `application:didFinishLaunchingWithOptions:` returns `YES` or `NO`,
-    and invoke `[[Branch getInstance] accountForFacebookSDKPreventingAppLaunch];`
-
- The reason for this second option is that the Facebook SDK will return `NO` if a Universal Link opens the app
- but that UL is not a Facebook UL. Some developers prefer not to modify
- `application:didFinishLaunchingWithOptions:` to always return `YES` and should use this method instead.
- */
-- (void)accountForFacebookSDKPreventingAppLaunch __attribute__((deprecated(("Please ensure application:didFinishLaunchingWithOptions: always returns YES/true instead of using this method. It will be removed in a future release."))));
-
-/**
  For use by other Branch SDKs
  
  @param name Plugin name.  For example, Unity or React Native
@@ -785,16 +763,6 @@ Sets a custom base URL for all calls to the Branch API.
  @param value Object to be included in request metadata
  */
 - (void)setRequestMetadataKey:(NSString *)key value:(nullable id)value;
-
-- (void)enableDelayedInit __attribute__((deprecated(("No longer valid with new init process"))));
-
-- (void)disableDelayedInit __attribute__((deprecated(("No longer valid with new init process"))));
-
-- (nullable NSURL *)getUrlForOnboardingWithRedirectUrl:(nullable NSString *)redirectUrl __attribute__((deprecated(("Feature removed.  Did not work on iOS 11+"))));;
-
-- (void)resumeInit __attribute__((deprecated(("Feature removed.  Did not work on iOS 11+"))));
-
-- (void)setInstallRequestDelay:(NSInteger)installRequestDelay __attribute__((deprecated(("No longer valid with new init process"))));
 
 /**
  Disables the Branch SDK from tracking the user. This is useful for GDPR privacy compliance.


### PR DESCRIPTION
## Reference
INTENG-19264 and INTENG-19577
Although the two issues are not the same, they are in related area of code and therefore handled in a single fix PR.

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
INTENG-19264
On cold link open, there are two iOS lifecycle events in a very small window of time. Our existing code improperly attempts to reconcile the two events, with a potential loss of link data. The frequency of failure depends on how much time is elapsed between the first and second lifecycle calls, a ~0.15s delay repros about 1/10 on our test app. Shorter and longer delays did not repro the issue.

Initial fix is to no longer attempt to reconcile the two close lifecycle events. This means all clients will see two callbacks on cold link open. The first is for the app initialization which will contain no link data, the second is for link data arrival.

INTENG-19577
Disable tracking resets SDK state and erases data. Our existing code did not queue the reset requests, so repeated rapid calls to this API could cause a hang. SDK reset and erase data requests are now queued.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue) - tracking disabled part of the fix does not impact existing behavior
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - cold link open will callback twice, once for each iOS lifecycle event the SDK receives. We previously tried to merge lifecycle events that arrive rapidly. Clients that ignore payloads with no link data are likely not impacted by the change, but those that take action in all cases may need to update code.
- [x] This change requires a documentation update - we will want to make clients aware that cold link open will now callback on cold link open more frequently

## Testing Instructions
Scheduled testing session

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
