### PR TITLE
The original code used boolValue

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/NSMutableDictionaryBranchTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/NSMutableDictionaryBranchTests.m
@@ -363,12 +363,13 @@
         @"bool2" : @(0),
         @"bool3" : @"1", // valid bool
         @"bool4" : @"0", // valid bool
-        @"bool5" : @"YES", // invalid bool, server expects a number. treated as false
-        @"bool6" : @"NO", // invalid bool, server expects a number. treated as false
+        @"bool5" : @"YES",
+        @"bool6" : @"NO",
         @"bool7" : @(-1), // all non-zero numbers are true
         @"bool8" : @(1234), // all non-zero numbers are true
-        @"bool9" : @[ ] // invalid bool, treated as false
-
+        @"bool9" : @[ ], // invalid bool, treated as false
+        @"bool10": @"true",
+        @"bool11": @"false"
     };
     NSMutableDictionary *dict = [tmp mutableCopy];
     
@@ -376,11 +377,13 @@
     XCTAssertFalse([dict bnc_getBooleanForKey:@"bool2"]);
     XCTAssertTrue([dict bnc_getBooleanForKey:@"bool3"]);
     XCTAssertFalse([dict bnc_getBooleanForKey:@"bool4"]);
-    XCTAssertFalse([dict bnc_getBooleanForKey:@"bool5"]);
+    XCTAssertTrue([dict bnc_getBooleanForKey:@"bool5"]);
     XCTAssertFalse([dict bnc_getBooleanForKey:@"bool6"]);
     XCTAssertTrue([dict bnc_getBooleanForKey:@"bool7"]);
     XCTAssertTrue([dict bnc_getBooleanForKey:@"bool8"]);
     XCTAssertFalse([dict bnc_getBooleanForKey:@"bool9"]);
+    XCTAssertTrue([dict bnc_getBooleanForKey:@"bool10"]);
+    XCTAssertFalse([dict bnc_getBooleanForKey:@"bool11"]);
 }
 
 @end

--- a/Sources/BranchSDK/NSMutableDictionary+Branch.m
+++ b/Sources/BranchSDK/NSMutableDictionary+Branch.m
@@ -192,7 +192,7 @@
         returnValue = [number boolValue];
     } else if ([tmp isKindOfClass:[NSString class]]) {
         NSString *numberAsString = (NSString *)tmp;
-        returnValue = [numberAsString doubleValue];
+        returnValue = [numberAsString boolValue];
     }
     
     return returnValue;


### PR DESCRIPTION
## Reference
SDK-2250

## Summary
Swap unused string check from `doubleValue` to `boolValue`

## Motivation
Be consistent with the code it is intended to replace.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Unit test has been updated. Note this utility code isn't actually used by the SDK. 

cc @BranchMetrics/saas-sdk-devs for visibility.
