### PR TITLE
Universal ink cold launch fix

### DIFF
--- a/Sources/BranchSDK/BNCServerRequestQueue.m
+++ b/Sources/BranchSDK/BNCServerRequestQueue.m
@@ -386,7 +386,7 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
     static dispatch_once_t onceToken = 0;
     dispatch_once(&onceToken, ^ {
         sharedQueue = [[BNCServerRequestQueue alloc] init];
-        [sharedQueue retrieve];
+        //[sharedQueue retrieve];
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Retrieved from storage: %@.", sharedQueue] error:nil];
     });
     return sharedQueue;

--- a/Sources/BranchSDK/BNCServerRequestQueue.m
+++ b/Sources/BranchSDK/BNCServerRequestQueue.m
@@ -42,6 +42,7 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
 
     self.queue = [NSMutableArray<BNCServerRequest *> new];
     self.asyncQueue = dispatch_queue_create("io.branch.persist_queue", DISPATCH_QUEUE_SERIAL);
+    self.processArchivedOpens = YES;
     return self;
 }
 

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -526,7 +526,7 @@ static NSString *bnc_branchKey = nil;
             // Set the flag:
             [BNCPreferenceHelper sharedInstance].trackingDisabled = NO;
             // Initialize a Branch session:
-            [Branch.getInstance initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil];
+            [Branch.getInstance initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:NO];
         }
     }
 }
@@ -642,7 +642,7 @@ static NSString *bnc_branchKey = nil;
     }
     #endif
 
-    [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:pushURL];
+    [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:pushURL reset:NO];
 }
 
 - (void)setDeepLinkDebugMode:(NSDictionary *)debugParams {
@@ -693,7 +693,7 @@ static NSString *bnc_branchKey = nil;
         self.preferenceHelper.externalIntentURI = pattern;
         self.preferenceHelper.referringURL = pattern;
 
-        [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil];
+        [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil reset:YES];
         return NO;
     }
 
@@ -741,7 +741,7 @@ static NSString *bnc_branchKey = nil;
             self.preferenceHelper.linkClickIdentifier = params[@"link_click_id"];
         }
     }
-    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:url.absoluteString];
+    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:url.absoluteString reset:YES];
     return handled;
 }
 
@@ -775,7 +775,7 @@ static NSString *bnc_branchKey = nil;
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Set universalLinkUrl and referringURL to %@", urlString] error:nil];
     }
 
-    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString];
+    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
 
     return [Branch isBranchLink:urlString];
 }
@@ -815,7 +815,7 @@ static NSString *bnc_branchKey = nil;
     }
     #endif
 
-    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:userActivity.webpageURL.absoluteString];
+    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:userActivity.webpageURL.absoluteString reset:YES];
 
     return spotlightIdentifier != nil;
 }
@@ -1716,7 +1716,7 @@ static NSString *bnc_branchKey = nil;
         if (!Branch.trackingDisabled && self.initializationStatus != BNCInitStatusInitialized && !installOrOpenInQueue) {
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue] error:nil];
 
-            [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:nil];
+            [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:nil reset:NO];
         }
     });
 }
@@ -1889,6 +1889,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
             if ( !(((BNCServerRequestQueue*)[BNCServerRequestQueue getInstance]).processArchivedOpens)
                 && [req isKindOfClass:[BranchOpenRequest class]]
                 && ((BranchOpenRequest *)req).isFromArchivedQueue){
+                [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Removed Archived Open Request from Queue  %@", [req description]] error:nil];
                 [self.requestQueue remove:req];
                 self.networkCount = 0;
                 [self processNextQueueItem];
@@ -1954,11 +1955,11 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 - (void)initSafetyCheck {
     if (self.initializationStatus == BNCInitStatusUninitialized) {
         [[BranchLogger shared] logDebug:@"Branch avoided an error by preemptively initializing." error:nil];
-        [self initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil];
+        [self initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:NO];
     }
 }
 
-- (void)initUserSessionAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier urlString:(NSString *)urlString {
+- (void)initUserSessionAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier urlString:(NSString *)urlString reset:(BOOL)reset {
     
     @synchronized (self) {
         if (self.deferInitForPluginRuntime) {
@@ -1980,8 +1981,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     
     dispatch_async(self.isolationQueue, ^(){
 
+        
         // If the session is not yet initialized
-        if (self.initializationStatus == BNCInitStatusUninitialized) {
+        if ( reset || self.initializationStatus == BNCInitStatusUninitialized) {
             [self initializeSessionAndCallCallback:callCallback sceneIdentifier:sceneIdentifier urlString:urlString];
         }
         // If the session was initialized, but callCallback was specified, do so.

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -1982,7 +1982,8 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     dispatch_async(self.isolationQueue, ^(){
 
         
-        // If the session is not yet initialized
+        // If the session is not yet initialized  OR
+        // If the session is already initialized or is initializing but we need to reset it.
         if ( reset || self.initializationStatus == BNCInitStatusUninitialized) {
             [self initializeSessionAndCallCallback:callCallback sceneIdentifier:sceneIdentifier urlString:urlString];
         }

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -1885,6 +1885,15 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
                     return;
                 }
             }
+            
+            if ( !(((BNCServerRequestQueue*)[BNCServerRequestQueue getInstance]).processArchivedOpens)
+                && [req isKindOfClass:[BranchOpenRequest class]]
+                && ((BranchOpenRequest *)req).isFromArchivedQueue){
+                [self.requestQueue remove:req];
+                self.networkCount = 0;
+                [self processNextQueueItem];
+                return;
+            }
 
             dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
             dispatch_async(queue, ^ {

--- a/Sources/BranchSDK/BranchLogger.m
+++ b/Sources/BranchSDK/BranchLogger.m
@@ -42,7 +42,7 @@
 }
 
 - (BOOL)shouldLog:(BranchLogLevel)level {
-    if (!self.loggingEnabled || level <= self.logLevelThreshold) {
+    if (!self.loggingEnabled || level < self.logLevelThreshold) {
         return NO;
     }
     return YES;

--- a/Sources/BranchSDK/BranchLogger.m
+++ b/Sources/BranchSDK/BranchLogger.m
@@ -42,7 +42,7 @@
 }
 
 - (BOOL)shouldLog:(BranchLogLevel)level {
-    if (!self.loggingEnabled || level < self.logLevelThreshold) {
+    if (!self.loggingEnabled || level <= self.logLevelThreshold) {
         return NO;
     }
     return YES;

--- a/Sources/BranchSDK/BranchOpenRequest.m
+++ b/Sources/BranchSDK/BranchOpenRequest.m
@@ -40,6 +40,7 @@
     if ((self = [super init])) {
         _callback = callback;
         _isInstall = isInstall;
+        _isFromArchivedQueue = NO;
     }
 
     return self;

--- a/Sources/BranchSDK/BranchOpenRequest.m
+++ b/Sources/BranchSDK/BranchOpenRequest.m
@@ -152,6 +152,10 @@
             }
         }
     }
+    
+    if (referringURL.length > 0) {
+        ((BNCServerRequestQueue *)[BNCServerRequestQueue getInstance]).processArchivedOpens = NO;
+    }
 
     // Clear link identifiers so they don't get reused on the next open
     preferenceHelper.linkClickIdentifier = nil;

--- a/Sources/BranchSDK/Private/BranchOpenRequest.h
+++ b/Sources/BranchSDK/Private/BranchOpenRequest.h
@@ -13,7 +13,7 @@
 
 // URL that triggered this install or open event
 @property (nonatomic, copy, readwrite) NSString *urlString;
-
+@property (assign, nonatomic) BOOL isFromArchivedQueue;
 @property (nonatomic, copy) callbackWithStatus callback;
 
 + (void) waitForOpenResponseLock;

--- a/Sources/BranchSDK/Public/BNCServerRequestQueue.h
+++ b/Sources/BranchSDK/Public/BNCServerRequestQueue.h
@@ -11,6 +11,8 @@
 
 @interface BNCServerRequestQueue : NSObject
 
+@property (assign, nonatomic) BOOL processArchivedOpens;
+
 - (void)enqueue:(BNCServerRequest *)request;
 - (BNCServerRequest *)dequeue;
 - (BNCServerRequest *)peek;


### PR DESCRIPTION
Fix for Universal Link Cold Launch

## Summary

Issues -

--   If tracking is disabled and app launch is cold, Universal Links were not resolving intermittently because of race condition happening between `branch.initSession` and `[BranchScene scene:continueUserActivity:]` for accessing preference variables. It happens only if both functions are called at the very same time. 
   Following is the sequence of events which happens 
   1. Session initialization starts from function `DidFinishLaunching` using `branch.initSession`. It has no `universal_link` in request. First Open Request is sent to server.
   2. In the meantime  - `[BranchScene scene:continueUserActivity:]` is called and it has `universal_link` url . It sets this value in prefs. So when First open request is going out - it checks if its a linking request (by checking url in prefs, which is just set by second request), function returns - YES.
  3. After First request is processed - it clears this url from prefs. Now when second Open request is sent - although request params have` universal_link_url` but its not anymore in prefs - its considered a non-linking request.

**Fix** : `isLinkingRelatedRequest` function will read values of identifiers from post params of request instead of preferences.

-- SDK keeps sending archived opens from the previous launch even after link is resolved

**Fix** :  A property is added in `BranchOpenRequest` class to find out if the event is from the archived queue. Another property `processArchivedOpens` is added in `BNCServerRequestQueue` to signal if archived opens should be propecessed.
After SDK gets `referringURL` in  `BranchOpenRequest` response, it turns of this flag. 

`processNextQueueItem` function uses these properties to find out if the next request is from archive and it should not be processed. If YES, it removes it from the queue and processes next one.

--  SDK resets session using enum variable `initializationStatus`. It sets its value to `BNCInitStatusUninitialized`.  Its a global variable and its value is sometimes changed by other parallel session initializations happening, if any,  to  `BNCInitStatusInitializing` or `BNCInitStatusInitialized`. So function `initUserSessionAndCallCallback`, which checks this value for session initialization, simply returns wihtout resetting/initializing session.

**Fix** : Added param in function `initUserSessionAndCallCallback` for forced session re-initialization irrespective of current SDK initializationStatus

## Testing Instructions

Use a test app with Universal Link Enabled and tracking disabled. 

--> If Test App is running kill it. Cold Launch is required.
--> Copy universal links for testing in iMessage.
--> Click on Univesal Links in iMessage.
--> Test App should be launched.
--> Check logs to see if Open request sent with param "universal_link_url" is processed and other opens without this params are dropped.

Repeat this test multiple times, by killing app and re-launching app using links from iMessage.

I have used this app https://github.com/BranchMetrics/SpotifyTest 

Links used for testing - 

```
https://cq9pf.app.link/FoVf9M9bDLb

https://cq9pf.app.link/fSMdfpldDLb

https://cq9pf.app.link/TfySwxRdDLb

```
Repeat test by enabling tracking as well as delaying  function calls `initSession` and` BranchScene.shared().scene`(...) 

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
