### PR TITLE
Fix cocoapods handling of privacy manifests to avoid collision

### DIFF
--- a/BranchSDK.podspec
+++ b/BranchSDK.podspec
@@ -18,7 +18,7 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
 
-  s.resource = "Sources/Resources/PrivacyInfo.xcprivacy"
+  s.resource_bundles = { 'BranchSDK' => 'Sources/Resources/*.xcprivacy' }
   s.ios.source_files = "Sources/BranchSDK/**/*.{h,m}"
 
   s.tvos.source_files = "Sources/BranchSDK/**/*.{h,m}"


### PR DESCRIPTION
## Reference
SDK-2314

## Summary
Fix cocoapods privacy manifest to avoid name collisions with other SDKs and the App.

## Motivation
Bug fix

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Include this branch via cocoapods and generate a privacy manifest. Notice things are properly put into a bundle.

cc @BranchMetrics/saas-sdk-devs for visibility.
