### PR TITLE
[INTENG-21518] Fix for compilation issue on tvOS

### DIFF
--- a/Framework/BranchSDK.h
+++ b/Framework/BranchSDK.h
@@ -30,14 +30,10 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 
 #import <BranchSDK/BranchDeepLinkingController.h>
 
-#if !TARGET_OS_TV
-// tvOS does not support these features
 #import <BranchSDK/BranchShareLink.h>
 #import <BranchSDK/BranchCSSearchableItemAttributeSet.h>
 #import <BranchSDK/BranchActivityItemProvider.h>
-
 #import <BranchSDK/BranchPasteControl.h>
-#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import <BranchSDK/BNCInitSessionResponse.h>

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,14 +30,11 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if !TARGET_OS_TV
-// tvOS does not support these features
+
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"
-
 #import "BranchPasteControl.h"
-#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import "BNCInitSessionResponse.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,12 +30,10 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if !TARGET_OS_TV
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"
 #import "BranchPasteControl.h"
-#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import "BNCInitSessionResponse.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,11 +30,12 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-
+#if !TARGET_OS_TV
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"
 #import "BranchPasteControl.h"
+#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import "BNCInitSessionResponse.h"


### PR DESCRIPTION
## Reference
INTENG-21518

## Summary
Removed a check for tvOS when including certain files in the umbrella header. Since the files themselves contain the tvOS checks, this one appears to be unnecessary and caused Xcode to be unable to locate these files when building an app with the SDK.

## Motivation
Fix for clients using tvOS apps.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Compile and run the app to make sure it still builds on different integrations as well.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
