### PR TITLE
[In Progress] SDK - 2519 Open Request Input Params Refactor

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCPreferenceHelperTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCPreferenceHelperTests.m
@@ -364,14 +364,8 @@
     [self.prefHelper clearTrackingInformation];
     
     XCTAssertNil(self.prefHelper.sessionID);
-    XCTAssertNil(self.prefHelper.linkClickIdentifier);
-    XCTAssertNil(self.prefHelper.spotlightIdentifier);
-    XCTAssertNil(self.prefHelper.referringURL);
-    XCTAssertNil(self.prefHelper.universalLinkUrl);
-    XCTAssertNil(self.prefHelper.initialReferrer);
     XCTAssertNil(self.prefHelper.installParams);
     XCTAssertNil(self.prefHelper.sessionParams);
-    XCTAssertNil(self.prefHelper.externalIntentURI);
     XCTAssertNil(self.prefHelper.savedAnalyticsData);
     XCTAssertNil(self.prefHelper.previousAppBuildDate);
     XCTAssertEqual(self.prefHelper.requestMetadataDictionary.count, 0);

--- a/Sources/BranchSDK/BNCAppGroupsData.m
+++ b/Sources/BranchSDK/BNCAppGroupsData.m
@@ -64,7 +64,7 @@
     return nil;
 }
 
-- (void)saveAppClipData {
+- (void)saveAppClipData:(NSString *) referringURL {
     if ([BNCSystemObserver isAppClip]) {
         
         BNCApplication *application = [BNCApplication currentApplication];
@@ -79,7 +79,7 @@
         
         BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
         
-        NSString *url = preferenceHelper.referringURL;
+        NSString *url = referringURL;
         NSString *token = preferenceHelper.randomizedDeviceToken;
         NSString *bundleToken = preferenceHelper.randomizedBundleToken;
         

--- a/Sources/BranchSDK/BNCPreferenceHelper.m
+++ b/Sources/BranchSDK/BNCPreferenceHelper.m
@@ -73,7 +73,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
     NSOperationQueue *_persistPrefsQueue;
     NSString         *_lastSystemBuildVersion;
     NSString         *_browserUserAgentString;
-    NSString         *_referringURL;
 }
 
 @property (strong, nonatomic) NSMutableDictionary *persistenceDict;
@@ -90,20 +89,15 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
 // since we override both setter and getter, these properties do not auto synthesize
 @synthesize
     lastRunBranchKey = _lastRunBranchKey,
-    appVersion = _appVersion,
     randomizedDeviceToken = _randomizedDeviceToken,
     sessionID = _sessionID,
-    spotlightIdentifier = _spotlightIdentifier,
     randomizedBundleToken = _randomizedBundleToken,
-    linkClickIdentifier = _linkClickIdentifier,
     userUrl = _userUrl,
     userIdentity = _userIdentity,
     sessionParams = _sessionParams,
     installParams = _installParams,
-    universalLinkUrl = _universalLinkUrl,
     initialReferrer = _initialReferrer,
     localUrl = _localUrl,
-    externalIntentURI = _externalIntentURI,
     isDebug = _isDebug,
     retryCount = _retryCount,
     retryInterval = _retryInterval,
@@ -220,20 +214,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
     }
 }
 
-- (NSString *)appVersion {
-    if (!_appVersion) {
-        _appVersion = [self readStringFromDefaults:BRANCH_PREFS_KEY_APP_VERSION];
-    }
-    return _appVersion;
-}
-
-- (void)setAppVersion:(NSString *)appVersion {
-    if (![_appVersion isEqualToString:appVersion]) {
-        _appVersion = appVersion;
-        [self writeObjectToDefaults:BRANCH_PREFS_KEY_APP_VERSION value:appVersion];
-    }
-}
-
 - (NSString *)randomizedDeviceToken {
     if (!_randomizedDeviceToken) {
         NSString *tmp = [self readStringFromDefaults:BRANCH_PREFS_KEY_RANDOMIZED_DEVICE_TOKEN];
@@ -306,62 +286,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
 
 - (void)setUserIdentity:(NSString *)userIdentity {
     [self writeObjectToDefaults:BRANCH_PREFS_KEY_IDENTITY value:userIdentity];
-}
-
-- (NSString *)linkClickIdentifier {
-    return [self readStringFromDefaults:BRANCH_PREFS_KEY_LINK_CLICK_IDENTIFIER];
-}
-
-- (void)setLinkClickIdentifier:(NSString *)linkClickIdentifier {
-    [self writeObjectToDefaults:BRANCH_PREFS_KEY_LINK_CLICK_IDENTIFIER value:linkClickIdentifier];
-}
-
-- (NSString *)spotlightIdentifier {
-    return [self readStringFromDefaults:BRANCH_PREFS_KEY_SPOTLIGHT_IDENTIFIER];
-}
-
-- (void)setSpotlightIdentifier:(NSString *)spotlightIdentifier {
-    [self writeObjectToDefaults:BRANCH_PREFS_KEY_SPOTLIGHT_IDENTIFIER value:spotlightIdentifier];
-}
-
-- (NSString *)externalIntentURI {
-    @synchronized(self) {
-        if (!_externalIntentURI) {
-            _externalIntentURI = [self readStringFromDefaults:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI];
-        }
-        return _externalIntentURI;
-    }
-}
-
-- (void)setExternalIntentURI:(NSString *)externalIntentURI {
-    @synchronized(self) {
-        if (externalIntentURI == nil || ![_externalIntentURI isEqualToString:externalIntentURI]) {
-            _externalIntentURI = externalIntentURI;
-            [self writeObjectToDefaults:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI value:externalIntentURI];
-        }
-    }
-}
-
-- (NSString*) referringURL {
-    @synchronized (self) {
-        if (!_referringURL) _referringURL = [self readStringFromDefaults:@"referringURL"];
-        return _referringURL;
-    }
-}
-
-- (void) setReferringURL:(NSString *)referringURL {
-    @synchronized (self) {
-        _referringURL = [referringURL copy];
-        [self writeObjectToDefaults:@"referringURL" value:_referringURL];
-    }
-}
-
-- (NSString *)universalLinkUrl {
-    return [self readStringFromDefaults:BRANCH_PREFS_KEY_UNIVERSAL_LINK_URL];
-}
-
-- (void)setUniversalLinkUrl:(NSString *)universalLinkUrl {
-    [self writeObjectToDefaults:BRANCH_PREFS_KEY_UNIVERSAL_LINK_URL value:universalLinkUrl];
 }
 
 - (NSString *)localUrl {
@@ -618,18 +542,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
     }
 }
 
-- (BOOL) dropURLOpen {
-    @synchronized(self) {
-        return [self readBoolFromDefaults:@"dropURLOpen"];
-    }
-}
-
-- (void) setDropURLOpen:(BOOL)value {
-    @synchronized(self) {
-        [self writeBoolToDefaults:@"dropURLOpen" value:value];
-    }
-}
-
 - (BOOL) trackingDisabled {
     @synchronized(self) {
         NSNumber *b = (id) [self readObjectFromDefaults:@"trackingDisabled"];
@@ -849,14 +761,8 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
          self.randomizedBundleToken = nil;
          */
         self.sessionID = nil;
-        self.linkClickIdentifier = nil;
-        self.spotlightIdentifier = nil;
-        self.referringURL = nil;
-        self.universalLinkUrl = nil;
-        self.initialReferrer = nil;
         self.installParams = nil;
         self.sessionParams = nil;
-        self.externalIntentURI = nil;
         self.savedAnalyticsData = nil;
         self.previousAppBuildDate = nil;
         self.requestMetadataDictionary = nil;

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -312,9 +312,6 @@
     [self safeSetValue:openRequest.linkParams.linkClickIdentifier forKey:BRANCH_REQUEST_KEY_LINK_IDENTIFIER onDict:json];
     [self safeSetValue:openRequest.linkParams.spotlightIdentifier forKey:BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER onDict:json];
    
-    
-    // This was only on opens before, cause it can't exist on install.
-    [self safeSetValue:openRequest.linkParams.externalIntentURI forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
 }
 
 - (void)addSystemObserverDataToJSON:(NSMutableDictionary *)json {

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -107,15 +107,15 @@
     [self addTimestampsToJSON:json];
     
     // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
- /*   if (openRequest.) {
-        NSURL *url = [NSURL URLWithString:urlString];
+    if (installRequest.urlString) {
+        NSURL *url = [NSURL URLWithString:installRequest.urlString];
         if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
-            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+            [self safeSetValue:installRequest.urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
         } else {
-            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
+            [self safeSetValue:installRequest.urlString forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
         }
     }
-    */
+    
     [self addAppleAttributionTokenToJSON:json];
 
     // Install Only

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -34,6 +34,8 @@
 #import "BNCSKAdNetwork.h"
 #import "BNCReferringURLUtility.h"
 #import "BNCPasteboard.h"
+#import "BranchOpenRequest.h"
+#import "BranchInstallRequest.h"
 
 @interface BNCRequestFactory()
 
@@ -80,7 +82,7 @@
     return Branch.trackingDisabled;
 }
 
-- (NSDictionary *)dataForInstallWithURLString:(NSString *)urlString {
+- (NSDictionary *)dataForInstallWithRequestObject:(BranchInstallRequest *) installRequest {
     NSMutableDictionary *json = [NSMutableDictionary new];
     
     // All requests
@@ -99,13 +101,13 @@
     // Install and Open
     [self addDeveloperUserIDToJSON:json];
     [self addSystemObserverDataToJSON:json];
-    [self addPreferenceHelperDataToJSON:json];
+    [self addOpenRequestDataToJSON:json fromRequestObject:installRequest];
     [self addPartnerParametersToJSON:json];
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
     // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
-    if (urlString) {
+ /*   if (openRequest.) {
         NSURL *url = [NSURL URLWithString:urlString];
         if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
             [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
@@ -113,7 +115,7 @@
             [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
         }
     }
-    
+    */
     [self addAppleAttributionTokenToJSON:json];
 
     // Install Only
@@ -132,7 +134,7 @@
     return json;
 }
 
-- (NSDictionary *)dataForOpenWithURLString:(NSString *)urlString {
+- (NSDictionary *)dataForOpenWithRequestObject:(BranchOpenRequest *) openRequest {
     NSMutableDictionary *json = [NSMutableDictionary new];
     
     // All requests
@@ -154,19 +156,19 @@
     // Install and Open
     [self addDeveloperUserIDToJSON:json];
     [self addSystemObserverDataToJSON:json];
-    [self addPreferenceHelperDataToJSON:json];
+    [self addOpenRequestDataToJSON:json fromRequestObject:openRequest];
     [self addPartnerParametersToJSON:json];
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
     
     // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
-    if (urlString) {
-        NSURL *url = [NSURL URLWithString:urlString];
+    if (openRequest.urlString) {
+        NSURL *url = [NSURL URLWithString:openRequest.urlString];
         if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
-            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+            [self safeSetValue:openRequest.urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
         } else {
-            [self safeSetValue:urlString forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
+            [self safeSetValue:openRequest.urlString forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
         }
     }
     
@@ -303,15 +305,16 @@
     json[BRANCH_REQUEST_KEY_SESSION_ID] = self.preferenceHelper.sessionID;
 }
 
-- (void)addPreferenceHelperDataToJSON:(NSMutableDictionary *)json {
+- (void)addOpenRequestDataToJSON:(NSMutableDictionary *)json fromRequestObject:(BranchOpenRequest *) openRequest{
     json[BRANCH_REQUEST_KEY_DEBUG] = @(self.preferenceHelper.isDebug);
-
-    [self safeSetValue:self.preferenceHelper.linkClickIdentifier forKey:BRANCH_REQUEST_KEY_LINK_IDENTIFIER onDict:json];
-    [self safeSetValue:self.preferenceHelper.spotlightIdentifier forKey:BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER onDict:json];
     [self safeSetValue:self.preferenceHelper.initialReferrer forKey:BRANCH_REQUEST_KEY_INITIAL_REFERRER onDict:json];
     
+    [self safeSetValue:openRequest.linkParams.linkClickIdentifier forKey:BRANCH_REQUEST_KEY_LINK_IDENTIFIER onDict:json];
+    [self safeSetValue:openRequest.linkParams.spotlightIdentifier forKey:BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER onDict:json];
+   
+    
     // This was only on opens before, cause it can't exist on install.
-    [self safeSetValue:self.preferenceHelper.externalIntentURI forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
+    [self safeSetValue:openRequest.linkParams.externalIntentURI forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
 }
 
 - (void)addSystemObserverDataToJSON:(NSMutableDictionary *)json {

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -107,7 +107,7 @@
     [self addTimestampsToJSON:json];
     
     // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
-    if (installRequest.urlString) {
+    if (installRequest.urlString && !installRequest.linkParams.dropURLOpen) {
         NSURL *url = [NSURL URLWithString:installRequest.urlString];
         if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
             [self safeSetValue:installRequest.urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
@@ -163,7 +163,7 @@
     
     
     // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
-    if (openRequest.urlString) {
+    if (openRequest.urlString && !openRequest.linkParams.dropURLOpen) {
         NSURL *url = [NSURL URLWithString:openRequest.urlString];
         if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
             [self safeSetValue:openRequest.urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -82,7 +82,7 @@
     return Branch.trackingDisabled;
 }
 
-- (NSDictionary *)dataForInstallWithRequestObject:(BranchInstallRequest *) installRequest {
+- (NSDictionary *)dataForInstallWithLinkParams:(BranchOpenRequestLinkParams *) linkParams {
     NSMutableDictionary *json = [NSMutableDictionary new];
     
     // All requests
@@ -101,18 +101,18 @@
     // Install and Open
     [self addDeveloperUserIDToJSON:json];
     [self addSystemObserverDataToJSON:json];
-    [self addOpenRequestDataToJSON:json fromRequestObject:installRequest];
+    [self addOpenRequestDataToJSON:json fromLinkParams:linkParams];
     [self addPartnerParametersToJSON:json];
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
     // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
-    if (installRequest.urlString && !installRequest.linkParams.dropURLOpen) {
-        NSURL *url = [NSURL URLWithString:installRequest.urlString];
+    if (linkParams.referringURL && !linkParams.dropURLOpen) {
+        NSURL *url = [NSURL URLWithString:linkParams.referringURL];
         if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
-            [self safeSetValue:installRequest.urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+            [self safeSetValue:linkParams.referringURL forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
         } else {
-            [self safeSetValue:installRequest.urlString forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
+            [self safeSetValue:linkParams.referringURL forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
         }
     }
     
@@ -134,7 +134,7 @@
     return json;
 }
 
-- (NSDictionary *)dataForOpenWithRequestObject:(BranchOpenRequest *) openRequest {
+- (NSDictionary *)dataForOpenWithLinkParams:(BranchOpenRequestLinkParams *) linkParams{
     NSMutableDictionary *json = [NSMutableDictionary new];
     
     // All requests
@@ -156,19 +156,19 @@
     // Install and Open
     [self addDeveloperUserIDToJSON:json];
     [self addSystemObserverDataToJSON:json];
-    [self addOpenRequestDataToJSON:json fromRequestObject:openRequest];
+    [self addOpenRequestDataToJSON:json fromLinkParams:linkParams];
     [self addPartnerParametersToJSON:json];
     [self addAppleReceiptSourceToJSON:json];
     [self addTimestampsToJSON:json];
     
     
     // Check if the urlString is a valid URL to ensure it's a universal link, not the external intent uri
-    if (openRequest.urlString && !openRequest.linkParams.dropURLOpen) {
-        NSURL *url = [NSURL URLWithString:openRequest.urlString];
+    if (linkParams.referringURL && !linkParams.dropURLOpen) {
+        NSURL *url = [NSURL URLWithString:linkParams.referringURL];
         if (url && ([url.scheme isEqualToString:@"http"] || [url.scheme isEqualToString:@"https"])) {
-            [self safeSetValue:openRequest.urlString forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
+            [self safeSetValue:linkParams.referringURL forKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL onDict:json];
         } else {
-            [self safeSetValue:openRequest.urlString forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
+            [self safeSetValue:linkParams.referringURL forKey:BRANCH_REQUEST_KEY_EXTERNAL_INTENT_URI onDict:json];
         }
     }
     
@@ -305,12 +305,12 @@
     json[BRANCH_REQUEST_KEY_SESSION_ID] = self.preferenceHelper.sessionID;
 }
 
-- (void)addOpenRequestDataToJSON:(NSMutableDictionary *)json fromRequestObject:(BranchOpenRequest *) openRequest{
+- (void)addOpenRequestDataToJSON:(NSMutableDictionary *)json fromLinkParams:(BranchOpenRequestLinkParams *) linkParams{
     json[BRANCH_REQUEST_KEY_DEBUG] = @(self.preferenceHelper.isDebug);
     [self safeSetValue:self.preferenceHelper.initialReferrer forKey:BRANCH_REQUEST_KEY_INITIAL_REFERRER onDict:json];
     
-    [self safeSetValue:openRequest.linkParams.linkClickIdentifier forKey:BRANCH_REQUEST_KEY_LINK_IDENTIFIER onDict:json];
-    [self safeSetValue:openRequest.linkParams.spotlightIdentifier forKey:BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER onDict:json];
+    [self safeSetValue:linkParams.linkClickIdentifier forKey:BRANCH_REQUEST_KEY_LINK_IDENTIFIER onDict:json];
+    [self safeSetValue:linkParams.spotlightIdentifier forKey:BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER onDict:json];
    
 }
 

--- a/Sources/BranchSDK/BNCServerRequestQueue.m
+++ b/Sources/BranchSDK/BNCServerRequestQueue.m
@@ -138,7 +138,7 @@
 
             // Install subclasses open, so only need to check open
             // Request should not be the one added from archived queue
-            if ([request isKindOfClass:[BranchOpenRequest class]] && !((BranchOpenRequest *)request).isFromArchivedQueue) {
+            if ([request isKindOfClass:[BranchOpenRequest class]]) {
                 return (BranchOpenRequest *)request;
             }
         }

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -687,7 +687,6 @@ static NSString *bnc_branchKey = nil;
     if ([options objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey]) {
         id branchUrlFromPush = [options objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey][BRANCH_PUSH_NOTIFICATION_PAYLOAD_KEY];
         if ([branchUrlFromPush isKindOfClass:[NSString class]]) {
-            params.universalLinkUrl = branchUrlFromPush;
             params.referringURL = branchUrlFromPush;
             pushURL = (NSString *)branchUrlFromPush;
         }
@@ -748,7 +747,6 @@ static NSString *bnc_branchKey = nil;
         params.dropURLOpen = YES;
         
         NSString *urlString = [url absoluteString];
-        params.externalIntentURI = urlString;
         params.referringURL = urlString;
 
         [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil urlParams:params  reset:YES];
@@ -772,20 +770,17 @@ static NSString *bnc_branchKey = nil;
 
         NSString *urlScheme = [url scheme];
 
-        // save the incoming url in the preferenceHelper in the externalIntentURI field
         if ([self.allowedSchemeList count]) {
             for (NSString *scheme in self.allowedSchemeList) {
                 if (urlScheme && [scheme isEqualToString:urlScheme]) {
-                    openRequestParams.externalIntentURI = [url absoluteString];
                     openRequestParams.referringURL = [url absoluteString];
-                    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Allowed scheme list, set externalIntentURI and referringURL to %@", [url absoluteString]] error:nil];
+                    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Allowed scheme list, set referringURL to %@", [url absoluteString]] error:nil];
                     break;
                 }
             }
         } else {
-            openRequestParams.externalIntentURI = [url absoluteString];
             openRequestParams.referringURL = [url absoluteString];
-            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Set externalIntentURI and referringURL to %@", [url absoluteString]] error:nil];
+            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Set  referringURL to %@", [url absoluteString]] error:nil];
         }
 
         NSString *query = [url fragment];
@@ -830,7 +825,6 @@ static NSString *bnc_branchKey = nil;
     
     BranchOpenRequestLinkParams *params = [[BranchOpenRequestLinkParams alloc] init];
     if (urlString.length) {
-        params.universalLinkUrl = urlString;
         params.referringURL = urlString;
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Set universalLinkUrl and referringURL to %@", urlString] error:nil];
     }

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -2093,7 +2093,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
                 }
                 req.callback = initSessionCallback;
                 req.urlString = urlString;
-                req.linkParams = params
+                req.linkParams = params;
                 
                 [self.requestQueue insert:req at:0];
                 

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -2089,12 +2089,11 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
                     req = [[BranchInstallRequest alloc] initWithCallback:initSessionCallback];
                 }
                 req.callback = initSessionCallback;
-                req.urlString = params.referringURL;
                 req.linkParams = params;
                 
                 [self.requestQueue insert:req at:0];
                 
-                NSString *message = [NSString stringWithFormat:@"Request %@ callback %@ link %@", req, req.callback, req.urlString];
+                NSString *message = [NSString stringWithFormat:@"Request %@ callback %@ link params %@", req, req.callback, req.linkParams];
                 [[BranchLogger shared] logDebug:message error:nil];
 
             } else {
@@ -2103,14 +2102,13 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
                 if (params.referringURL) {
                     req = [[BranchOpenRequest alloc] initWithCallback:initSessionCallback];
                     req.callback = initSessionCallback;
-                    req.urlString = params.referringURL;
                     req.linkParams = params;
                     
                     // put it behind the one that's already on queue
                     [self.requestQueue insert:req at:1];
 
                     [[BranchLogger shared] logDebug:@"Link resolution request" error:nil];
-                    NSString *message = [NSString stringWithFormat:@"Request %@ callback %@ link %@", req, req.callback, req.urlString];
+                    NSString *message = [NSString stringWithFormat:@"Request %@ callback %@ link params%@", req, req.callback, req.linkParams];
                     [[BranchLogger shared] logDebug:message error:nil];
                 }
             }

--- a/Sources/BranchSDK/BranchInstallRequest.m
+++ b/Sources/BranchSDK/BranchInstallRequest.m
@@ -20,7 +20,7 @@
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:key UUID:self.requestUUID TimeStamp:self.requestCreationTimeStamp];
-    NSDictionary *params = [factory dataForInstallWithURLString:self.urlString];
+    NSDictionary *params  = [factory dataForInstallWithRequestObject:self];
 
     [serverInterface postRequest:params url:[[BNCServerAPI sharedInstance] installServiceURL] key:key callback:callback];
 }

--- a/Sources/BranchSDK/BranchInstallRequest.m
+++ b/Sources/BranchSDK/BranchInstallRequest.m
@@ -20,7 +20,7 @@
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:key UUID:self.requestUUID TimeStamp:self.requestCreationTimeStamp];
-    NSDictionary *params  = [factory dataForInstallWithRequestObject:self];
+    NSDictionary *params  = [factory dataForInstallWithLinkParams:self.linkParams];
 
     [serverInterface postRequest:params url:[[BNCServerAPI sharedInstance] installServiceURL] key:key callback:callback];
 }

--- a/Sources/BranchSDK/BranchOpenRequest.m
+++ b/Sources/BranchSDK/BranchOpenRequest.m
@@ -166,7 +166,7 @@
     [BranchOpenRequest releaseOpenResponseLock];
     
     if (self.isInstall) {
-        [[BNCAppGroupsData shared] saveAppClipData];
+        [[BNCAppGroupsData shared] saveAppClipData: self.linkParams.referringURL];
     }
     
 #if !TARGET_OS_TV

--- a/Sources/BranchSDK/BranchOpenRequest.m
+++ b/Sources/BranchSDK/BranchOpenRequest.m
@@ -47,7 +47,7 @@
 
 - (void)makeRequest:(BNCServerInterface *)serverInterface key:(NSString *)key callback:(BNCServerCallback)callback {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:key UUID:self.requestUUID TimeStamp:self.requestCreationTimeStamp];
-    NSDictionary *params = [factory dataForOpenWithRequestObject:self];
+    NSDictionary *params = [factory dataForOpenWithLinkParams:self.linkParams];
 
     [serverInterface postRequest:params
         url:[[BNCServerAPI sharedInstance] openServiceURL]
@@ -140,8 +140,8 @@
     }
 
     NSString *referringURL = nil;
-    if (self.urlString.length > 0) {
-        referringURL = self.urlString;
+    if (self.linkParams.referringURL.length > 0) {
+        referringURL = self.linkParams.referringURL;
     } else {
         NSDictionary *sessionDataDict = [BNCEncodingUtils decodeJsonStringToDictionary:sessionData];
         NSString *link = sessionDataDict[BRANCH_RESPONSE_KEY_BRANCH_REFERRING_LINK];
@@ -249,13 +249,13 @@
 - (instancetype)initWithCoder:(NSCoder *)decoder {
     self = [super initWithCoder:decoder];
     if (!self) return self;
-    self.urlString = [decoder decodeObjectOfClass:NSString.class forKey:@"urlString"];
+    self.linkParams.referringURL = [decoder decodeObjectOfClass:NSString.class forKey:@"urlString"];
     return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
     [super encodeWithCoder:coder];
-    [coder encodeObject:self.urlString forKey:@"urlString"];
+    [coder encodeObject:self.linkParams.referringURL forKey:@"urlString"];
 }
 
 + (BOOL)supportsSecureCoding {

--- a/Sources/BranchSDK/BranchOpenRequest.m
+++ b/Sources/BranchSDK/BranchOpenRequest.m
@@ -40,7 +40,6 @@
     if ((self = [super init])) {
         _callback = callback;
         _isInstall = isInstall;
-        _isFromArchivedQueue = NO;
     }
 
     return self;

--- a/Sources/BranchSDK/Private/BNCAppGroupsData.h
+++ b/Sources/BranchSDK/Private/BNCAppGroupsData.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)shared;
 
 // saves app clip data when appropriate
-- (void)saveAppClipData;
+- (void)saveAppClipData:(NSString *) referringURL ;
 
 // loads app clip data
 - (BOOL)loadAppClipData;

--- a/Sources/BranchSDK/Private/BNCRequestFactory.h
+++ b/Sources/BranchSDK/Private/BNCRequestFactory.h
@@ -25,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithBranchKey:(NSString *)key UUID:(NSString *)requestUUID TimeStamp:(NSNumber *)requestTimeStamp NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
-- (NSDictionary *)dataForInstallWithRequestObject:(BranchInstallRequest *) installRequest;
-- (NSDictionary *)dataForOpenWithRequestObject:(BranchOpenRequest *) openRequest;
+- (NSDictionary *)dataForInstallWithLinkParams:(BranchOpenRequestLinkParams *) linkParams;
+- (NSDictionary *)dataForOpenWithLinkParams:(BranchOpenRequestLinkParams *) linkParams;
 
 // Event data is passed in
 - (NSDictionary *)dataForEventWithEventDictionary:(NSMutableDictionary *)dictionary;

--- a/Sources/BranchSDK/Private/BNCRequestFactory.h
+++ b/Sources/BranchSDK/Private/BNCRequestFactory.h
@@ -7,6 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "BranchOpenRequest.h"
+#import "BranchInstallRequest.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithBranchKey:(NSString *)key UUID:(NSString *)requestUUID TimeStamp:(NSNumber *)requestTimeStamp NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
-- (NSDictionary *)dataForInstallWithURLString:(nullable NSString *)urlString;
-- (NSDictionary *)dataForOpenWithURLString:(nullable NSString *)urlString;
+- (NSDictionary *)dataForInstallWithRequestObject:(BranchInstallRequest *) installRequest;
+- (NSDictionary *)dataForOpenWithRequestObject:(BranchOpenRequest *) openRequest;
 
 // Event data is passed in
 - (NSDictionary *)dataForEventWithEventDictionary:(NSMutableDictionary *)dictionary;

--- a/Sources/BranchSDK/Private/BranchOpenRequest.h
+++ b/Sources/BranchSDK/Private/BranchOpenRequest.h
@@ -12,9 +12,7 @@
 @interface BranchOpenRequestLinkParams : NSObject
 @property (copy, nonatomic) NSString *linkClickIdentifier;
 @property (copy, nonatomic) NSString *spotlightIdentifier;
-@property (copy, nonatomic) NSString *universalLinkUrl;
 @property (copy, nonatomic) NSString *referringURL;
-@property (copy, nonatomic) NSString *externalIntentURI;
 @property (assign, nonatomic) BOOL dropURLOpen;
 @end
 

--- a/Sources/BranchSDK/Private/BranchOpenRequest.h
+++ b/Sources/BranchSDK/Private/BranchOpenRequest.h
@@ -12,14 +12,13 @@
 @interface BranchOpenRequestLinkParams : NSObject
 @property (copy, nonatomic) NSString *linkClickIdentifier;
 @property (copy, nonatomic) NSString *spotlightIdentifier;
-@property (copy, nonatomic) NSString *referringURL;
+@property (copy, nonatomic) NSString *referringURL; // URL that triggered this install or open event
 @property (assign, nonatomic) BOOL dropURLOpen;
 @end
 
 @interface BranchOpenRequest : BNCServerRequest
 
-// URL that triggered this install or open event
-@property (nonatomic, copy, readwrite) NSString *urlString;
+
 @property (nonatomic, copy) callbackWithStatus callback;
 @property (nonatomic, copy, readwrite) BranchOpenRequestLinkParams *linkParams;
 

--- a/Sources/BranchSDK/Private/BranchOpenRequest.h
+++ b/Sources/BranchSDK/Private/BranchOpenRequest.h
@@ -13,7 +13,6 @@
 
 // URL that triggered this install or open event
 @property (nonatomic, copy, readwrite) NSString *urlString;
-@property (assign, nonatomic) BOOL isFromArchivedQueue;
 @property (nonatomic, copy) callbackWithStatus callback;
 
 + (void) waitForOpenResponseLock;

--- a/Sources/BranchSDK/Private/BranchOpenRequest.h
+++ b/Sources/BranchSDK/Private/BranchOpenRequest.h
@@ -9,11 +9,21 @@
 #import "BNCServerRequest.h"
 #import "BNCCallbacks.h"
 
+@interface BranchOpenRequestLinkParams : NSObject
+@property (copy, nonatomic) NSString *linkClickIdentifier;
+@property (copy, nonatomic) NSString *spotlightIdentifier;
+@property (copy, nonatomic) NSString *universalLinkUrl;
+@property (copy, nonatomic) NSString *referringURL;
+@property (copy, nonatomic) NSString *externalIntentURI;
+@property (assign, nonatomic) BOOL dropURLOpen;
+@end
+
 @interface BranchOpenRequest : BNCServerRequest
 
 // URL that triggered this install or open event
 @property (nonatomic, copy, readwrite) NSString *urlString;
 @property (nonatomic, copy) callbackWithStatus callback;
+@property (nonatomic, copy, readwrite) BranchOpenRequestLinkParams *linkParams;
 
 + (void) waitForOpenResponseLock;
 + (void) releaseOpenResponseLock;

--- a/Sources/BranchSDK/Public/BNCPreferenceHelper.h
+++ b/Sources/BranchSDK/Public/BNCPreferenceHelper.h
@@ -23,16 +23,12 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 
 @property (copy, nonatomic) NSString *lastRunBranchKey;
 @property (strong, nonatomic) NSDate *lastStrongMatchDate;
-@property (copy, nonatomic) NSString *appVersion;
 
 @property (copy, nonatomic) NSString *randomizedDeviceToken;
 @property (copy, nonatomic) NSString *randomizedBundleToken;
 @property (copy, nonatomic) NSString *anonID;
 
 @property (copy, nonatomic) NSString *sessionID;
-@property (copy, nonatomic) NSString *linkClickIdentifier;
-@property (copy, nonatomic) NSString *spotlightIdentifier;
-@property (copy, nonatomic) NSString *universalLinkUrl;
 @property (copy, nonatomic) NSString *initialReferrer;
 @property (copy, nonatomic) NSString *userUrl;
 @property (copy, nonatomic) NSString *localUrl;
@@ -46,11 +42,9 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 @property (assign, nonatomic) NSInteger retryCount;
 @property (assign, nonatomic) NSTimeInterval retryInterval;
 @property (assign, nonatomic) NSTimeInterval timeout;
-@property (copy, nonatomic) NSString *externalIntentURI;
 @property (strong, nonatomic) NSMutableDictionary *savedAnalyticsData;
 @property (copy, nonatomic) NSString *lastSystemBuildVersion;
 @property (copy, nonatomic) NSString *browserUserAgentString;
-@property (copy, nonatomic) NSString *referringURL;
 @property (assign, nonatomic) BOOL limitFacebookTracking;
 @property (strong, nonatomic) NSDate *previousAppBuildDate;
 @property (assign, nonatomic, readwrite) BOOL disableAdNetworkCallouts;
@@ -58,7 +52,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 @property (nonatomic, copy, readwrite) NSString *patternListURL;
 @property (strong, nonatomic) NSArray<NSString *> *savedURLPatternList;
 @property (assign, nonatomic) NSInteger savedURLPatternListVersion;
-@property (assign, nonatomic) BOOL dropURLOpen;
 
 @property (assign, nonatomic) BOOL trackingDisabled;
 


### PR DESCRIPTION
## Reference

SDK-2518 --  Code refactor to handle Preference Helper Race Conditions
https://branch.atlassian.net/browse/SDK-2518
Subtask -- SDK-2519 -- Open Request Refactor
https://branch.atlassian.net/browse/SDK-2519
## Summary
** SDK will no longer save following values in preference helper -
- linkClickIdentifier
- spotlightIdentifier
- universalLinkUrl
- referringURL
- externalIntentURI
- dropURLOpen
 These values will be stored in BranchOpenRequest object 
 A new class is added to encapsulate above variables.
** Removed universalLinkUrl and externalIntentURI. referringURL contains same values. So Request construction will use referringURL now.
** Remove appVersion property from preference helper. Its no longer used.


## Type Of Change
- [ ] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
