### PR TITLE
SDK-2372 prep iOS 3.4.2 release 

### DIFF
--- a/BranchSDK.podspec
+++ b/BranchSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "BranchSDK"
-  s.version          = "3.4.1"
+  s.version          = "3.4.2"
   s.summary          = "Create an HTTP URL for any piece of content in your app"
   s.description      = <<-DESC
 - Want the highest possible conversions on your sharing feature?

--- a/BranchSDK.xcodeproj/project.pbxproj
+++ b/BranchSDK.xcodeproj/project.pbxproj
@@ -1974,7 +1974,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.1;
+				MARKETING_VERSION = 3.4.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2009,7 +2009,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.1;
+				MARKETING_VERSION = 3.4.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2215,7 +2215,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 3.4.1;
+				MARKETING_VERSION = 3.4.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2254,7 +2254,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 3.4.1;
+				MARKETING_VERSION = 3.4.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2291,7 +2291,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.1;
+				MARKETING_VERSION = 3.4.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2326,7 +2326,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.4.1;
+				MARKETING_VERSION = 3.4.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 Branch iOS SDK Change Log
 
+v.3.4.2
+- Fix tvOS when using SPM or source builds
+
 v.3.4.1
 - Fix cold link launch when using deferred initialization and an AppDelegate only app.
 - Fix cocoapods privacy manifest collision.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 Branch iOS SDK Change Log
 
 v.3.4.2
-- Fix tvOS when using SPM or source builds
+- Fix tvOS when using SPM
 
 v.3.4.1
 - Fix cold link launch when using deferred initialization and an AppDelegate only app.

--- a/Sources/BranchSDK/BNCConfig.m
+++ b/Sources/BranchSDK/BNCConfig.m
@@ -8,7 +8,7 @@
 
 #include "BNCConfig.h"
 
-NSString * const BNC_SDK_VERSION  = @"3.4.1";
+NSString * const BNC_SDK_VERSION  = @"3.4.2";
 NSString * const BNC_LINK_URL = @"https://bnc.lt";
 NSString * const BNC_CDN_URL = @"https://cdn.branch.io";
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -30,7 +30,7 @@ Options:
 USAGE
 }
 
-version=3.4.1
+version=3.4.2
 prev_version="$version"
 
 if (( $# == 0 )); then


### PR DESCRIPTION
## Reference
SDK-2372

## Summary
Fix for tvOS builds when using SPM

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
SDK builds when tvOS apps are integrated via SPM

cc @BranchMetrics/saas-sdk-devs for visibility.
