### PR TITLE
Added  API setSafetrackAPIURL

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
@@ -457,6 +457,7 @@
     [BNCServerAPI sharedInstance].useEUServers = NO;
     [BNCServerAPI sharedInstance].automaticallyEnableTrackingDomain = YES;
     [BNCServerAPI sharedInstance].customAPIURL = nil;
+    [BNCServerAPI sharedInstance].customSafeTrackAPIURL = nil;
     
 }
 
@@ -507,6 +508,7 @@
     [BNCServerAPI sharedInstance].useEUServers = NO;
     [BNCServerAPI sharedInstance].automaticallyEnableTrackingDomain = YES;
     [BNCServerAPI sharedInstance].customAPIURL = nil;
+    [BNCServerAPI sharedInstance].customSafeTrackAPIURL = nil;
     
 }
 

--- a/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
@@ -409,4 +409,95 @@
     XCTAssertEqualObjects(storedUrl, expectedUrl);
 }
 
+
+- (void)testSafeTrackServiceURLWithUserTrackingDomain {
+    NSString *url = @"https://links.tospotify.com";
+    NSString *safeTrackUrl = @"https://links.tospotify-safeTrack.com";
+    
+    [Branch setAPIUrl:url];
+    [Branch setSafetrackAPIURL:safeTrackUrl];
+    
+    BNCServerAPI *serverAPI = [BNCServerAPI sharedInstance];
+    serverAPI.automaticallyEnableTrackingDomain = NO;
+    serverAPI.useTrackingDomain = YES;
+    
+    NSString *storedUrl = [[BNCServerAPI sharedInstance] installServiceURL];
+    NSString *expectedUrl = @"https://links.tospotify-safeTrack.com/v1/install";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] openServiceURL];
+    expectedUrl = @"https://links.tospotify-safeTrack.com/v1/open";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] standardEventServiceURL];
+    expectedUrl = @"https://links.tospotify-safeTrack.com/v2/event/standard";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] customEventServiceURL];
+    expectedUrl = @"https://links.tospotify-safeTrack.com/v2/event/custom";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] linkServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v1/url";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] qrcodeServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v1/qr-code";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] latdServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v1/cpid/latd";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] validationServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v1/app-link-settings";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+}
+
+- (void)testSafeTrackServiceURLWithOutUserTrackingDomain {
+    NSString *url = @"https://links.tospotify.com";
+    NSString *safeTrackUrl = @"https://links.tospotify-safeTrack.com";
+    
+    [Branch setAPIUrl:url];
+    [Branch setSafetrackAPIURL:safeTrackUrl];
+    
+    BNCServerAPI *serverAPI = [BNCServerAPI sharedInstance];
+    serverAPI.automaticallyEnableTrackingDomain = NO;
+    serverAPI.useTrackingDomain = NO;
+    
+    NSString *storedUrl = [[BNCServerAPI sharedInstance] installServiceURL];
+    NSString *expectedUrl = @"https://links.tospotify.com/v1/install";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] openServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v1/open";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] standardEventServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v2/event/standard";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] customEventServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v2/event/custom";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] linkServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v1/url";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] qrcodeServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v1/qr-code";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] latdServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v1/cpid/latd";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    storedUrl = [[BNCServerAPI sharedInstance] validationServiceURL];
+    expectedUrl = @"https://links.tospotify.com/v1/app-link-settings";
+    XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+}
+
 @end

--- a/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
@@ -410,7 +410,7 @@
 }
 
 
-- (void)testSafeTrackServiceURLWithUserTrackingDomain {
+- (void)testSetSafeTrackServiceURLWithUserTrackingDomain {
     NSString *url = @"https://links.tospotify.com";
     NSString *safeTrackUrl = @"https://links.tospotify-safeTrack.com";
     
@@ -453,9 +453,14 @@
     expectedUrl = @"https://links.tospotify.com/v1/app-link-settings";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
+    [BNCServerAPI sharedInstance].useTrackingDomain = NO;
+    [BNCServerAPI sharedInstance].useEUServers = NO;
+    [BNCServerAPI sharedInstance].automaticallyEnableTrackingDomain = YES;
+    [BNCServerAPI sharedInstance].customAPIURL = nil;
+    
 }
 
-- (void)testSafeTrackServiceURLWithOutUserTrackingDomain {
+- (void)testSetSafeTrackServiceURLWithOutUserTrackingDomain {
     NSString *url = @"https://links.tospotify.com";
     NSString *safeTrackUrl = @"https://links.tospotify-safeTrack.com";
     
@@ -497,6 +502,11 @@
     storedUrl = [[BNCServerAPI sharedInstance] validationServiceURL];
     expectedUrl = @"https://links.tospotify.com/v1/app-link-settings";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
+    
+    [BNCServerAPI sharedInstance].useTrackingDomain = NO;
+    [BNCServerAPI sharedInstance].useEUServers = NO;
+    [BNCServerAPI sharedInstance].automaticallyEnableTrackingDomain = YES;
+    [BNCServerAPI sharedInstance].customAPIURL = nil;
     
 }
 

--- a/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCAPIServerTest.m
@@ -411,8 +411,8 @@
 
 
 - (void)testSetSafeTrackServiceURLWithUserTrackingDomain {
-    NSString *url = @"https://links.tospotify.com";
-    NSString *safeTrackUrl = @"https://links.tospotify-safeTrack.com";
+    NSString *url = @"https://links.toTestDomain.com";
+    NSString *safeTrackUrl = @"https://links.toTestDomain-safeTrack.com";
     
     [Branch setAPIUrl:url];
     [Branch setSafetrackAPIURL:safeTrackUrl];
@@ -422,35 +422,35 @@
     serverAPI.useTrackingDomain = YES;
     
     NSString *storedUrl = [[BNCServerAPI sharedInstance] installServiceURL];
-    NSString *expectedUrl = @"https://links.tospotify-safeTrack.com/v1/install";
+    NSString *expectedUrl = @"https://links.toTestDomain-safeTrack.com/v1/install";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] openServiceURL];
-    expectedUrl = @"https://links.tospotify-safeTrack.com/v1/open";
+    expectedUrl = @"https://links.toTestDomain-safeTrack.com/v1/open";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] standardEventServiceURL];
-    expectedUrl = @"https://links.tospotify-safeTrack.com/v2/event/standard";
+    expectedUrl = @"https://links.toTestDomain-safeTrack.com/v2/event/standard";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] customEventServiceURL];
-    expectedUrl = @"https://links.tospotify-safeTrack.com/v2/event/custom";
+    expectedUrl = @"https://links.toTestDomain-safeTrack.com/v2/event/custom";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] linkServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v1/url";
+    expectedUrl = @"https://links.toTestDomain.com/v1/url";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] qrcodeServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v1/qr-code";
+    expectedUrl = @"https://links.toTestDomain.com/v1/qr-code";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] latdServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v1/cpid/latd";
+    expectedUrl = @"https://links.toTestDomain.com/v1/cpid/latd";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] validationServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v1/app-link-settings";
+    expectedUrl = @"https://links.toTestDomain.com/v1/app-link-settings";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     [BNCServerAPI sharedInstance].useTrackingDomain = NO;
@@ -462,8 +462,8 @@
 }
 
 - (void)testSetSafeTrackServiceURLWithOutUserTrackingDomain {
-    NSString *url = @"https://links.tospotify.com";
-    NSString *safeTrackUrl = @"https://links.tospotify-safeTrack.com";
+    NSString *url = @"https://links.toTestDomain.com";
+    NSString *safeTrackUrl = @"https://links.toTestDomain-safeTrack.com";
     
     [Branch setAPIUrl:url];
     [Branch setSafetrackAPIURL:safeTrackUrl];
@@ -473,35 +473,35 @@
     serverAPI.useTrackingDomain = NO;
     
     NSString *storedUrl = [[BNCServerAPI sharedInstance] installServiceURL];
-    NSString *expectedUrl = @"https://links.tospotify.com/v1/install";
+    NSString *expectedUrl = @"https://links.toTestDomain.com/v1/install";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] openServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v1/open";
+    expectedUrl = @"https://links.toTestDomain.com/v1/open";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] standardEventServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v2/event/standard";
+    expectedUrl = @"https://links.toTestDomain.com/v2/event/standard";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] customEventServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v2/event/custom";
+    expectedUrl = @"https://links.toTestDomain.com/v2/event/custom";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] linkServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v1/url";
+    expectedUrl = @"https://links.toTestDomain.com/v1/url";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] qrcodeServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v1/qr-code";
+    expectedUrl = @"https://links.toTestDomain.com/v1/qr-code";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] latdServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v1/cpid/latd";
+    expectedUrl = @"https://links.toTestDomain.com/v1/cpid/latd";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     storedUrl = [[BNCServerAPI sharedInstance] validationServiceURL];
-    expectedUrl = @"https://links.tospotify.com/v1/app-link-settings";
+    expectedUrl = @"https://links.toTestDomain.com/v1/app-link-settings";
     XCTAssertEqualObjects(storedUrl, expectedUrl);
     
     [BNCServerAPI sharedInstance].useTrackingDomain = NO;

--- a/Sources/BranchSDK/BNCServerAPI.m
+++ b/Sources/BranchSDK/BNCServerAPI.m
@@ -94,13 +94,17 @@
 }
 
 - (NSString *)getBaseURL {
-    //Check if user has set a custom API base URL
-    if (self.customAPIURL) {
-        return self.customAPIURL;
-    }
     
     if (self.automaticallyEnableTrackingDomain) {
         self.useTrackingDomain = [self optedIntoIDFA];
+    }
+    
+    //Check if user has set a custom API base URL / custom API safetrack base url
+    if (self.useTrackingDomain && self.customSafeTrackAPIURL){
+        return self.customSafeTrackAPIURL;
+    }
+    else if (self.customAPIURL) {
+        return self.customAPIURL;
     }
     
     NSString * urlString;

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -490,6 +490,14 @@ static NSString *bnc_branchKey = nil;
     }
 }
 
++ (void)setSafetrackAPIURL:(NSString *)url {
+    if ([url hasPrefix:@"http://"] || [url hasPrefix:@"https://"] ){
+        [BNCServerAPI sharedInstance].customSafeTrackAPIURL = url;
+    } else {
+        [[BranchLogger shared] logWarning:@"Ignoring invalid custom Safe Track API URL" error:nil];
+    }
+}
+
 - (void)validateSDKIntegration {
     [self validateSDKIntegrationCore];
 }

--- a/Sources/BranchSDK/Private/BNCServerAPI.h
+++ b/Sources/BranchSDK/Private/BNCServerAPI.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readwrite) BOOL automaticallyEnableTrackingDomain;
 
 @property (nonatomic, copy, readwrite, nullable) NSString *customAPIURL;
+@property (nonatomic, copy, readwrite, nullable) NSString *customSafeTrackAPIURL;
 
 @end
 

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -588,6 +588,13 @@ Sets a custom base URL for all calls to the Branch API.
 + (void)setAPIUrl:(NSString *)url;
 
 /**
+Sets a custom base safetrack URL for non-linking calls to the Branch API.
+@param url  Base safetrack URL that the Branch API will use.
+ */
+
++ (void)setSafetrackAPIURL:(NSString *)url ;
+
+/**
   @brief        Use the `validateSDKIntegration` method as a debugging aid to assure that you've
                 integrated the Branch SDK correctly.
 


### PR DESCRIPTION
## Reference
EMT-1779 -- [iOS SDK] Provide setSafetrackAPIURL utility to override BNC_SAFETRACK_API_URL
https://branch.atlassian.net/browse/EMT-1779

## Summary
Added new API - `setSafetrackAPIURL`. It overrides `BNC_SAFETRACK_API_URL`. 
If app sets a custom safe track url and user opts in for IDFA collection (useTrackingDomain is true), this custom url will be used for all v2 requests, v1/open and v1/install.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] New feature (non-breaking change which adds functionality)

## Testing Instructions

* Verify all unit tests pass ( This PR adds two new tests - testSetSafeTrackServiceURLWithUserTrackingDomain and testSetSafeTrackServiceURLWithOutUserTrackingDomain)
* Set a custom safetrack url using this new API - setSafetrackAPIURL in any test. Opt in for IDFA collection or manually set following params 
`BNCServerAPI *serverAPI = [BNCServerAPI sharedInstance];
    serverAPI.automaticallyEnableTrackingDomain = NO;
    serverAPI.useTrackingDomain = YES;`

Verify SDK uses this custom safetrack URL as base URL for linking and v2 requests. A sample of expected URLs is added here https://branch.atlassian.net/browse/EMT-1779?focusedCommentId=620999 



<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
