### PR TITLE
Updated ad blocker log warnings to errors

### DIFF
--- a/Sources/BranchSDK/BNCServerInterface.m
+++ b/Sources/BranchSDK/BNCServerInterface.m
@@ -125,9 +125,9 @@
             } else {
                 if (status != 200) {
                     if ([NSError branchDNSBlockingError:underlyingError]) {
-                        [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"Possible DNS Ad Blocker. Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
+                        [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible DNS Ad Blocker. Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
                     } else if ([NSError branchVPNBlockingError:underlyingError]) {
-                        [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"Possible VPN Ad Blocker. Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
+                        [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible VPN Ad Blocker. Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
                     } else {
                         [[BranchLogger shared] logWarning: [NSString stringWithFormat:@"Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
                     }

--- a/Sources/BranchSDK/BNCServerInterface.m
+++ b/Sources/BranchSDK/BNCServerInterface.m
@@ -125,9 +125,11 @@
             } else {
                 if (status != 200) {
                     if ([NSError branchDNSBlockingError:underlyingError]) {
-                        [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible DNS Ad Blocker. Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
+                        NSError *error = [NSError branchErrorWithCode:BNCDNSAdBlockerError];
+                        [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible DNS Ad Blocker. Giving up on request with HTTP status code %ld. Underlying error: %@", (long)status, underlyingError] error:error];
                     } else if ([NSError branchVPNBlockingError:underlyingError]) {
-                        [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible VPN Ad Blocker. Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
+                        NSError *error = [NSError branchErrorWithCode:BNCVPNAdBlockerError];
+                        [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible VPN Ad Blocker. Giving up on request with HTTP status code %ld. Underlying error: %@", (long)status, underlyingError] error:error];
                     } else {
                         [[BranchLogger shared] logWarning: [NSString stringWithFormat:@"Giving up on request with HTTP status code %ld", (long)status] error:underlyingError];
                     }

--- a/Sources/BranchSDK/BNCURLFilter.m
+++ b/Sources/BranchSDK/BNCURLFilter.m
@@ -130,11 +130,13 @@
     if (statusCode == 404) {
         [[BranchLogger shared] logDebug:@"No update for URL ignore list found." error:nil];
         return NO;
-    } else if (statusCode != 200 || error != nil || jsonString == nil) {
+    } else if (statusCode != 200 || error != nil || jsonString == nil) {   
         if ([NSError branchDNSBlockingError:error]) {
-            [[BranchLogger shared] logWarning:@"Possible DNS Ad Blocker" error:error];
+            NSError *dnsError = [NSError branchErrorWithCode:BNCDNSAdBlockerError];
+            [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible DNS Ad Blocker. Giving up on request with HTTP status code %ld. Underlying error: %@", (long)statusCode, error] error:dnsError];
         } else if ([NSError branchVPNBlockingError:error]) {
-            [[BranchLogger shared] logWarning:@"Possible VPN Ad Blocker" error:error];
+            NSError *vpnError = [NSError branchErrorWithCode:BNCVPNAdBlockerError];
+            [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible VPN Ad Blocker. Giving up on request with HTTP status code %ld. Underlying error: %@", (long)statusCode, error] error:vpnError];
         } else {
             [[BranchLogger shared] logWarning:@"Failed to update URL ignore list" error:operation.error];
         }

--- a/Sources/BranchSDK/BranchQRCode.m
+++ b/Sources/BranchSDK/BranchQRCode.m
@@ -144,9 +144,11 @@
         
         if (error) {
             if ([NSError branchDNSBlockingError:error]) {
-                [[BranchLogger shared] logWarning:@"Possible DNS Ad Blocker" error:error];
+                NSError *dnsError = [NSError branchErrorWithCode:BNCDNSAdBlockerError];
+                [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible DNS Ad Blocker. Giving up on QR code request. Underlying error: %@", error] error:dnsError];
             } else if ([NSError branchVPNBlockingError:error]) {
-                [[BranchLogger shared] logWarning:@"Possible VPN Ad Blocker" error:error];
+                NSError *vpnError = [NSError branchErrorWithCode:BNCVPNAdBlockerError];
+                [[BranchLogger shared] logError:[NSString stringWithFormat:@"Possible VPN Ad Blocker. Giving up on QR code request. Underlying error: %@", error] error:vpnError];
             } else {
                 [[BranchLogger shared] logError:@"QR Code request failed" error:error];
                 completion(nil, error);

--- a/Sources/BranchSDK/NSError+Branch.m
+++ b/Sources/BranchSDK/NSError+Branch.m
@@ -40,6 +40,8 @@ __attribute__((constructor)) void BNCForceNSErrorCategoryToLoad(void) {
         [messages setObject:@"The Spotlight identifier is required to remove indexing from spotlight." forKey:@(BNCSpotlightIdentifierError)];
         [messages setObject:@"Spotlight cannot remove publicly indexed content." forKey:@(BNCSpotlightPublicIndexError)];
         [messages setObject:@"User tracking is disabled and the request is not allowed" forKey:@(BNCTrackingDisabledError)];
+        [messages setObject:@"Possible DNS Ad Blocker. Giving up on request." forKey:@(BNCDNSAdBlockerError)];
+        [messages setObject:@"Possible VPN Ad Blocker. Giving up on request." forKey:@(BNCVPNAdBlockerError)];
     });
     
     NSString *errorMessage = [messages objectForKey:@(code)];

--- a/Sources/BranchSDK/Private/NSError+Branch.h
+++ b/Sources/BranchSDK/Private/NSError+Branch.h
@@ -32,6 +32,8 @@ typedef NS_ENUM(NSInteger, BNCErrorCode) {
     BNCSpotlightPublicIndexError    = 1014,
     BNCTrackingDisabledError        = 1015,
     BNCGeneralError                 = 1016, // General Branch SDK Error
+    BNCDNSAdBlockerError                 = 1017,
+    BNCVPNAdBlockerError                 = 1018,
     BNCHighestError
 };
 


### PR DESCRIPTION
## Summary
Updated the "Possible VPN/DNS Ad Blocker" logs from warnings to errors by changing the `BranchLogger` method used form `logWarning` to `logError`.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
So clients can better identify these logs.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Use an ad blocker and confirm the logs appear as error logs instead of warnings now.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
