### PR TITLE
[SDK-2527] Add request & response objects to the BranchLogCallback

### DIFF
--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -41,13 +41,21 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // test pre init support
     //[self testDispatchToIsolationQueue:branch]
     
-    
-    [Branch enableLoggingAtLevel:BranchLogLevelVerbose withCallback:^(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error) {
+    [Branch enableLoggingAtLevel:BranchLogLevelVerbose withCallback:^(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error, NSMutableURLRequest * _Nullable request, BNCServerResponse * _Nullable response) {
         // Handle the log message and error here. For example, printing to the console:
         if (error) {
             NSLog(@"[BranchLog] Level: %lu, Message: %@, Error: %@", (unsigned long)logLevel, message, error.localizedDescription);
         } else {
             NSLog(@"[BranchLog] Level: %lu, Message: %@", (unsigned long)logLevel, message);
+        }
+        
+        if (request) {
+            NSString *jsonString = [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding];
+            NSLog(@"[BranchLog] Got %@ Request: %@", request.URL , jsonString);
+        }
+        
+        if (response) {
+            NSLog(@"[BranchLog] Got %@ Response: %@", response, response.data);
         }
         
         NSString *logEntry = error ? [NSString stringWithFormat:@"Level: %lu, Message: %@, Error: %@", (unsigned long)logLevel, message, error.localizedDescription]

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -41,7 +41,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // test pre init support
     //[self testDispatchToIsolationQueue:branch]
     
-    [Branch enableLoggingAtLevel:BranchLogLevelVerbose withCallback:^(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error, NSMutableURLRequest * _Nullable request, BNCServerResponse * _Nullable response) {
+    [Branch enableLoggingAtLevel:BranchLogLevelVerbose withAdvancedCallback:^(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error, NSMutableURLRequest * _Nullable request, BNCServerResponse * _Nullable response) {
         // Handle the log message and error here. For example, printing to the console:
         if (error) {
             NSLog(@"[BranchLog] Level: %lu, Message: %@, Error: %@", (unsigned long)logLevel, message, error.localizedDescription);
@@ -55,7 +55,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
         }
         
         if (response) {
-            NSLog(@"[BranchLog] Got Response for request(%@): %@", response.requestId, response.data);
+            NSLog(@"[BranchLog] Got Response for request (%@): %@", response.requestId, response.data);
         }
         
         NSString *logEntry = error ? [NSString stringWithFormat:@"Level: %lu, Message: %@, Error: %@", (unsigned long)logLevel, message, error.localizedDescription]

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -55,7 +55,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
         }
         
         if (response) {
-            NSLog(@"[BranchLog] Got %@ Response: %@", response, response.data);
+            NSLog(@"[BranchLog] Got Response for request(%@): %@", response.requestId, response.data);
         }
         
         NSString *logEntry = error ? [NSString stringWithFormat:@"Level: %lu, Message: %@, Error: %@", (unsigned long)logLevel, message, error.localizedDescription]

--- a/Sources/BranchSDK/BNCServerInterface.m
+++ b/Sources/BranchSDK/BNCServerInterface.m
@@ -289,7 +289,7 @@
     [request setHTTPBody:postData];
     
     if ([[BranchLogger shared] shouldLog:BranchLogLevelDebug]) {
-        [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"%@\nHeaders %@\nBody %@", request, [request allHTTPHeaderFields], [BNCEncodingUtils prettyPrintJSON:updatedParams]] error:nil];
+        [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"%@\nHeaders %@\nBody %@", request, [request allHTTPHeaderFields], [BNCEncodingUtils prettyPrintJSON:updatedParams]] error:nil request:request response:nil];
     }
     
     return request;
@@ -310,7 +310,7 @@
         serverResponse.requestId = requestId;
      
         if ([[BranchLogger shared] shouldLog:BranchLogLevelDebug]) {
-            [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"%@\nBody %@", response, [BNCEncodingUtils prettyPrintJSON:serverResponse.data]] error:nil];
+            [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"%@\nBody %@", response, [BNCEncodingUtils prettyPrintJSON:serverResponse.data]] error:nil request:nil response:serverResponse];
         }
         
     } else {

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -455,6 +455,15 @@ static NSString *bnc_branchKey = nil;
     }
 }
 
++ (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withAdvancedCallback:(nullable BranchAdvancedLogCallback)callback {
+    BranchLogger *logger = [BranchLogger shared];
+    logger.loggingEnabled = YES;
+    logger.logLevelThreshold = logLevel;
+    if (callback) {
+        logger.advancedLogCallback = callback;
+    }
+}
+
 - (void)useEUEndpoints {
     [BNCServerAPI sharedInstance].useEUServers = YES;
 }

--- a/Sources/BranchSDK/BranchLogger.m
+++ b/Sources/BranchSDK/BranchLogger.m
@@ -25,15 +25,6 @@
             os_log_type_t osLogType = [BranchLogger osLogTypeForBranchLogLevel:logLevel];
             os_log_with_type(log, osLogType, "%{private}@", formattedMessage);
         };
-        
-        // default advanced callback sends logs to os_log
-        _advancedLogCallback = ^(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error, NSMutableURLRequest * _Nullable request, BNCServerResponse * _Nullable response) {
-            NSString *formattedMessage = [BranchLogger formatMessage:message logLevel:logLevel error:error];
-            
-            os_log_t log = os_log_create("io.branch.sdk", "BranchSDK");
-            os_log_type_t osLogType = [BranchLogger osLogTypeForBranchLogLevel:logLevel];
-            os_log_with_type(log, osLogType, "%{private}@", formattedMessage);
-        };
     }
     return self;
 }

--- a/Sources/BranchSDK/BranchLogger.m
+++ b/Sources/BranchSDK/BranchLogger.m
@@ -18,7 +18,7 @@
         _includeCallerDetails = YES;
         
         // default callback sends logs to os_log
-        _logCallback = ^(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error) {
+        _logCallback = ^(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error, NSMutableURLRequest * _Nullable request, BNCServerResponse * _Nullable response) {
             NSString *formattedMessage = [BranchLogger formatMessage:message logLevel:logLevel error:error];
             
             os_log_t log = os_log_create("io.branch.sdk", "BranchSDK");
@@ -53,22 +53,29 @@
 }
 
 - (void)logError:(NSString *)message error:(NSError *_Nullable)error {
-    [self logMessage:message withLevel:BranchLogLevelError error:error];
+    [self logMessage:message withLevel:BranchLogLevelError error:error request:nil response:nil];
 }
 
 - (void)logWarning:(NSString *)message error:(NSError *_Nullable)error {
-    [self logMessage:message withLevel:BranchLogLevelWarning error:error];
+    [self logMessage:message withLevel:BranchLogLevelWarning error:error request:nil response:nil];
 }
 
-- (void)logDebug:(NSString *)message error:(NSError *_Nullable)error {
-    [self logMessage:message withLevel:BranchLogLevelDebug error:error];
+- (void)logDebug:(NSString * _Nonnull)message error:(NSError * _Nullable)error {
+    [self logDebug:message error:error request:nil response:nil];
+}
+
+- (void)logDebug:(NSString * _Nonnull)message
+           error:(NSError * _Nullable)error
+         request:(NSMutableURLRequest * _Nullable)request
+        response:(BNCServerResponse * _Nullable)response {
+    [self logMessage:message withLevel:BranchLogLevelDebug error:error request:request response:response];
 }
 
 - (void)logVerbose:(NSString *)message error:(NSError *_Nullable)error {
-    [self logMessage:message withLevel:BranchLogLevelVerbose error:error];
+    [self logMessage:message withLevel:BranchLogLevelVerbose error:error request:nil response:nil];
 }
 
-- (void)logMessage:(NSString *)message withLevel:(BranchLogLevel)level error:(NSError *_Nullable)error {
+- (void)logMessage:(NSString *)message withLevel:(BranchLogLevel)level error:(NSError *_Nullable)error request:(NSMutableURLRequest * _Nullable)request response:(BNCServerResponse * _Nullable)response {
     if (!self.loggingEnabled || level < self.logLevelThreshold || message.length == 0) {
         return;
     }
@@ -79,7 +86,7 @@
     }
 
     if (self.logCallback) {
-        self.logCallback(formattedMessage, level, error);
+        self.logCallback(formattedMessage, level, error, request, response);
     }
 }
 

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -568,6 +568,7 @@ extern NSString * __nonnull const BNCSpotlightFeature;
  */
 + (void)enableLogging;
 + (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withCallback:(nullable BranchLogCallback)callback;
++ (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withAdvancedCallback:(nullable BranchAdvancedLogCallback)callback;
 
 // The new logging system is independent of the Branch singleton and can be called earlier.
 - (void)enableLogging __attribute__((deprecated(("This API is deprecated. Please use the static version."))));

--- a/Sources/BranchSDK/Public/BranchLogger.h
+++ b/Sources/BranchSDK/Public/BranchLogger.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "BNCServerResponse.h"
 
 typedef NS_ENUM(NSUInteger, BranchLogLevel) {
     BranchLogLevelVerbose, // development
@@ -15,7 +16,7 @@ typedef NS_ENUM(NSUInteger, BranchLogLevel) {
     BranchLogLevelError,   // severe errors. SDK is probably in a bad state.
 };
 
-typedef void(^BranchLogCallback)(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error);
+typedef void(^BranchLogCallback)(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error, NSMutableURLRequest * _Nullable request, BNCServerResponse * _Nullable response);
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -37,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)logError:(NSString * _Nonnull)message error:(NSError * _Nullable)error;
 - (void)logWarning:(NSString * _Nonnull)message error:(NSError * _Nullable)error;
 - (void)logDebug:(NSString * _Nonnull)message error:(NSError * _Nullable)error;
+- (void)logDebug:(NSString * _Nonnull)message error:(NSError * _Nullable)error request:(NSMutableURLRequest * _Nullable)request response:(BNCServerResponse * _Nullable)response;
 - (void)logVerbose:(NSString * _Nonnull)message error:(NSError * _Nullable)error;
 
 // default Branch log format

--- a/Sources/BranchSDK/Public/BranchLogger.h
+++ b/Sources/BranchSDK/Public/BranchLogger.h
@@ -16,7 +16,8 @@ typedef NS_ENUM(NSUInteger, BranchLogLevel) {
     BranchLogLevelError,   // severe errors. SDK is probably in a bad state.
 };
 
-typedef void(^BranchLogCallback)(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error, NSMutableURLRequest * _Nullable request, BNCServerResponse * _Nullable response);
+typedef void(^BranchLogCallback)(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error);
+typedef void(^BranchAdvancedLogCallback)(NSString * _Nonnull message, BranchLogLevel logLevel, NSError * _Nullable error, NSMutableURLRequest * _Nullable request, BNCServerResponse * _Nullable response);
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL loggingEnabled;
 @property (nonatomic, assign) BOOL includeCallerDetails;
 @property (nonatomic, copy, nullable) BranchLogCallback logCallback;
+@property (nonatomic, copy, nullable) BranchAdvancedLogCallback advancedLogCallback;
 @property (nonatomic, assign) BranchLogLevel logLevelThreshold;
 
 + (instancetype _Nonnull)shared;


### PR DESCRIPTION
## Reference
SDK-2427 -- Add request & response objects to the BranchLogCallback

## Summary
<!-- Simple summary of what was changed. -->
Updates the BranchLogCallback to include the request and response objects themselves rather than just include the data in the log message.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Make it easier to parse networking logs.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Try out the new BranchLogCallback with the request and response. This is a breaking change since it adds new fields to the BranchLogCallback

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
