### PR TITLE
INTENG-21518 - SPM + Hybrid app compilation issue.

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run unit tests
         run: bundle exec fastlane unit_tests
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() # even if tests fail
         with:
           name: test-results

--- a/BranchSDK.podspec
+++ b/BranchSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "BranchSDK"
-  s.version          = "3.6.5"
+  s.version          = "3.9.0"
   s.summary          = "Create an HTTP URL for any piece of content in your app"
   s.description      = <<-DESC
 - Want the highest possible conversions on your sharing feature?
@@ -25,11 +25,6 @@ Use the Branch SDK (branch.io) to create and power the links that point back to 
   s.tvos.exclude_files = "Sources/BranchSDK/**/BNCContentDiscoveryManager.{h,m}",
 	"Sources/BranchSDK/**/BNCUserAgentCollector.{h,m}",
 	"Sources/BranchSDK/**/BNCSpotlightService.{h,m}",
-	"Sources/BranchSDK/**/BranchActivityItemProvider.{h,m}",
-	"Sources/BranchSDK/**/BranchCSSearchableItemAttributeSet.{h,m}",
-	"Sources/BranchSDK/**/BranchShareLink.{h,m}",
-	"Sources/BranchSDK/**/BranchPasteControl.{h,m}"
-
   s.frameworks = 'CoreServices', 'SystemConfiguration'
   s.weak_framework = 'LinkPresentation'
   s.ios.frameworks = 'WebKit'

--- a/BranchSDK.xcodeproj/project.pbxproj
+++ b/BranchSDK.xcodeproj/project.pbxproj
@@ -250,7 +250,7 @@
 		5FCDD4B82B7AC6A200EAF29F /* BNCServerRequestQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3AA2B7AC6A100EAF29F /* BNCServerRequestQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5FCDD4B92B7AC6A200EAF29F /* BranchPasteControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3AB2B7AC6A100EAF29F /* BranchPasteControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5FCDD4BA2B7AC6A200EAF29F /* BranchPasteControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3AB2B7AC6A100EAF29F /* BranchPasteControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		5FCDD4BB2B7AC6A200EAF29F /* BranchPasteControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3AB2B7AC6A100EAF29F /* BranchPasteControl.h */; };
+		5FCDD4BB2B7AC6A200EAF29F /* BranchPasteControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3AB2B7AC6A100EAF29F /* BranchPasteControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5FCDD4BC2B7AC6A200EAF29F /* BranchUniversalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3AC2B7AC6A100EAF29F /* BranchUniversalObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5FCDD4BD2B7AC6A200EAF29F /* BranchUniversalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3AC2B7AC6A100EAF29F /* BranchUniversalObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5FCDD4BE2B7AC6A200EAF29F /* BranchUniversalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3AC2B7AC6A100EAF29F /* BranchUniversalObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1162,6 +1162,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5FCDD4BB2B7AC6A200EAF29F /* BranchPasteControl.h in Headers */,
 				5FCDD5302B7AC6A300EAF29F /* Branch+Validator.h in Headers */,
 				5FCDD4A62B7AC6A200EAF29F /* BNCCallbacks.h in Headers */,
 				5FCDD4942B7AC6A100EAF29F /* BranchLinkProperties.h in Headers */,
@@ -1227,7 +1228,6 @@
 				5FCDD51B2B7AC6A300EAF29F /* NSError+Branch.h in Headers */,
 				5FCDD5032B7AC6A300EAF29F /* BranchOpenRequest.h in Headers */,
 				5FCDD4F72B7AC6A200EAF29F /* BNCEventUtils.h in Headers */,
-				5FCDD4BB2B7AC6A200EAF29F /* BranchPasteControl.h in Headers */,
 				5FCDD5632B7AC6A300EAF29F /* BNCReachability.h in Headers */,
 				5FCDD50F2B7AC6A300EAF29F /* NSMutableDictionary+Branch.h in Headers */,
 				5FCDD4D92B7AC6A200EAF29F /* BNCAppleReceipt.h in Headers */,

--- a/Framework/BranchSDK.h
+++ b/Framework/BranchSDK.h
@@ -30,14 +30,10 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 
 #import <BranchSDK/BranchDeepLinkingController.h>
 
-#if !TARGET_OS_TV
-// tvOS does not support these features
 #import <BranchSDK/BranchShareLink.h>
 #import <BranchSDK/BranchCSSearchableItemAttributeSet.h>
 #import <BranchSDK/BranchActivityItemProvider.h>
-
 #import <BranchSDK/BranchPasteControl.h>
-#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import <BranchSDK/BNCInitSessionResponse.h>

--- a/Framework/BranchSDK.h
+++ b/Framework/BranchSDK.h
@@ -30,10 +30,14 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 
 #import <BranchSDK/BranchDeepLinkingController.h>
 
+#if !TARGET_OS_TV
+// tvOS does not support these features
 #import <BranchSDK/BranchShareLink.h>
 #import <BranchSDK/BranchCSSearchableItemAttributeSet.h>
 #import <BranchSDK/BranchActivityItemProvider.h>
+
 #import <BranchSDK/BranchPasteControl.h>
+#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import <BranchSDK/BNCInitSessionResponse.h>

--- a/Framework/BranchSDK.h
+++ b/Framework/BranchSDK.h
@@ -30,7 +30,7 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 
 #import <BranchSDK/BranchDeepLinkingController.h>
 
-#if !TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_MAC || TARGET_OS_WATCH
 // tvOS does not support these features
 #import <BranchSDK/BranchShareLink.h>
 #import <BranchSDK/BranchCSSearchableItemAttributeSet.h>

--- a/Framework/BranchSDK.h
+++ b/Framework/BranchSDK.h
@@ -30,8 +30,7 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 
 #import <BranchSDK/BranchDeepLinkingController.h>
 
-#if TARGET_OS_IOS
-// tvOS does not support these features
+#if TARGET_OS_IPHONE
 #import <BranchSDK/BranchShareLink.h>
 #import <BranchSDK/BranchCSSearchableItemAttributeSet.h>
 #import <BranchSDK/BranchActivityItemProvider.h>

--- a/Framework/BranchSDK.h
+++ b/Framework/BranchSDK.h
@@ -30,7 +30,7 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 
 #import <BranchSDK/BranchDeepLinkingController.h>
 
-#if TARGET_OS_IOS || TARGET_OS_MAC
+#if TARGET_OS_IOS
 // tvOS does not support these features
 #import <BranchSDK/BranchShareLink.h>
 #import <BranchSDK/BranchCSSearchableItemAttributeSet.h>

--- a/Framework/BranchSDK.h
+++ b/Framework/BranchSDK.h
@@ -30,7 +30,7 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 
 #import <BranchSDK/BranchDeepLinkingController.h>
 
-#if TARGET_OS_IOS || TARGET_OS_MAC || TARGET_OS_WATCH
+#if TARGET_OS_IOS || TARGET_OS_MAC
 // tvOS does not support these features
 #import <BranchSDK/BranchShareLink.h>
 #import <BranchSDK/BranchCSSearchableItemAttributeSet.h>

--- a/Framework/BranchSDK.h
+++ b/Framework/BranchSDK.h
@@ -30,14 +30,10 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 
 #import <BranchSDK/BranchDeepLinkingController.h>
 
-#if TARGET_OS_IOS || TARGET_OS_SIMULATOR
-// tvOS does not support these features
 #import <BranchSDK/BranchShareLink.h>
 #import <BranchSDK/BranchCSSearchableItemAttributeSet.h>
 #import <BranchSDK/BranchActivityItemProvider.h>
-
 #import <BranchSDK/BranchPasteControl.h>
-#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import <BranchSDK/BNCInitSessionResponse.h>

--- a/Framework/BranchSDK.h
+++ b/Framework/BranchSDK.h
@@ -30,7 +30,8 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 
 #import <BranchSDK/BranchDeepLinkingController.h>
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS || TARGET_OS_SIMULATOR
+// tvOS does not support these features
 #import <BranchSDK/BranchShareLink.h>
 #import <BranchSDK/BranchCSSearchableItemAttributeSet.h>
 #import <BranchSDK/BranchActivityItemProvider.h>

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,7 +30,7 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if TARGET_OS_IOS || TARGET_OS_MAC
+#if TARGET_OS_IOS
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,14 +30,11 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if !TARGET_OS_TV
-// tvOS does not support these features
+
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"
-
 #import "BranchPasteControl.h"
-#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import "BNCInitSessionResponse.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,7 +30,7 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if TARGET_OS_IOS || TARGET_OS_MAC || TARGET_OS_WATCH
+#if TARGET_OS_IOS || TARGET_OS_MAC
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,7 +30,7 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS || TARGET_OS_SIMULATOR
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,10 +30,12 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
+#if !TARGET_OS_TV
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"
 #import "BranchPasteControl.h"
+#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import "BNCInitSessionResponse.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,12 +30,13 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if TARGET_OS_IOS || TARGET_OS_SIMULATOR
+#if TARGET_OS_IOS || (TARGET_OS_SIMULATOR && !TARGET_OS_TVOS)
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"
 #import "BranchPasteControl.h"
 #endif
+
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import "BNCInitSessionResponse.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,7 +30,7 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if !TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_MAC || TARGET_OS_WATCH
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,13 +30,10 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if TARGET_OS_IOS || (TARGET_OS_SIMULATOR && !TARGET_OS_TVOS)
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"
 #import "BranchPasteControl.h"
-#endif
-
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import "BNCInitSessionResponse.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,12 +30,10 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if !TARGET_OS_TV
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"
 #import "BranchPasteControl.h"
-#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import "BNCInitSessionResponse.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,7 +30,7 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IPHONE
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"

--- a/Sources/BranchSDK/Public/BranchSDK.h
+++ b/Sources/BranchSDK/Public/BranchSDK.h
@@ -30,11 +30,12 @@ FOUNDATION_EXPORT const unsigned char BranchSDKVersionString[];
 #import "BranchDeepLinkingController.h"
 #import "BranchLogger.h"
 
-
+#if !TARGET_OS_TV
 #import "BranchShareLink.h"
 #import "BranchCSSearchableItemAttributeSet.h"
 #import "BranchActivityItemProvider.h"
 #import "BranchPasteControl.h"
+#endif
 
 // Used by Branch.h for debug and testing APIs. Need to move these.
 #import "BNCInitSessionResponse.h"


### PR DESCRIPTION
## Reference
INTENG-21518 : tvOS v3.5.1 and v3.6.4 are throwing compilation errors addressed in previous INTENG due to clients updated implementation
https://branch.atlassian.net/browse/INTENG-21518

## Summary

Branch SDK umbrella header file is common for all the platforms. Some files are for iOS platform only. Branch SDK handles platform specific code using preprocessor checks.  Module map and SPM manifest file has also configuration common for all the platforms. This works fine if app is iOS only or tvOS only. But it fails for a hybrid app.

This PR includes following workarounds :

SPM :  Removed a check for tvOS when including certain files in the umbrella header. Since the files themselves contain the tvOS checks, this one appears to be unnecessary and caused Xcode to be unable to locate these files when building an app with the SDK. 
Cocoa Pods: Removed explicit exclusion of files included in cocoa pod spec file.
Framework Binaries : Moved BranchPasteControl.h to Public folder for tvOS platform.

## Motivation
Fix for clients using tvOS apps.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Compile and run the app to make sure it still builds on different integrations.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
