### PR TITLE
Added checks for empty url and class type. Added unit tests also.

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCReferringURLUtilityTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCReferringURLUtilityTests.m
@@ -79,6 +79,17 @@ static NSString *eventEndpoint = @"/v2/event";
     XCTAssert([expected isEqualToDictionary:params]);
 }
 
+- (void)testNilReferringURL {
+    NSURL *url = nil;
+    NSDictionary *expected = @{};
+    
+    BNCReferringURLUtility *utility = [self referringUtilityForTests];
+    [utility parseReferringURL:url];
+    NSDictionary *params = [utility referringURLQueryParamsForEndpoint:openEndpoint];
+    
+    XCTAssert([expected isEqualToDictionary:params]);
+}
+
 - (void)testReferringURLIgnoredParam {
     NSURL *url = [NSURL URLWithString:@"https://bnctestbed.app.link?other=12345"];
     NSDictionary *expected = @{ };
@@ -226,6 +237,17 @@ static NSString *eventEndpoint = @"/v2/event";
     NSDictionary *params2 = [utility referringURLQueryParamsForEndpoint:openEndpoint];
     
     XCTAssert([expected2 isEqualToDictionary:params2]);
+}
+
+- (void)testReferringURLWithMetaCampaignIdsAndInvalidURL {
+    NSURL *url = [NSURL URLWithString:@"https://bnctestbed.app.link?al_applink_data=[]#target_url%22%3A%22http%3A%5C%2F%5C%2Fitunes.apple.com%5C%2Fapp%5C%2Fid880047117%22%2C%22extras%22%3A%7B%22fb_app_id%22%3A2020399148181142%7D%2C%22referer_app_link%22%3A%7B%22url%22%3A%22fb%3A%5C%2F%5C%2F%5C%2F%3Fapp_id%3D2020399148181142%22%2C%22app_name%22%3A%22Facebook%22%7D%2C%22acs_token%22%3A%22debuggingtoken%22%2C%22campaign_ids%22%3A%22ARFUlbyOurYrHT2DsknR7VksCSgN4tiH8TzG8RIvVoUQoYog5bVCvADGJil5kFQC6tQm-fFJQH0w8wCi3NbOmEHHrtgCNglkXNY-bECEL0aUhj908hIxnBB0tchJCqwxHjorOUqyk2v4bTF75PyWvxOksZ6uTzBmr7wJq8XnOav0bA%22%2C%22test_deeplink%22%3A1%7D"];
+    NSDictionary *expected = @{};
+    
+    BNCReferringURLUtility *utility = [self referringUtilityForTests];
+    [utility parseReferringURL:url];
+    NSDictionary *params = [utility referringURLQueryParamsForEndpoint:openEndpoint];
+    
+    XCTAssert([expected isEqualToDictionary:params]);
 }
 
 - (void)testReferringURLWithMetaCampaignIds {

--- a/Sources/BranchSDK/BNCReferringURLUtility.m
+++ b/Sources/BranchSDK/BNCReferringURLUtility.m
@@ -48,6 +48,11 @@
 - (void)parseReferringURL:(NSURL *)url {
     [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Parsing URL %@", url] error:nil];
     
+    if (!url) {
+        [[BranchLogger shared] logVerbose:@"URL is nil" error:nil];
+        return;
+    }
+    
     NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
     for  (NSURLQueryItem *item in components.queryItems) {
         if ([self isSupportedQueryParameter:item.name]) {
@@ -115,6 +120,11 @@
     if (jsonData) {
         NSError *error;
         NSDictionary *json = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+        if (![json isKindOfClass:[NSDictionary class]]) {
+            [[BranchLogger shared] logVerbose:@"Encoded json string did not decode to a dictionary; skipping" error:nil];
+            json = nil;
+        }
+
         if (!error) {
             return json;
         } else {


### PR DESCRIPTION
## Reference
INTENG-22710 -- https://branch.atlassian.net/browse/INTENG-22710
Opening Facebook generated URI scheme crashes iOS SDK

## Summary
This PR fixes above crash. It includes -
-> Checks to ensure data type of the object returned from the `[NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error] ` is a dictionary.
-> Added nil check for URL
-> Added unit tests

## Motivation
Fix crash when Facebook generated URI does not contain campaign IDs.

## Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
Please refer to INTENG-22710 to get the URI on which Apps are crashing.
Apps should not crash when URI mentioned in JIRA ticket  is clicked.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
