### PR TITLE
[SDK-2470] Created branchVPNBlockingError method

### DIFF
--- a/Sources/BranchSDK/BNCServerInterface.m
+++ b/Sources/BranchSDK/BNCServerInterface.m
@@ -124,6 +124,8 @@
                 if (status != 200) {
                     if ([NSError branchDNSBlockingError:underlyingError]) {
                         [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"Possible DNS Ad Blocker. Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
+                    } else if ([NSError branchVPNBlockingError:underlyingError]) {
+                        [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"Possible VPN Ad Blocker. Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
                     } else {
                         [[BranchLogger shared] logWarning: [NSString stringWithFormat:@"Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
                     }

--- a/Sources/BranchSDK/BNCURLFilter.m
+++ b/Sources/BranchSDK/BNCURLFilter.m
@@ -133,6 +133,8 @@
     } else if (statusCode != 200 || error != nil || jsonString == nil) {
         if ([NSError branchDNSBlockingError:error]) {
             [[BranchLogger shared] logWarning:@"Possible DNS Ad Blocker" error:error];
+        } else if ([NSError branchVPNBlockingError:error]) {
+            [[BranchLogger shared] logWarning:@"Possible VPN Ad Blocker" error:error];
         } else {
             [[BranchLogger shared] logWarning:@"Failed to update URL ignore list" error:operation.error];
         }

--- a/Sources/BranchSDK/BranchQRCode.m
+++ b/Sources/BranchSDK/BranchQRCode.m
@@ -145,6 +145,8 @@
         if (error) {
             if ([NSError branchDNSBlockingError:error]) {
                 [[BranchLogger shared] logWarning:@"Possible DNS Ad Blocker" error:error];
+            } else if ([NSError branchVPNBlockingError:error]) {
+                [[BranchLogger shared] logWarning:@"Possible VPN Ad Blocker" error:error];
             } else {
                 [[BranchLogger shared] logError:@"QR Code request failed" error:error];
                 completion(nil, error);

--- a/Sources/BranchSDK/NSError+Branch.m
+++ b/Sources/BranchSDK/NSError+Branch.m
@@ -120,6 +120,14 @@ __attribute__((constructor)) void BNCForceNSErrorCategoryToLoad(void) {
         NSError *underlyingError = error.userInfo[@"NSUnderlyingError"];
         if (underlyingError) {
 
+            /**
+             `Domain=kCFErrorDomainCFNetwork Code=-1004` indicates that the connection failed because a connection can't be made to the host.
+             Reference: https://developer.apple.com/documentation/cfnetwork/cfnetworkerrors/kcfurlerrorcannotconnecttohost?language=objc
+             
+             `_kCFStreamErrorCodeKey=61` indicates that the connection was refused.
+             Reference: https://opensource.apple.com/source/xnu/xnu-792/bsd/sys/errno.h.auto.html
+             */
+            
             BOOL isCouldntConnectErrorCode = [@(-1004) isEqual:@(underlyingError.code)];
             BOOL isLocalHostErrorKey = [@(61) isEqual:error.userInfo[@"_kCFStreamErrorCodeKey"]];
             
@@ -131,6 +139,10 @@ __attribute__((constructor)) void BNCForceNSErrorCategoryToLoad(void) {
     return NO;
 }
 
+/**
+ Helper method to which checks the device's internet proxy settings for common VPN protocol and interface substrings to determine if a VPN enabled.
+ https://developer.apple.com/documentation/cfnetwork/cfnetworkcopysystemproxysettings()
+ */
 + (BOOL)isConnectedToVPN {
     NSDictionary *proxySettings = (__bridge NSDictionary *)(CFNetworkCopySystemProxySettings());
     if (proxySettings) {

--- a/Sources/BranchSDK/Private/NSError+Branch.h
+++ b/Sources/BranchSDK/Private/NSError+Branch.h
@@ -46,6 +46,9 @@ typedef NS_ENUM(NSInteger, BNCErrorCode) {
 // Checks if an NSError looks like a DNS blocking error
 + (BOOL)branchDNSBlockingError:(NSError *)error;
 
+// Checks if an NSError looks like a VPN blocking error
++ (BOOL)branchVPNBlockingError:(NSError *)error;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Reference
SDK-2470 -- Create new method for detecting VPN Ad blocker

## Summary
Added `branchVPNBlockingError` to detect when a device is connected to a VPN and requests are failing with a specific error code.

Error Code Docs: https://developer.apple.com/documentation/cfnetwork/cfnetworkerrors/kcfurlerrorcannotconnecttohost?language=objc
CFNetworkingCopySystemProxySettings Docs:
https://developer.apple.com/documentation/cfnetwork/cfnetworkcopysystemproxysettings()

## Motivation
We want to provide more information in error logs to help clients with debugging regarding Branch.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Enable a VPN Ad Blocker and observe if requests are failing and returning the proper error logs.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
