### PR TITLE
[INTENG-22230] Clear initial referrer after init

### DIFF
--- a/Sources/BranchSDK/BranchOpenRequest.m
+++ b/Sources/BranchSDK/BranchOpenRequest.m
@@ -159,6 +159,7 @@
     preferenceHelper.universalLinkUrl = nil;
     preferenceHelper.externalIntentURI = nil;
     preferenceHelper.referringURL = referringURL;
+    preferenceHelper.initialReferrer = nil;
     preferenceHelper.dropURLOpen = NO;
     
     NSString *string = BNCStringFromWireFormat(data[BRANCH_RESPONSE_KEY_RANDOMIZED_BUNDLE_TOKEN]);


### PR DESCRIPTION
## Reference
[INTENG-22230] 

## Summary
To be consistent, nil out initial referrer as we do for other fields after an open request succeeds. Otherwise, it is not guaranteed that storage would be cleared out and previous initial referrer value could be reused. 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.


[INTENG-22230]: https://branch.atlassian.net/browse/INTENG-22230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ