### PR TITLE
Double Purchase Event with ApplePay Fix

### DIFF
--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -1768,7 +1768,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
             }
         });
 
-        [self.requestQueue dequeue];
+        [self.requestQueue remove:req];
         self.networkCount = 0;
         dispatch_async(self.isolationQueue, ^{
             [self processNextQueueItem];


### PR DESCRIPTION
## Reference
INTENG-20410 - [Multiple] Purchase event being triggered twice in iOS
https://branch.atlassian.net/browse/INTENG-20410

## Summary

In Event queue, `dequeue` function is replaced with `- (void)remove:(BNCServerRequest *)request` function. 
This fix will, instead of removing first event in the queue, will remove current event from the queue.

## Detailed Description 

When In-App-Purchase sheet or Apple Pay sheet appears branch goes to inactive state. After payment is done, `logEvent` API is called inside the Apple/Stripe payment API callback. And then sheet is closed and app comes back to active state again. This creates two events -

	* Standard Purchase Event
	* Open Event
	
Following is order of events happened inside SDK:

* Standard Purchase Event Inserted in Queue and processing of Next Event in Queue is triggered by calling function `processNextQueueItem` 
* Open Event Created and inserted in beginning of Queue and processing of Next Event in Queue is triggered again by calling function `processNextQueueItem`. (Note: Branch Open/Install events are inserted in begining og queue)
* At the same time, Purchase Event Processing finishes and request is made to  remove it from Queue. For removing `dequeue` function is called which removes the first Event in Queue. So instead of removing PurchaseEvent, OpenEvent is removed.

 Queue State(s)
       PurchaseEvent (Waiting)                                                             
       PurchaseEvent (In Processing)  —> OpenEvent (Waiting)         
       PurchaseEvent (Finished)  —> OpenEvent (Waiting)                 
       PurchaseEvent (Finished)                             
       PurchaseEvent (In Processing) 

Fix: Instead of removing first event in the queue, current event (whose processing finished) should be removed.

## Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

Use following sample app for testing. 
https://github.com/BranchMetrics/InAppPurchaseAPITest

This app uses sandbox envirnoment for testing.
    - Steps for creating sandbox test user account - https://developer.apple.com/help/app-store-connect/test-in-app-purchases/create-sandbox-apple-ids.
    - Use above account for purchase.

Validate Following :

After you close Apple Pay Purchase Sheet, 

**Without Fix**
        --> You you will see double purchase events in logs and No open event.
**With Fix**
        --> You you will see one purchase event and one open event in logs.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
