### PR TITLE
Removed 'nullable' attribute of BranchAdvancedLogCallback param

### DIFF
--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -469,7 +469,7 @@ static NSString *bnc_branchKey = nil;
     }
 }
 
-+ (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withAdvancedCallback:(nullable BranchAdvancedLogCallback)callback {
++ (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withAdvancedCallback:(BranchAdvancedLogCallback)callback {
     BranchLogger *logger = [BranchLogger shared];
     logger.loggingEnabled = YES;
     logger.logLevelThreshold = logLevel;

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -568,7 +568,7 @@ extern NSString * __nonnull const BNCSpotlightFeature;
  */
 + (void)enableLogging;
 + (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withCallback:(nullable BranchLogCallback)callback;
-+ (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withAdvancedCallback:(nullable BranchAdvancedLogCallback)callback;
++ (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withAdvancedCallback:(BranchAdvancedLogCallback)callback;
 
 // The new logging system is independent of the Branch singleton and can be called earlier.
 - (void)enableLogging __attribute__((deprecated(("This API is deprecated. Please use the static version."))));


### PR DESCRIPTION
## Reference
SDK-2537 -- Fix enableLogging API error - Ambiguous use of 'enableLogging'
https://branch.atlassian.net/browse/SDK-2537

## Summary

Following are two overloaded versions of static API `enableLoggingAtLevel` and both had the second param `nullable` attribute. This resulted in two methods with same name and same param.

```
+ (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withCallback:(nullable BranchLogCallback)callback;
+ (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withAdvancedCallback:(nullable  BranchAdvancedLogCallback)callback;
```

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
In a test app, call API ` Branch.enableLogging(at: .verbose)`. Compile app to see we no longer get Build error.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
