### PR TITLE
[SDK-2522] Set CPP Level via branch.json

### DIFF
--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -256,6 +256,20 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
     if (config.checkPasteboardOnInstall) {
         [self checkPasteboardOnInstall];
     }
+    
+    if (config.cppLevel) {
+        if ([config.cppLevel caseInsensitiveCompare:@"FULL"] == NSOrderedSame) {
+            [[Branch getInstance] setConsumerProtectionAttributionLevel:BranchAttributionLevelFull];
+        } else if ([config.cppLevel caseInsensitiveCompare:@"REDUCED"] == NSOrderedSame) {
+            [[Branch getInstance] setConsumerProtectionAttributionLevel:BranchAttributionLevelReduced];
+        } else if ([config.cppLevel caseInsensitiveCompare:@"MINIMAL"] == NSOrderedSame) {
+            [[Branch getInstance] setConsumerProtectionAttributionLevel:BranchAttributionLevelMinimal];
+        } else if ([config.cppLevel caseInsensitiveCompare:@"NONE"] == NSOrderedSame) {
+            [[Branch getInstance] setConsumerProtectionAttributionLevel:BranchAttributionLevelNone];
+        } else {
+            NSLog(@"Invalid CPP Level set in branch.json: %@", config.cppLevel);
+        }
+    }
 
     return self;
 }
@@ -632,7 +646,7 @@ static NSString *bnc_branchKey = nil;
 
 #pragma mark - Actual Init Session
 
-- (void)initSessionWithLaunchOptions:(NSDictionary *)options isReferrable:(BOOL)isReferrable explicitlyRequestedReferrable:(BOOL)explicitlyRequestedReferrable automaticallyDisplayController:(BOOL)automaticallyDisplayController registerDeepLinkHandlerUsingBranchUniversalObject:(callbackWithBranchUniversalObject)callback {    
+- (void)initSessionWithLaunchOptions:(NSDictionary *)options isReferrable:(BOOL)isReferrable explicitlyRequestedReferrable:(BOOL)explicitlyRequestedReferrable automaticallyDisplayController:(BOOL)automaticallyDisplayController registerDeepLinkHandlerUsingBranchUniversalObject:(callbackWithBranchUniversalObject)callback {
     [self initSceneSessionWithLaunchOptions:options isReferrable:isReferrable explicitlyRequestedReferrable:explicitlyRequestedReferrable automaticallyDisplayController:automaticallyDisplayController
                     registerDeepLinkHandler:^(BNCInitSessionResponse * _Nullable initResponse, NSError * _Nullable error) {
         if (callback) {
@@ -1107,8 +1121,8 @@ static NSString *bnc_branchKey = nil;
 
     if (self.deepLinkDebugParams) {
         NSMutableDictionary* debugInstallParams =
-			[[BNCEncodingUtils decodeJsonStringToDictionary:self.preferenceHelper.sessionParams]
-				mutableCopy];
+            [[BNCEncodingUtils decodeJsonStringToDictionary:self.preferenceHelper.sessionParams]
+                mutableCopy];
         [debugInstallParams addEntriesFromDictionary:self.deepLinkDebugParams];
         return debugInstallParams;
     }
@@ -2051,7 +2065,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 // only called from initUserSessionAndCallCallback!
 - (void)initializeSessionAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier urlString:(NSString *)urlString {
 
-	// BranchDelegate willStartSessionWithURL notification
+    // BranchDelegate willStartSessionWithURL notification
     NSURL *URL = (self.preferenceHelper.referringURL.length) ? [NSURL URLWithString:self.preferenceHelper.referringURL] : nil;
     if ([self.delegate respondsToSelector:@selector(branch:willStartSessionWithURL:)]) {
         [self.delegate branch:self willStartSessionWithURL:URL];
@@ -2116,7 +2130,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
             [self processNextQueueItem];
         });
-	}
+    }
 }
 
 

--- a/Sources/BranchSDK/BranchJsonConfig.m
+++ b/Sources/BranchSDK/BranchJsonConfig.m
@@ -18,7 +18,7 @@ NSString * _Nonnull const BranchJsonConfigDeferInitForPluginRuntimeOption = @"de
 NSString * _Nonnull const BranchJsonConfigEnableLogging = @"enableLogging";
 NSString * _Nonnull const BranchJsonConfigCheckPasteboardOnInstall = @"checkPasteboardOnInstall";
 NSString * _Nonnull const BranchJsonConfigAPIUrl = @"apiUrl";
-
+NSString * _Nonnull const BranchJsonConfigCPPLevel = @"consumerProtectionAttributionLevel";
 
 @interface BranchJsonConfig()
 @property (nonatomic, strong) NSDictionary *configuration;
@@ -161,6 +161,11 @@ NSString * _Nonnull const BranchJsonConfigAPIUrl = @"apiUrl";
 - (NSString *)apiUrl
 {
     return self[BranchJsonConfigAPIUrl];
+}
+
+- (NSString *)cppLevel
+{
+    return self[BranchJsonConfigCPPLevel];
 }
 
 - (id)objectForKey:(NSString *)key

--- a/Sources/BranchSDK/Private/BranchJsonConfig.h
+++ b/Sources/BranchSDK/Private/BranchJsonConfig.h
@@ -31,6 +31,7 @@ extern NSString * _Nonnull const BranchJsonConfigAPIUrl;
 @property (nonatomic, readonly, assign) BOOL enableLogging;
 @property (nonatomic, readonly, assign) BOOL checkPasteboardOnInstall;
 @property (nonatomic, readonly, nullable, copy) NSString *apiUrl;
+@property (nonatomic, readonly, nullable, copy) NSString *cppLevel;
 
 - (nullable id)objectForKey:(NSString * _Nonnull)key;
 - (nullable id)objectForKeyedSubscript:(NSString * _Nonnull)key;


### PR DESCRIPTION
## Reference
SDK-2522 -- Support CPP Level in Branch.json

## Summary
Added a check in the brach.json for the CPP Level

## Motivation
To support setting it early and in plugins easily.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Add `consumerProtectionAttributionLevel: "Full/Reduced/None"` to branch.json and observe the CPP level being changed.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
