### PR TITLE
[SDK-2473] Fix for early branch init on install

### DIFF
--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -12,6 +12,7 @@
 #import "ViewController.h"
 #import "Branch.h"
 #import "BNCEncodingUtils.h"
+#import "BranchEvent.h"
 
 AppDelegate* appDelegate = nil;
 void APPLogHookFunction(NSDate*_Nonnull timestamp, BranchLogLevel level, NSString*_Nullable message);
@@ -33,7 +34,6 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
     // Branch.useTestBranchKey = YES;  // Make sure to comment this line out for production apps!!!
     Branch *branch = [Branch getInstance];
-    
 
     // Change the Branch base API URL
     //[Branch setAPIUrl:@"https://api3.branch.io"];
@@ -81,6 +81,12 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
         [self handleDeepLinkObject:universalObject linkProperties:linkProperties error:error];
     }];
 
+    
+    BranchEvent *earlyEvent = [BranchEvent standardEvent:BNCAddToCartEvent];
+    NSLog(@"Logging Early Event: %@", earlyEvent);
+    [earlyEvent logEvent];
+
+    
     // Push notification support (Optional)
     // [self registerForPushNotifications:application];
 

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -1935,6 +1935,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
                 } else if (![req isKindOfClass:[BranchOpenRequest class]] &&
                     (!self.preferenceHelper.randomizedDeviceToken || !self.preferenceHelper.sessionID)) {
                     [[BranchLogger shared] logError:@"Missing session items!" error:nil];
+                    self.networkCount = 0;
                     BNCPerformBlockOnMainThreadSync(^{
                         [req processResponse:nil error:[NSError branchErrorWithCode:BNCInitError]];
                     });

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -1908,7 +1908,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 - (void)processNextQueueItem {
     dispatch_semaphore_wait(self.processing_sema, DISPATCH_TIME_FOREVER);
-
+    
+    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Processing next queue item. Network Count: %ld. Queue depth: %ld", (long)self.networkCount, (long)self.requestQueue.queueDepth] error:nil];
+   
     if (self.networkCount == 0 &&
         self.requestQueue.queueDepth > 0) {
 
@@ -1920,10 +1922,11 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
         if (req) {
 
-            // If tracking is disabled, then do not check for install event.  It won't exist.
+            // If tracking is disabled, then do not check for install event. It won't exist.
             if (!Branch.trackingDisabled) {
                 if (![req isKindOfClass:[BranchInstallRequest class]] && !self.preferenceHelper.randomizedBundleToken) {
                     [[BranchLogger shared] logError:@"User session has not been initialized!" error:nil];
+                    self.networkCount = 0;                    
                     BNCPerformBlockOnMainThreadSync(^{
                         [req processResponse:nil error:[NSError branchErrorWithCode:BNCInitError]];
                     });


### PR DESCRIPTION
## Summary
When a BranchEvent is logged on first open before the SDK is initialized, we try to initialize first to log it properly. However, the SDK was reaching a state where `processNextQueueItem` was stuck and unable to process the first install or the event and nothing would happen until the next session. It seems like this was due to the BranchEvent request basically causing the queue to get stuck and the SDK to stay in an initializing state since `processNextQueueItem` would be skipped `networkCount` wasn't equal to 0. 
This change updates the if statement to also set the networkCount to 0 which allows the install to be processed and then the event to be processed after that. Since this statement only applies to non-install or open events on the first session, this change shouldn't have an effect on other cases.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix for a bug, mainly for the Adobe Branch plugin, but other clients may be trying to log events early in some cases as well.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Try out the updated testbed which logs an event from the AppDelegate before the SDK is initialized. 

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
