### PR TITLE
SDK-2533 Integration validator crash fix

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCSystemObserverTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCSystemObserverTests.m
@@ -9,6 +9,10 @@
 #import <XCTest/XCTest.h>
 #import "BNCSystemObserver.h"
 
+@interface BNCSystemObserver ()
++ (BOOL)compareUriSchemes:(NSString *)serverUriScheme With:(NSArray *)urlTypes;
+@end
+
 @interface BNCSystemObserverTests : XCTestCase
 
 @end
@@ -98,6 +102,37 @@
 - (void)testIsAppClip {
     // currently not running unit tests on extensions
     XCTAssert(![BNCSystemObserver isAppClip]);
+}
+
+- (void)testCompareURIScemes {
+    
+    NSString *serverUriScheme = @"bnctest://";
+    NSArray *urlTypes = @[@{@"CFBundleURLSchemes" : @[@""]}, @{@"CFBundleURLSchemes" : @[@"bnctest", @"xyzs"]}];
+    
+    XCTAssertTrue([BNCSystemObserver compareUriSchemes:serverUriScheme With:urlTypes]);
+    
+    XCTAssertFalse([BNCSystemObserver compareUriSchemes:serverUriScheme With:nil]);
+    
+    XCTAssertFalse([BNCSystemObserver compareUriSchemes:nil With:nil]);
+    
+    XCTAssertFalse([BNCSystemObserver compareUriSchemes:nil With:urlTypes]);
+    
+    serverUriScheme = @":/";
+    XCTAssertFalse([BNCSystemObserver compareUriSchemes:serverUriScheme With:urlTypes]);
+    
+    serverUriScheme = @"bnctest";
+    XCTAssertTrue([BNCSystemObserver compareUriSchemes:serverUriScheme With:urlTypes]);
+    
+    serverUriScheme = @"bnctest://";
+    urlTypes = @[ @{@"CFBundleURLSchemes" : @[@"bnctestX", @"xyzs"]}];
+    XCTAssertFalse([BNCSystemObserver compareUriSchemes:serverUriScheme With:urlTypes]);
+    
+    serverUriScheme = @"://";
+    XCTAssertFalse([BNCSystemObserver compareUriSchemes:serverUriScheme With:urlTypes]);
+    
+    XCTAssertFalse([BNCSystemObserver compareUriSchemes:@"" With:urlTypes]);
+    
+    XCTAssertFalse([BNCSystemObserver compareUriSchemes:@"" With:@[@{}]]);
 }
 
 @end

--- a/Sources/BranchSDK/BNCSystemObserver.m
+++ b/Sources/BranchSDK/BNCSystemObserver.m
@@ -150,14 +150,25 @@
 
 + (BOOL)compareUriSchemes : (NSString *) serverUriScheme {
     NSArray *urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
+    return [self compareUriSchemes:serverUriScheme With:urlTypes];
+}
+
++ (BOOL)compareUriSchemes:(NSString *)serverUriScheme With:(NSArray *)urlTypes {
+    NSString * serverUriSchemeWithoutSuffix ;
+    
+    if ([serverUriScheme hasSuffix:@"://"]) {
+        serverUriSchemeWithoutSuffix = [serverUriScheme substringToIndex:[serverUriScheme length] - 3];
+    } else {
+        serverUriSchemeWithoutSuffix = serverUriScheme;
+    }
 
     for (NSDictionary *urlType in urlTypes) {
 
         NSArray *urlSchemes = [urlType objectForKey:@"CFBundleURLSchemes"];
         for (NSString *uriScheme in urlSchemes) {
-            NSString * serverUriSchemeWithoutSuffix = [serverUriScheme substringToIndex:[serverUriScheme length] - 3];
             if ([uriScheme isEqualToString:serverUriSchemeWithoutSuffix]) {
-                return true; }
+                return true;
+            }
         }
     }
     return false;


### PR DESCRIPTION

## Reference
SDK-2533 -- Integration Validator crashes if URI scheme is not set (null) in dashboard.
https://branch.atlassian.net/browse/SDK-2533

Related Github Issue - https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/issues/1463 

## Summary
* Fixed function `compareUriSchemes` to handle empty strings
* Added wrapper function for `compareUriSchemes` to make it testable.
* Added unit test

## Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Delete URI scheme from the branch dashboard for the app and run integration validator. It should not crash and display message for mismatch. 


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
