### PR TITLE
Static Framework Missing IDFA Fix 

### DIFF
--- a/BranchSDK.xcodeproj/project.pbxproj
+++ b/BranchSDK.xcodeproj/project.pbxproj
@@ -1526,7 +1526,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nScripts/build_static_xcframework.sh\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nScripts/build_static_xcframework_noidfa.sh\n";
 		};
 		5FF9DEFA28EE805C00D62DE1 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1544,7 +1544,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nScripts/build_static_xcframework_noidfa.sh\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nScripts/build_static_xcframework.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Reference
SDK-2408 --  Investigate loss of AdSupport for Spotify
https://branch.atlassian.net/browse/SDK-2408

## Summary
Fixed script names in "Run Script" phase of targets static-xcframework and  static-xcframework-noidfa.

## Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

**IDFA Support**

Generate a static framework by running script. - 
           /scripts/prep_static_xcframework.sh
This will generate a static framework with IDFA support.

Link this framework to a test app with ATTrackingmanager support ( https://help.branch.io/developers-hub/docs/ios-advanced-features#include-apples-attrackingmanager).

Build and Run App. Check logs if idfa is present in requests -
```
  "hardware_id" : "XXXXXXXXXXXX",
  "hardware_id_type" : "idfa",
```

**IDFA Excluded**

Generate a static framework by running script. - 
./scripts/prep_static_xcframework_noidfa.sh

This will generate a static framework without IDFA support (Macro **BRANCH_EXCLUDE_IDFA_CODE** is enabled )

Link this framework to a test app with ATTrackingmanager support ( https://help.branch.io/developers-hub/docs/ios-advanced-features#include-apples-attrackingmanager).

Build and Run App. Check logs if idfa is NOT present in requests -
```
  "hardware_id" : "XXXXXXXXXXXX",
  "hardware_id_type" : "vendor_id",
```

Also, logs print following message 
`[BranchSDK][Debug][BNCDeviceInfo checkAdvertisingIdentifier] BRANCH_EXCLUDE_IDFA_CODE flag enabled. IDFA is not available
`

I am also attaching here static framework (with IDFA enabled) for testing.
[Branch_static.zip](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/files/15506156/Branch_static.zip)


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
