### PR TITLE
[IN PROGRESS] INTENG-21262 Fix for Duplicate purchase events (cached).

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCServerRequestQueueTests.m
@@ -26,6 +26,7 @@
 - (NSData *)oldArchiveQueue:(NSArray<BNCServerRequest *> *)queue;
 
 + (NSURL * _Nonnull) URLForQueueFile;
+- (void)retrieve;
 
 @end
 
@@ -173,11 +174,12 @@
         decodedQueue = [_queue unarchiveQueueFromData:data];
     }
     XCTAssert([decodedQueue count] == 2);
-    
-    [_queue remove:eventObject];
-    [_queue remove:openObject];
-    [_queue persistImmediately];
-     // Request Queue is empty. So there should not be any queue file on disk.
+    [_queue clearQueue];
+    XCTAssert([_queue queueDepth] == 0);
+    [_queue retrieve];
+    XCTAssert([_queue queueDepth] == 2);
+
+     // Request are loaded. So there should not be any queue file on disk.
     XCTAssert([NSFileManager.defaultManager fileExistsAtPath:[[BNCServerRequestQueue URLForQueueFile] path]] == NO);
 }
 

--- a/BranchSDK.podspec
+++ b/BranchSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "BranchSDK"
-  s.version          = "3.6.2"
+  s.version          = "3.6.3"
   s.summary          = "Create an HTTP URL for any piece of content in your app"
   s.description      = <<-DESC
 - Want the highest possible conversions on your sharing feature?

--- a/BranchSDK.xcodeproj/project.pbxproj
+++ b/BranchSDK.xcodeproj/project.pbxproj
@@ -1974,7 +1974,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.2;
+				MARKETING_VERSION = 3.6.3;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2009,7 +2009,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.2;
+				MARKETING_VERSION = 3.6.3;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2215,7 +2215,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 3.6.2;
+				MARKETING_VERSION = 3.6.3;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2254,7 +2254,7 @@
 					"@loader_path/Frameworks",
 				);
 				MACH_O_TYPE = staticlib;
-				MARKETING_VERSION = 3.6.2;
+				MARKETING_VERSION = 3.6.3;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2291,7 +2291,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.2;
+				MARKETING_VERSION = 3.6.3;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,
@@ -2326,7 +2326,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.6.2;
+				MARKETING_VERSION = 3.6.3;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					LinkPresentation,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 Branch iOS SDK Change Log
 
+v.3.6.3
+- Fix for duplicate purchase events created from archived request queue on disk.
+
 v.3.6.2
 - Fix for issue which was sending an extra open request on cold app launch. 
 - Updated fix for cold link launch when using deferred initialization and an AppDelegate only app.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 Branch iOS SDK Change Log
 
 v.3.6.3
-- Fix for duplicate purchase events created from archived request queue on disk.
+- Fix for duplicate events created from archived request queue on disk.
 
 v.3.6.2
 - Fix for issue which was sending an extra open request on cold app launch. 

--- a/Sources/BranchSDK/BNCConfig.m
+++ b/Sources/BranchSDK/BNCConfig.m
@@ -8,7 +8,7 @@
 
 #include "BNCConfig.h"
 
-NSString * const BNC_SDK_VERSION  = @"3.6.2";
+NSString * const BNC_SDK_VERSION  = @"3.6.3";
 NSString * const BNC_LINK_URL = @"https://bnc.lt";
 NSString * const BNC_CDN_URL = @"https://cdn.branch.io";
 

--- a/Sources/BranchSDK/BNCServerRequestQueue.m
+++ b/Sources/BranchSDK/BNCServerRequestQueue.m
@@ -217,8 +217,6 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
 - (void)persistImmediately {
     @synchronized (self) {
         if (!self.queue || self.queue.count == 0) {
-            //No more requests. Delete cached queue file.
-            [self removeSaveFile];
             return;
         }
         NSArray *queueCopy = [self.queue copy];
@@ -298,7 +296,7 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
 // It's been reported that unarchive can fail in some situations. In that case, remove the queued requests file.
 - (void)removeSaveFile {
     NSURL *fileURL = [BNCServerRequestQueue URLForQueueFile];
-    if (fileURL && [NSFileManager.defaultManager fileExistsAtPath:[fileURL path]]) {
+    if (fileURL) {
         NSError *error;
         [NSFileManager.defaultManager removeItemAtURL:fileURL error:&error];
         

--- a/Sources/BranchSDK/BNCServerRequestQueue.m
+++ b/Sources/BranchSDK/BNCServerRequestQueue.m
@@ -217,6 +217,8 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
 - (void)persistImmediately {
     @synchronized (self) {
         if (!self.queue || self.queue.count == 0) {
+            //No more requests. Delete cached queue file.
+            [self removeSaveFile];
             return;
         }
         NSArray *queueCopy = [self.queue copy];
@@ -287,6 +289,8 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
                 }
             }
             self.queue = decodedQueue;
+            // Requests are loaded into queue now. Delete queue file stored on disk.
+            [self removeSaveFile];
         }
     }
 }
@@ -294,7 +298,7 @@ static inline uint64_t BNCNanoSecondsFromTimeInterval(NSTimeInterval interval) {
 // It's been reported that unarchive can fail in some situations. In that case, remove the queued requests file.
 - (void)removeSaveFile {
     NSURL *fileURL = [BNCServerRequestQueue URLForQueueFile];
-    if (fileURL) {
+    if (fileURL && [NSFileManager.defaultManager fileExistsAtPath:[fileURL path]]) {
         NSError *error;
         [NSFileManager.defaultManager removeItemAtURL:fileURL error:&error];
         

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -30,7 +30,7 @@ Options:
 USAGE
 }
 
-version=3.6.2
+version=3.6.3
 prev_version="$version"
 
 if (( $# == 0 )); then


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/INTENG-21262 

## Summary

Issue : SDK sends Duplicate purchase events on cold launch of app if network request processing failed in previous launches.

SDK archives a copy of its Request Queue on Disk. Its a txt file (`BNCServerRequestQueue`)stored inside the `Application Support` folder of the data container of app. This archived copy is updated at regular intervals using a timer. 
When app is cold launched, SDK reads this file and adds requests left unprocessed from last run in its Request Queue. 
Because of a bug in SDK, this archived file was not deleted from disk if current request queue is empty. As a result, SDK keeps sending these cached requests on every cold launch of app.

Steps for reproducing bug :

1. Turn off WIFI / internet
2. Send any Standard or custom Event.
3. Quit App.
4. Turn On WIFI / Internet
5. Launch App. (Cold launch is required for reproducing this issue)
6. On Launch app will send all failed events. This is expected behavior.
7. Quit App 
8. Re-Launch again
9. On Launch app will send all failed events again. These events are not cleared from cache and SDK keeps sending them.

## Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
-> Check all unit tests pass.
-> Verify fix -
       - Create `BNCServerRequestQueue` archive file using steps mentioned above (Steps 1-4). On my system its stored at path `/Users/nidhi.dixit/Library/Developer/CoreSimulator/Devices/9C999B8A-A12B-4DDC-9A7E-A7F9DE201024/data/Containers/Data/Application/FD451857-78A8-4C5A-88C3-7CC9932D931C/Library/Application\ Support/io.branch`. I am testing using simulator.
       - Cold Lauch App and check all failed requests in previous launch are processed. `BNCServerRequestQueue`  file is deleted / updated and it does not contain processed requests anymore.
       - Cold Launch App again and check  SDK is not sending duplicate purchase events.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
