### PR TITLE
fix: update metadata type to string

### DIFF
--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -491,7 +491,7 @@ static NSString *bnc_branchKey = nil;
 }
 
 
-- (void)setRequestMetadataKey:(NSString *)key value:(NSObject *)value {
+- (void)setRequestMetadataKey:(NSString *)key value:(NSString *)value {
     [self.preferenceHelper setRequestMetadataKey:key value:value];
 }
 

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -764,9 +764,9 @@ Sets a custom base URL for all calls to the Branch API.
  Key-value pairs to be included in the metadata on every request.
 
  @param key String to be included in request metadata
- @param value Object to be included in request metadata
+ @param value Value to be included in request metadata
  */
-- (void)setRequestMetadataKey:(NSString *)key value:(nullable id)value;
+- (void)setRequestMetadataKey:(NSString *)key value:(nullable NSString *)value;
 
 /**
  Disables the Branch SDK from tracking the user. This is useful for GDPR privacy compliance.


### PR DESCRIPTION
## Reference

No JIRA ticket, based on Slack discussions

## Summary

The `setRequestMetadataKey` function used to accept any object in the value parameter. The function is now modified to take in only a string or nil as Branch APIs cannot process non-string values for metadata.

## Motivation

The SDK exposes the `setRequestMetadataKey` function to allow developers to send in any value that can be attached with all event metadata. This includes IDs, custom parameters etc. 

As of today, the function takes in a string key with any value (string/bool/object/integer) without any errors. However, on passing a non-string value for metadata, one can observe that all Branch APIs start failing with a 400 error, citing invalid JSON. This is because the Branch APIs are designed to take in only string values for metadata. This can lead to confusion and difficulty in debugging the issue because it is not immediately apparent that the issue is caused because of a non-string metadata value.

This PR aims to eliminate this confusion by updating the signature of the `setRequestMetadataKey` function to accept only string or nil values (nil is accepted so that the value can be unset).

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->

On a sample project, use this version of the SDK and try to set a value for metadata that is not null and not a string. The function will throw an error.

When trying the same experiment with an older version of the SDK, there is no compile time error but Branch SDK API calls constantly fail at run-time with a 400 "Invalid JSON" error.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
