### PR TITLE
[SDK-2474] Fix for sending URI scheme as universal_link_url

### DIFF
--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -105,6 +105,8 @@
         NSURL *url = [NSURL URLWithString:urlString];
         if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
             [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        } else {
+            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
         }
     }
     
@@ -157,6 +159,8 @@
         NSURL *url = [NSURL URLWithString:urlString];
         if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
             [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        } else {
+            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
         }
     }
     

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -100,8 +100,12 @@
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
+    // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
     if (urlString) {
-        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        NSURL *url = [NSURL URLWithString:urlString];
+        if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
+            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        }
     }
     
     [self addAppleAttributionTokenToJSON:json];
@@ -147,8 +151,13 @@
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
+    
+    // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
     if (urlString) {
-        [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        NSURL *url = [NSURL URLWithString:urlString];
+        if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
+            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+        }
     }
     
     // Usually sent with install, but retry on open if it didn't get sent

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -690,8 +690,10 @@ static NSString *bnc_branchKey = nil;
     }
     if (pattern) {
         self.preferenceHelper.dropURLOpen = YES;
-        self.preferenceHelper.externalIntentURI = pattern;
-        self.preferenceHelper.referringURL = pattern;
+        
+        NSString *urlString = [url absoluteString];
+        self.preferenceHelper.externalIntentURI = urlString;
+        self.preferenceHelper.referringURL = urlString;
 
         [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil];
         return NO;

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -690,10 +690,8 @@ static NSString *bnc_branchKey = nil;
     }
     if (pattern) {
         self.preferenceHelper.dropURLOpen = YES;
-        
-        NSString *urlString = [url absoluteString];
-        self.preferenceHelper.externalIntentURI = urlString;
-        self.preferenceHelper.referringURL = urlString;
+        self.preferenceHelper.externalIntentURI = pattern;
+        self.preferenceHelper.referringURL = pattern;
 
         [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil];
         return NO;


### PR DESCRIPTION
## Reference
SDK-2474 -- Fix for sending URI schemes as universal_link_urls

## Summary
When the app was opened via URI scheme, the SDK was incorrectly setting the `universal_link_url` as that URI. This is because the URI would be passed into the request factory and there wasn't a check for if it was actually a universal link instead of a URI. This would lead to requests incorrectly having `external_intent_uri` and `universal_link_url` be the same value.
This change adds a check for if `urlString` contains http or https to confirm its a universal link.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To avoid having `universal_link_url` wrongly set to a URI.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Open your app via a uri scheme (e.g. branchtest://) before and after the change and observe the `external_intent_uri` and `universal_link_url` fields in the requests to make sure they look correct.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
