### PR TITLE
Misc Bug Fixes : SDK-2530, SDK-2532

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCServerInterfaceTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCServerInterfaceTests.m
@@ -1,0 +1,43 @@
+//
+//  BNCServerInterfaceTests.m
+//  Branch-SDK-Tests
+//
+//  Created by Nidhi Dixit on 1/7/25.
+//  Copyright © 2025 Branch, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "Branch/BNCServerInterface.h"
+
+@interface BNCServerInterface()
+- (BOOL)isLinkingRelatedRequest:(NSString *)endpoint postParams:(NSDictionary *)post;
+@end
+
+@interface BNCServerInterfaceTests : XCTestCase
+@end
+
+@implementation BNCServerInterfaceTests
+
+- (void)testIsLinkingRelatedRequest {
+    
+    BNCServerInterface *serverInterface = [[BNCServerInterface alloc] init];
+    
+    // install
+    XCTAssertTrue([serverInterface isLinkingRelatedRequest:@"/v1/install" postParams:nil]);
+    
+    // open
+    XCTAssertFalse([serverInterface isLinkingRelatedRequest:@"/v1/open" postParams:nil]);
+    XCTAssertFalse([serverInterface isLinkingRelatedRequest:@"/v1/open" postParams:@{}]);
+    XCTAssertTrue([serverInterface isLinkingRelatedRequest:@"/v1/open" postParams:@{@"spotlight_identifier":@"io.branch.link.v1.url.testbed.app.link/1234"}]);
+    XCTAssertTrue([serverInterface isLinkingRelatedRequest:@"/v1/open" postParams:@{@"link_identifier": @"1305991233204308323"}]);
+    XCTAssertTrue([serverInterface isLinkingRelatedRequest:@"/v1/open" postParams:@{@"universal_link_url":@"branchtest://open?_branch_referrer=H4sIAAAAAAAAA8soKSkottLXT8pLLkktLklKTd"}]);
+    XCTAssertFalse([serverInterface isLinkingRelatedRequest:@"/v1/open" postParams:@{@"uri_scheme" : @"branchtest"}]);
+    
+    // v2/event
+    XCTAssertFalse([serverInterface isLinkingRelatedRequest:@"/v2/event" postParams:@{@"spotlight_identifier":@"io.branch.link.v1.url.testbed.app.link/1234"}]);
+    
+    // v1/url
+    XCTAssertTrue([serverInterface isLinkingRelatedRequest:@"/v1/url" postParams:nil]);
+
+}
+@end

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 		C17DAF7B2AC20C2000B16B1A /* BranchClassTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C17DAF7A2AC20C2000B16B1A /* BranchClassTests.m */; };
 		C1CC888229BAAFC000BDD2B5 /* BNCReferringURLUtilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1CC888129BAAFC000BDD2B5 /* BNCReferringURLUtilityTests.m */; };
 		E72489D228E40D0200DCD8FD /* PasteControlViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E72489D128E40D0200DCD8FD /* PasteControlViewController.m */; };
+		E74B54402D2DB0660049A89D /* BNCServerInterfaceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E74B543F2D2DB0660049A89D /* BNCServerInterfaceTests.m */; };
 		E7A728BD2AA9A112009343B7 /* BNCAPIServerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A728BC2AA9A112009343B7 /* BNCAPIServerTest.m */; };
 		F1CF14111F4CC79F00BB2694 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 /* End PBXBuildFile section */
@@ -538,6 +539,7 @@
 		C1CC888129BAAFC000BDD2B5 /* BNCReferringURLUtilityTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCReferringURLUtilityTests.m; sourceTree = "<group>"; };
 		E72489D028E40D0200DCD8FD /* PasteControlViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PasteControlViewController.h; sourceTree = "<group>"; };
 		E72489D128E40D0200DCD8FD /* PasteControlViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PasteControlViewController.m; sourceTree = "<group>"; };
+		E74B543F2D2DB0660049A89D /* BNCServerInterfaceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCServerInterfaceTests.m; sourceTree = "<group>"; };
 		E7A728BC2AA9A112009343B7 /* BNCAPIServerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCAPIServerTest.m; sourceTree = "<group>"; };
 		F1D4F9AC1F323F01002D13FF /* Branch-TestBed-UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Branch-TestBed-UITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -648,6 +650,7 @@
 				5F8650192B76DA3200364BDE /* NSMutableDictionaryBranchTests.m */,
 				4D16839E2098C901008819E3 /* NSStringBranchTests.m */,
 				5F6D86D82BB5E9650068B536 /* BNCClassSerializationTests.m */,
+				E74B543F2D2DB0660049A89D /* BNCServerInterfaceTests.m */,
 			);
 			path = "Branch-SDK-Tests";
 			sourceTree = "<group>";
@@ -1360,6 +1363,7 @@
 			files = (
 				4D1683B82098C902008819E3 /* BNCEncodingUtilsTests.m in Sources */,
 				5F909B5E23314CE900A774D2 /* BNCJSONUtilityTests.m in Sources */,
+				E74B54402D2DB0660049A89D /* BNCServerInterfaceTests.m in Sources */,
 				5F909B722332BEF600A774D2 /* BranchLastAttributedTouchDataTests.m in Sources */,
 				5FC20E732A93D85F00D9E1C8 /* BNCRequestFactoryTests.m in Sources */,
 				5FA9112F29BC662000F3D35C /* BNCNetworkInterfaceTests.m in Sources */,

--- a/Sources/BranchSDK/BNCServerInterface.m
+++ b/Sources/BranchSDK/BNCServerInterface.m
@@ -177,7 +177,7 @@
 
 - (BOOL)isLinkingRelatedRequest:(NSString *)endpoint postParams:(NSDictionary *)post {
    
-    BOOL hasIdentifier = (post[BRANCH_REQUEST_KEY_LINK_IDENTIFIER] != nil ) || (post[BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER] != nil) || (post[BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL] != nil); // ND - Fix it
+    BOOL hasIdentifier = (post[BRANCH_REQUEST_KEY_LINK_IDENTIFIER] != nil ) || (post[BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER] != nil) || (post[BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL] != nil);
     
     // Allow install to resolve a link.
     if ([endpoint containsString:@"/v1/install"]) {

--- a/Sources/BranchSDK/BNCServerInterface.m
+++ b/Sources/BranchSDK/BNCServerInterface.m
@@ -177,7 +177,7 @@
 
 - (BOOL)isLinkingRelatedRequest:(NSString *)endpoint postParams:(NSDictionary *)post {
    
-    BOOL hasIdentifier = (post[BRANCH_REQUEST_KEY_LINK_IDENTIFIER] != nil ) || (post[BRANCH_REQUEST_KEY_LINK_IDENTIFIER] != nil) || (post[BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL] != nil);
+    BOOL hasIdentifier = (post[BRANCH_REQUEST_KEY_LINK_IDENTIFIER] != nil ) || (post[BRANCH_REQUEST_KEY_SPOTLIGHT_IDENTIFIER] != nil) || (post[BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL] != nil); // ND - Fix it
     
     // Allow install to resolve a link.
     if ([endpoint containsString:@"/v1/install"]) {

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -704,18 +704,18 @@ static NSString *bnc_branchKey = nil;
     self.shouldAutomaticallyDeepLink = automaticallyDisplayController;
 
     // Check for Branch link in a push payload
-    BranchOpenRequestLinkParams *params = [[BranchOpenRequestLinkParams alloc] init];
+    BOOL appLaunchViaPushNotification = NO;
     #if !TARGET_OS_TV
     if ([options objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey]) {
         id branchUrlFromPush = [options objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey][BRANCH_PUSH_NOTIFICATION_PAYLOAD_KEY];
         if ([branchUrlFromPush isKindOfClass:[NSString class]]) {
-            params.referringURL = (NSString *)branchUrlFromPush;
+            appLaunchViaPushNotification = YES;
         }
     }
     #endif
 
-    if(params.referringURL || [[options objectForKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"] isEqualToNumber:@1] || (![options.allKeys containsObject:UIApplicationLaunchOptionsURLKey] && ![options.allKeys containsObject:UIApplicationLaunchOptionsUserActivityDictionaryKey]) ) {
-        [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlParams:params reset:NO];
+    if( [[options objectForKey:@"BRANCH_DEFER_INIT_FOR_PLUGIN_RUNTIME_KEY"] isEqualToNumber:@1] || (![options.allKeys containsObject:UIApplicationLaunchOptionsURLKey] && ![options.allKeys containsObject:UIApplicationLaunchOptionsUserActivityDictionaryKey] && !appLaunchViaPushNotification)) {
+        [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlParams:nil reset:NO];
     }
 }
 


### PR DESCRIPTION
## Reference
SDK-2530 -- Fix Init Race for Push notifications
https://branch.atlassian.net/browse/SDK-2530

SDK-2532 -- If tracking is disabled and app is launched via spotlight results, linking request is not sent.
https://branch.atlassian.net/browse/SDK-2532

## Summary
Fixes :
* Push notifications are handled via `handlePushNotification` API which is called inside didReceiveRemoteNotification. So `initSessionWithLaunchOptions` is updated to not to send and extra open and call callback if app is launched via push notification.
* Fixed isLinkingRelatedRequest function to allow opens if tracking is disabled and spotlight identifier is present.

## Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

* Launch App via push notification and verify  initsession callback is called only once ( cold launch app, warm launch + active app , warm launch + background app )
* Disable tracking and launch app vi Spotlight results or any link having spotlight identifier and verify open request was sent.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
