### PR TITLE
INTENG-21106 Fix for double opens

### DIFF
--- a/BranchSDK.podspec
+++ b/BranchSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "BranchSDK"
-  s.version          = "3.6.1"
+  s.version          = "3.6.2"
   s.summary          = "Create an HTTP URL for any piece of content in your app"
   s.description      = <<-DESC
 - Want the highest possible conversions on your sharing feature?

--- a/BranchSDK.xcodeproj/project.pbxproj
+++ b/BranchSDK.xcodeproj/project.pbxproj
@@ -1974,7 +1974,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2009,7 +2009,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2215,7 +2215,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2254,7 +2254,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2291,7 +2291,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2326,7 +2326,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.1;
+				MARKETING_VERSION = 3.6.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 Branch iOS SDK Change Log
 
+v.3.6.2
+- Fix for issue which was sending an extra open request on cold app launch. 
+- Updated fix for cold link launch when using deferred initialization and an AppDelegate only app.
+
 v.3.6.1
 - Fixed issues where external_intent_uri was incorrectly set in certain cases
 

--- a/DeepLinkDemo/DeepLinkDemo/Controllers/HomeViewController.swift
+++ b/DeepLinkDemo/DeepLinkDemo/Controllers/HomeViewController.swift
@@ -168,6 +168,7 @@ class HomeViewController: UITableViewController {
             return
         }
         self.enableBranchLogging(){(message:String, loglevel:BranchLogLevel, error:Error?)->() in
+            print("BranchSDK : " + message)
             if (message.contains("BranchSDK")){
                 self.logData = self.logData + message + "\n"
                 Utils.shared.printLogMessage(message + "\n")

--- a/DeepLinkDemo/DeepLinkDemo/Controllers/HomeViewController.swift
+++ b/DeepLinkDemo/DeepLinkDemo/Controllers/HomeViewController.swift
@@ -4,6 +4,15 @@
 
 import UIKit
 import BranchSDK
+import Darwin
+import os
+
+
+@available(iOS 14.0, *)
+extension Logger {
+    static let branchLogs = Logger(subsystem: Bundle.main.bundleIdentifier!, category: String(describing: "BranchSDK"))
+}
+
 class HomeViewController: UITableViewController {
     private var reachability:Reachability?
     
@@ -168,6 +177,30 @@ class HomeViewController: UITableViewController {
             return
         }
         self.enableBranchLogging(){(message:String, loglevel:BranchLogLevel, error:Error?)->() in
+            
+            var str = message
+            var startIndex = 0;
+            while (str.count > 0)  {
+                var substring : String = ""
+                substring = String(str.prefix(1024))
+                if #available(iOS 14.0, *) {
+                    Logger.branchLogs.log("\(substring , privacy: .public)" )
+                } else {
+                    // Fallback on earlier versions
+                }
+                print(substring )
+                str = String(str.dropFirst(1024))
+            }
+            
+            if let err = error {
+                if #available(iOS 14.0, *) {
+                    Logger.branchLogs.log("Error is \(String(describing: err), privacy: .public)" )
+                } else {
+                    // Fallback on earlier versions
+                }
+
+            }
+            
             print("BranchSDK : " + message)
             if (message.contains("BranchSDK")){
                 self.logData = self.logData + message + "\n"

--- a/DeepLinkDemo/DeepLinkDemo/Controllers/HomeViewController.swift
+++ b/DeepLinkDemo/DeepLinkDemo/Controllers/HomeViewController.swift
@@ -4,14 +4,6 @@
 
 import UIKit
 import BranchSDK
-import Darwin
-import os
-
-
-@available(iOS 14.0, *)
-extension Logger {
-    static let branchLogs = Logger(subsystem: Bundle.main.bundleIdentifier!, category: String(describing: "BranchSDK"))
-}
 
 class HomeViewController: UITableViewController {
     private var reachability:Reachability?
@@ -177,31 +169,6 @@ class HomeViewController: UITableViewController {
             return
         }
         self.enableBranchLogging(){(message:String, loglevel:BranchLogLevel, error:Error?)->() in
-            
-            var str = message
-            var startIndex = 0;
-            while (str.count > 0)  {
-                var substring : String = ""
-                substring = String(str.prefix(1024))
-                if #available(iOS 14.0, *) {
-                    Logger.branchLogs.log("\(substring , privacy: .public)" )
-                } else {
-                    // Fallback on earlier versions
-                }
-                print(substring )
-                str = String(str.dropFirst(1024))
-            }
-            
-            if let err = error {
-                if #available(iOS 14.0, *) {
-                    Logger.branchLogs.log("Error is \(String(describing: err), privacy: .public)" )
-                } else {
-                    // Fallback on earlier versions
-                }
-
-            }
-            
-            print("BranchSDK : " + message)
             if (message.contains("BranchSDK")){
                 self.logData = self.logData + message + "\n"
                 Utils.shared.printLogMessage(message + "\n")

--- a/DeepLinkDemo/DeepLinkDemo/Controllers/HomeViewController.swift
+++ b/DeepLinkDemo/DeepLinkDemo/Controllers/HomeViewController.swift
@@ -4,7 +4,6 @@
 
 import UIKit
 import BranchSDK
-
 class HomeViewController: UITableViewController {
     private var reachability:Reachability?
     

--- a/Sources/BranchSDK/BNCConfig.m
+++ b/Sources/BranchSDK/BNCConfig.m
@@ -8,7 +8,7 @@
 
 #include "BNCConfig.h"
 
-NSString * const BNC_SDK_VERSION  = @"3.6.1";
+NSString * const BNC_SDK_VERSION  = @"3.6.2";
 NSString * const BNC_LINK_URL = @"https://bnc.lt";
 NSString * const BNC_CDN_URL = @"https://cdn.branch.io";
 

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -70,6 +70,7 @@ NSString * const BRANCH_INIT_KEY_PHONE_NUMBER = @"+phone_number";
 NSString * const BRANCH_INIT_KEY_IS_FIRST_SESSION = @"+is_first_session";
 NSString * const BRANCH_INIT_KEY_CLICKED_BRANCH_LINK = @"+clicked_branch_link";
 static NSString * const BRANCH_PUSH_NOTIFICATION_PAYLOAD_KEY = @"branch";
+static NSString * const BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY = @"deferInitForPluginRuntime";
 
 NSString * const BNCCanonicalIdList = @"$canonical_identifier_list";
 NSString * const BNCPurchaseAmount = @"$amount";
@@ -615,9 +616,15 @@ static NSString *bnc_branchKey = nil;
 
 - (void)initSceneSessionWithLaunchOptions:(NSDictionary *)options isReferrable:(BOOL)isReferrable explicitlyRequestedReferrable:(BOOL)explicitlyRequestedReferrable automaticallyDisplayController:(BOOL)automaticallyDisplayController
                   registerDeepLinkHandler:(void (^)(BNCInitSessionResponse * _Nullable initResponse, NSError * _Nullable error))callback {
+    NSMutableDictionary * optionsWithDeferredInit = [options mutableCopy] ;
+        if (self.deferInitForPluginRuntime) {
+            [optionsWithDeferredInit setObject:@1 forKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"];
+        } else {
+            [optionsWithDeferredInit setObject:@0 forKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"];
+        }
     [self deferInitBlock:^{
         self.sceneSessionInitWithCallback = callback;
-        [self initSessionWithLaunchOptions:options isReferrable:isReferrable explicitlyRequestedReferrable:explicitlyRequestedReferrable automaticallyDisplayController:automaticallyDisplayController];
+        [self initSessionWithLaunchOptions:(NSDictionary *)optionsWithDeferredInit isReferrable:isReferrable explicitlyRequestedReferrable:explicitlyRequestedReferrable automaticallyDisplayController:automaticallyDisplayController];
     }];
 }
 
@@ -642,7 +649,9 @@ static NSString *bnc_branchKey = nil;
     }
     #endif
 
-    [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:pushURL reset:NO];
+    if(pushURL || [[options objectForKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"] isEqualToNumber:@1]) {
+        [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:pushURL reset:NO];
+    }
 }
 
 - (void)setDeepLinkDebugMode:(NSDictionary *)debugParams {

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -616,7 +616,7 @@ static NSString *bnc_branchKey = nil;
 
 - (void)initSceneSessionWithLaunchOptions:(NSDictionary *)options isReferrable:(BOOL)isReferrable explicitlyRequestedReferrable:(BOOL)explicitlyRequestedReferrable automaticallyDisplayController:(BOOL)automaticallyDisplayController
                   registerDeepLinkHandler:(void (^)(BNCInitSessionResponse * _Nullable initResponse, NSError * _Nullable error))callback {
-    NSMutableDictionary * optionsWithDeferredInit = [options mutableCopy] ;
+    NSMutableDictionary * optionsWithDeferredInit = [[NSMutableDictionary alloc ] initWithDictionary:options];
     if (self.deferInitForPluginRuntime) {
         [optionsWithDeferredInit setObject:@1 forKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"];
     } else {

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -649,7 +649,7 @@ static NSString *bnc_branchKey = nil;
     }
     #endif
 
-    if(pushURL || [[options objectForKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"] isEqualToNumber:@1]) {
+    if(pushURL || [[options objectForKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"] isEqualToNumber:@1] || (![options.allKeys containsObject:UIApplicationLaunchOptionsURLKey] && ![options.allKeys containsObject:UIApplicationLaunchOptionsUserActivityDictionaryKey]) ) {
         [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:pushURL reset:NO];
     }
 }

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -617,11 +617,11 @@ static NSString *bnc_branchKey = nil;
 - (void)initSceneSessionWithLaunchOptions:(NSDictionary *)options isReferrable:(BOOL)isReferrable explicitlyRequestedReferrable:(BOOL)explicitlyRequestedReferrable automaticallyDisplayController:(BOOL)automaticallyDisplayController
                   registerDeepLinkHandler:(void (^)(BNCInitSessionResponse * _Nullable initResponse, NSError * _Nullable error))callback {
     NSMutableDictionary * optionsWithDeferredInit = [options mutableCopy] ;
-        if (self.deferInitForPluginRuntime) {
-            [optionsWithDeferredInit setObject:@1 forKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"];
-        } else {
-            [optionsWithDeferredInit setObject:@0 forKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"];
-        }
+    if (self.deferInitForPluginRuntime) {
+        [optionsWithDeferredInit setObject:@1 forKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"];
+    } else {
+        [optionsWithDeferredInit setObject:@0 forKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"];
+    }
     [self deferInitBlock:^{
         self.sceneSessionInitWithCallback = callback;
         [self initSessionWithLaunchOptions:(NSDictionary *)optionsWithDeferredInit isReferrable:isReferrable explicitlyRequestedReferrable:explicitlyRequestedReferrable automaticallyDisplayController:automaticallyDisplayController];

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -30,7 +30,7 @@ Options:
 USAGE
 }
 
-version=3.6.1
+version=3.6.2
 prev_version="$version"
 
 if (( $# == 0 )); then


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/INTENG-21106  - Double Opens Issue

## Summary

iOS SDK sends two OPEN requests on cold launch (since Release 3.3 + ) if app is opened by clicking universal link.
First `OPEN` is sent by API `Branch.getInstance().initSessionWithLaunchOptions` and second `OPEN` is from  `Branch.getInstance().continue(userActivity)`
So if app sets a callback while initializing session using API `initSessionWithLaunchOptions`, this callback will be called twice on cold launch via universal link click.

This behavior came as a side effect to fix -  https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/pull/1369/files/2009c84ae1b603d963a5e064c2f5eb7e97f6f242. 

This pull request adds back some of the checks removed in above pull requests as well as adds few more.

As per the current state of SDK,`initSessionWithLaunchOptions` will call send OPEN ( by calling  `initUserSessionAndCallCallback` method ) only if ,
-->  There is a URL in push notification OR
-->  Deffered init is enabled.  OR
-->  Universal Link / Cutom URI is NOT expected to come later. (Organic Open)

## Motivation

This pull request fixes [Double Opens Issue](https://branch.atlassian.net/browse/INTENG-21106). Issue can be reproduced as described below -

-> Integrate latest iOS SDK with an AppDelegate only app (like device finder app). [Other Apps Not Using Scenes](https://help.branch.io/developers-hub/docs/ios-basic-integration#other-apps-not-using-scenes)

-> Kill app if its already running.

-> Click universal link to launch app again. Check logs. You will find two OPEN requests. If callback is set during intialization, that callback will be called twice.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

--> Cold Launch an AppDelegate Only app by clicking a universal link and verify only one OPEN request is sent and callback is called only once.(Ignore OPENs called by `applicationDidBecomeActive`. They dont call callbacks. )
--> On organic opens,  single OPEN request is sent.
--> On deferred initialization and cold launch via universal link click, links are resolved. Please refer to [this]( https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/pull/1369/files/2009c84ae1b603d963a5e064c2f5eb7e97f6f242) pull request for more details about testing this feature.

@rob-gioia-branch This pull request is related to fix for issue [INTENG-20098](https://branch.atlassian.net/browse/INTENG-20098). So I have tagged you as well for review.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.


[INTENG-20098]: https://branch.atlassian.net/browse/INTENG-20098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ