### PR TITLE
[SDK-2475] Fix for BNCURLFilter's regex being set as external_intent_uri

### DIFF
--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -100,12 +100,8 @@
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
-    // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
     if (urlString) {
-        NSURL *url = [NSURL URLWithString:urlString];
-        if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
-            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
-        }
+        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
     }
     
     [self addAppleAttributionTokenToJSON:json];
@@ -152,12 +148,8 @@
     [self addTimestampsToJSON:json];
     
     
-    // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
     if (urlString) {
-        NSURL *url = [NSURL URLWithString:urlString];
-        if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
-            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
-        }
+        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
     }
     
     // Usually sent with install, but retry on open if it didn't get sent

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -147,7 +147,6 @@
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
-    
     if (urlString) {
         [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
     }

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -100,8 +100,12 @@
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
+    // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
     if (urlString) {
-        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        NSURL *url = [NSURL URLWithString:urlString];
+        if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
+            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        }
     }
     
     [self addAppleAttributionTokenToJSON:json];
@@ -147,8 +151,13 @@
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
+    
+    // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
     if (urlString) {
-        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        NSURL *url = [NSURL URLWithString:urlString];
+        if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
+            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        }
     }
     
     // Usually sent with install, but retry on open if it didn't get sent

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -690,8 +690,10 @@ static NSString *bnc_branchKey = nil;
     }
     if (pattern) {
         self.preferenceHelper.dropURLOpen = YES;
-        self.preferenceHelper.externalIntentURI = pattern;
-        self.preferenceHelper.referringURL = pattern;
+        
+        NSString *urlString = [url absoluteString];
+        self.preferenceHelper.externalIntentURI = urlString;
+        self.preferenceHelper.referringURL = urlString;
 
         [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil];
         return NO;


### PR DESCRIPTION
## Reference
SDK-2475 -- Fix bug where URL filter regex is being sent as external_intent_uri

## Summary
We have been seeing requests where the external_intent_uri is one of the values in our URL filter pattern likes, like `"^fb\\d+:((?!campaign_ids).)*$"`. This appears to be due to a typo in the `handleDeepLink` function where if the link which opened the app matches the pattern, we set it as the `externalIntentURI` and `referringURL`. Changing this to set these fields to the actual URI seems to fix this issue and sends the proper requests.

**Branch.m**
```
   pattern = [self.urlFilter patternMatchingURL:url];
    if (!pattern) {
        pattern = [self.userURLFilter patternMatchingURL:url];
    }
    if (pattern) {
        self.preferenceHelper.dropURLOpen = YES;

        //Problematic Lines
        self.preferenceHelper.externalIntentURI = pattern;
        self.preferenceHelper.referringURL = pattern;
        //

        [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil];
        return NO;
    }
```

## Motivation
To fix the bug and correctly set the `external_intent_uri` in requests.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Add any URI scheme that matches the regex to your app and then open your app via that link. Observe the request's `external_intent_uri` before and after the change.

**Possible URI schemes:**
Facebook: fb1234://some_path
LinkedIn: li5678://profile
Pinterest: pdk91011://board
TwitterKit: twitterkit-xyz123://timeline
Google OAuth: com.googleusercontent.apps.1234567890-abcdef:/oauth
Sensitive Info, Non-HTTP/HTTPS: customscheme://login?oauth_token=abcdef123456
Sensitive Info, HTTP/HTTPS: https://example.com/resource?access_token=abcdef123456

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
