### PR TITLE
SDK-1217 workaround tvOS SPM issue

### DIFF
--- a/Sources/BranchSDK/BNCContentDiscoveryManager.m
+++ b/Sources/BranchSDK/BNCContentDiscoveryManager.m
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Branch Metrics. All rights reserved.
 //
 
+#if !TARGET_OS_TV
+
 #import "BNCContentDiscoveryManager.h"
 #import "Branch.h"
 #import "BranchConstants.h"
@@ -396,3 +398,4 @@ static NSString* const kUTTypeGeneric = @"public.content";
 }
 
 @end
+#endif

--- a/Sources/BranchSDK/BNCSpotlightService.m
+++ b/Sources/BranchSDK/BNCSpotlightService.m
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
+#if !TARGET_OS_TV
+
 #import "BNCSpotlightService.h"
 #import "Branch.h"
 #import "BNCSystemObserver.h"
@@ -487,3 +489,4 @@ static NSString* const kDomainIdentifier = @"io.branch.sdk.spotlight";
     #undef IndexingNotAvalable
 }
 @end
+#endif

--- a/Sources/BranchSDK/BNCUserAgentCollector.m
+++ b/Sources/BranchSDK/BNCUserAgentCollector.m
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Branch, Inc. All rights reserved.
 //
 
+#if !TARGET_OS_TV
 #import "BNCUserAgentCollector.h"
 #import "BNCPreferenceHelper.h"
 #import "BNCDeviceSystem.h"
@@ -108,3 +109,4 @@
 }
 
 @end
+#endif

--- a/Sources/BranchSDK/BranchActivityItemProvider.m
+++ b/Sources/BranchSDK/BranchActivityItemProvider.m
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Branch Metrics. All rights reserved.
 //
 
+#if !TARGET_OS_TV
+
 #import "BranchActivityItemProvider.h"
 #import "Branch.h"
 #import "BranchConstants.h"
@@ -255,3 +257,4 @@
 }
 
 @end
+#endif

--- a/Sources/BranchSDK/BranchCSSearchableItemAttributeSet.m
+++ b/Sources/BranchSDK/BranchCSSearchableItemAttributeSet.m
@@ -5,6 +5,7 @@
 //  Created by Derrick Staten on 9/8/15.
 //  Copyright © 2015 Branch Metrics. All rights reserved.
 //
+#if !TARGET_OS_TV
 
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "NSError+Branch.h"
@@ -157,3 +158,4 @@
 }
 
 @end
+#endif

--- a/Sources/BranchSDK/BranchPasteControl.m
+++ b/Sources/BranchSDK/BranchPasteControl.m
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Branch, Inc. All rights reserved.
 //
 
+#if !TARGET_OS_TV
 #import "BranchPasteControl.h"
 #import "Branch.h"
 
@@ -50,3 +51,4 @@
 }
 
 @end
+#endif

--- a/Sources/BranchSDK/BranchShareLink.m
+++ b/Sources/BranchSDK/BranchShareLink.m
@@ -5,6 +5,7 @@
 //  Created by Edward Smith on 3/13/17.
 //  Copyright © 2017 Branch Metrics. All rights reserved.
 //
+#if !TARGET_OS_TV
 
 #import "BranchShareLink.h"
 #import "BranchConstants.h"
@@ -330,3 +331,4 @@ typedef NS_ENUM(NSInteger, BranchShareActivityItemType) {
 }
 
 @end
+#endif

--- a/Sources/BranchSDK/Private/BNCContentDiscoveryManager.h
+++ b/Sources/BranchSDK/Private/BNCContentDiscoveryManager.h
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Branch Metrics. All rights reserved.
 //
 
+#if !TARGET_OS_TV
+
 #if __has_feature(modules)
 @import Foundation;
 #else
@@ -60,3 +62,4 @@
             spotlightCallback:(callbackWithUrlAndSpotlightIdentifier)spotlightCallback;
 
 @end
+#endif

--- a/Sources/BranchSDK/Private/BNCSpotlightService.h
+++ b/Sources/BranchSDK/Private/BNCSpotlightService.h
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
+#if !TARGET_OS_TV
+
 #if __has_feature(modules)
 @import Foundation;
 #else
@@ -36,3 +38,4 @@
 
 - (void)removeAllBranchSearchableItemsWithCallback:(void (^_Nullable)(NSError * _Nullable error))completion;
 @end
+#endif

--- a/Sources/BranchSDK/Private/BNCUserAgentCollector.h
+++ b/Sources/BranchSDK/Private/BNCUserAgentCollector.h
@@ -8,6 +8,7 @@
 //  Copyright © 2019 Branch, Inc. All rights reserved.
 //
 
+#if !TARGET_OS_TV
 #if __has_feature(modules)
 @import Foundation;
 #else
@@ -28,3 +29,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/Sources/BranchSDK/Public/BranchActivityItemProvider.h
+++ b/Sources/BranchSDK/Public/BranchActivityItemProvider.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Branch Metrics. All rights reserved.
 //
 
+#if !TARGET_OS_TV
+
 #if __has_feature(modules)
 @import Foundation;
 @import UIKit;
@@ -40,3 +42,4 @@
 
 + (NSString *)humanReadableChannelWithActivityType:(NSString *)activityString;
 @end
+#endif

--- a/Sources/BranchSDK/Public/BranchCSSearchableItemAttributeSet.h
+++ b/Sources/BranchSDK/Public/BranchCSSearchableItemAttributeSet.h
@@ -5,6 +5,7 @@
 //  Created by Derrick Staten on 9/8/15.
 //  Copyright © 2015 Branch Metrics. All rights reserved.
 //
+#if !TARGET_OS_TV
 
 #if __has_feature(modules)
 @import Foundation;
@@ -39,3 +40,4 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/Sources/BranchSDK/Public/BranchPasteControl.h
+++ b/Sources/BranchSDK/Public/BranchPasteControl.h
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Branch, Inc. All rights reserved.
 //
 
+#if !TARGET_OS_TV
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -20,3 +21,4 @@ API_AVAILABLE(ios(16.0), macCatalyst(16.0))
 
 @end
 NS_ASSUME_NONNULL_END
+#endif

--- a/Sources/BranchSDK/Public/BranchShareLink.h
+++ b/Sources/BranchSDK/Public/BranchShareLink.h
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
+#if !TARGET_OS_TV
+
 #import "BranchUniversalObject.h"
 #import <LinkPresentation/LinkPresentation.h>
 @class BranchShareLink;
@@ -137,3 +139,4 @@ Creates and attaches an LPLinkMetadata using the provided title and icon. This m
 - (void) addLPLinkMetadata:(NSString *_Nullable)title icon:(UIImage *_Nullable)icon API_AVAILABLE(ios(13.0), macCatalyst(13.1));
 
 @end
+#endif


### PR DESCRIPTION
## Reference
SDK-1217 workaround tvOS SPM issue

## Summary
Added preprocessor guards on all files that are not valid on tvOS. With other integration methods we can conditionally exclude these files, but it seems SPM does not allow this.

## Motivation
Allow tvOS builds using SPM.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Integrate Branch SDK into a tvOS app using SPM.
App should build properly.

cc @BranchMetrics/saas-sdk-devs for visibility.
