### PR TITLE
Removed Auto Initialization

### DIFF
--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -1230,11 +1230,9 @@ static NSString *bnc_branchKey = nil;
         if (self.initializationStatus == BNCInitStatusUninitialized) {
             NSError *error = [NSError branchErrorWithCode:BNCInitError];
             [[BranchLogger shared] logWarning:@"Branch SDK is not initialized, cannot send this request. Please intialize session before calling this API." error:error];
-            if ([[BNCCallbackMap shared] containsRequest:request]) {
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [[BNCCallbackMap shared] callCompletionForRequest:request withSuccessStatus:NO error:error];
-                });
-            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[BNCCallbackMap shared] callCompletionForRequest:request withSuccessStatus:NO error:error];
+            });
             return;
         }
     }

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -690,6 +690,10 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)setConsumerProtectionAttributionLevel:(BranchAttributionLevel)level {
+    [self setConsumerProtectionAttributionLevel:level resetSession:YES];
+}
+
+- (void)setConsumerProtectionAttributionLevel:(BranchAttributionLevel)level resetSession:(BOOL)resetSession {
     self.preferenceHelper.attributionLevel = level;
     
     [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Setting Consumer Protection Attribution Level to %@", level] error:nil];
@@ -720,8 +724,10 @@ static NSString *bnc_branchKey = nil;
             // Set the flag:
             [BNCPreferenceHelper sharedInstance].trackingDisabled = NO;
 
-            // Initialize a Branch session:
-            [[Branch getInstance] initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:true];
+            if (resetSession) {
+                // Initialize a Branch session:
+                [[Branch getInstance] initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:true];
+            }
         }
     }
     
@@ -1220,7 +1226,16 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)sendServerRequest:(BNCServerRequest*)request {
-    [self initSafetyCheck];
+    @synchronized (self) {
+        if (self.initializationStatus == BNCInitStatusUninitialized) {
+            NSError *error = [NSError branchErrorWithCode:BNCInitError];
+            [[BranchLogger shared] logWarning:@"Branch SDK is not initialized, cannot send this request. Please intialize session before calling this API." error:error];
+            BNCPerformBlockOnMainThreadSync(^{
+                [[BNCCallbackMap shared] callCompletionForRequest:request withSuccessStatus:NO error:error];
+            });
+            return;
+        }
+    }
     dispatch_async(self.isolationQueue, ^(){
         [self.requestQueue enqueue:request];
         [self processNextQueueItem];
@@ -1298,7 +1313,14 @@ static NSString *bnc_branchKey = nil;
 #pragma mark - Query methods
 
 - (void)lastAttributedTouchDataWithAttributionWindow:(NSInteger)window completion:(void(^) (BranchLastAttributedTouchData * _Nullable latd, NSError * _Nullable error))completion {
-    [self initSafetyCheck];
+    @synchronized (self) {
+        if (self.initializationStatus == BNCInitStatusUninitialized) {
+            NSError *error = [NSError branchErrorWithCode:BNCInitError];
+            [[BranchLogger shared] logWarning:@"Branch SDK is not initialized, cannot request LATD. Please intialize session before calling this API." error:error];
+            if (completion) { completion(nil, error); }
+            return;
+        }
+    }
     dispatch_async(self.isolationQueue, ^(){
         [BranchLastAttributedTouchData requestLastTouchAttributedData:self.serverInterface key:self.class.branchKey attributionWindow:window completion:completion];
     });
@@ -1419,7 +1441,16 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)getSpotlightUrlWithParams:(NSDictionary *)params callback:(callbackWithParams)callback {
-    [self initSafetyCheck];
+    @synchronized (self) {
+        if (self.initializationStatus == BNCInitStatusUninitialized) {
+            NSError *error = [NSError branchErrorWithCode:BNCInitError];
+            [[BranchLogger shared] logWarning:@"Branch SDK is not initialized, cannot create Spotlight URL. Please intialize session before calling this API." error:error];
+            BNCPerformBlockOnMainThreadSync(^{
+                if (callback) { callback(nil, error); }
+            });
+            return;
+        }
+    }
     dispatch_async(self.isolationQueue, ^(){
         BranchSpotlightUrlRequest *req = [[BranchSpotlightUrlRequest alloc] initWithParams:params callback:callback];
         [self.requestQueue enqueue:req];
@@ -1683,7 +1714,18 @@ static NSString *bnc_branchKey = nil;
              andCampaign:campaign andParams:(NSDictionary *)params
              andCallback:(callbackWithUrl)callback {
 
-    [self initSafetyCheck];
+    @synchronized (self) {
+        if (self.initializationStatus == BNCInitStatusUninitialized) {
+            NSError *error = [NSError branchErrorWithCode:BNCInitError];
+            [[BranchLogger shared] logWarning:@"Branch SDK is not initialized, cannot generate short URL. Please intialize session before calling this API." error:error];
+            if (callback) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    callback(nil, error);
+                });
+            }
+            return;
+        }
+    }
     dispatch_async(self.isolationQueue, ^(){
         BNCLinkData *linkData = [self prepareLinkDataFor:tags
                                                 andAlias:alias
@@ -1891,7 +1933,18 @@ static NSString *bnc_branchKey = nil;
 #pragma mark - BranchUniversalObject methods
 
 - (void)registerViewWithParams:(NSDictionary *)params andCallback:(callbackWithParams)callback {
-    [self initSafetyCheck];
+    @synchronized (self) {
+        if (self.initializationStatus == BNCInitStatusUninitialized) {
+            NSError *error = [NSError branchErrorWithCode:BNCInitError];
+            [[BranchLogger shared] logWarning:@"Branch SDK is not initialized, cannot register view. Please intialize session before calling this API." error:error];
+            if (callback) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    callback(nil, error);
+                });
+            }
+            return;
+        }
+    }
     dispatch_async(self.isolationQueue, ^(){
         BranchUniversalObject *buo = [[BranchUniversalObject alloc] init];
         buo.contentMetadata.customMetadata = (id) params;
@@ -2151,14 +2204,6 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     self.cachedInitBlock = nil;
 }
 
-// SDK-631 Workaround to maintain existing error handling behavior.
-// Some methods require init before they are called.  Instead of returning an error, we try to fix the situation by calling init ourselves.
-- (void)initSafetyCheck {
-    if (self.initializationStatus == BNCInitStatusUninitialized) {
-        [[BranchLogger shared] logDebug:@"Branch avoided an error by preemptively initializing." error:nil];
-        [self initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:NO];
-    }
-}
 
 - (void)initUserSessionAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier urlString:(NSString *)urlString reset:(BOOL)reset {
     

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -1230,9 +1230,11 @@ static NSString *bnc_branchKey = nil;
         if (self.initializationStatus == BNCInitStatusUninitialized) {
             NSError *error = [NSError branchErrorWithCode:BNCInitError];
             [[BranchLogger shared] logWarning:@"Branch SDK is not initialized, cannot send this request. Please intialize session before calling this API." error:error];
-            BNCPerformBlockOnMainThreadSync(^{
-                [[BNCCallbackMap shared] callCompletionForRequest:request withSuccessStatus:NO error:error];
-            });
+            if ([[BNCCallbackMap shared] containsRequest:request]) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [[BNCCallbackMap shared] callCompletionForRequest:request withSuccessStatus:NO error:error];
+                });
+            }
             return;
         }
     }
@@ -1317,7 +1319,9 @@ static NSString *bnc_branchKey = nil;
         if (self.initializationStatus == BNCInitStatusUninitialized) {
             NSError *error = [NSError branchErrorWithCode:BNCInitError];
             [[BranchLogger shared] logWarning:@"Branch SDK is not initialized, cannot request LATD. Please intialize session before calling this API." error:error];
-            if (completion) { completion(nil, error); }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (completion) { completion(nil, error); }
+            });
             return;
         }
     }
@@ -1445,7 +1449,7 @@ static NSString *bnc_branchKey = nil;
         if (self.initializationStatus == BNCInitStatusUninitialized) {
             NSError *error = [NSError branchErrorWithCode:BNCInitError];
             [[BranchLogger shared] logWarning:@"Branch SDK is not initialized, cannot create Spotlight URL. Please intialize session before calling this API." error:error];
-            BNCPerformBlockOnMainThreadSync(^{
+            dispatch_async(dispatch_get_main_queue(), ^{
                 if (callback) { callback(nil, error); }
             });
             return;

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -941,6 +941,15 @@ extern BranchAttributionLevel const BranchAttributionLevelNone;
  */
 - (void)setConsumerProtectionAttributionLevel:(BranchAttributionLevel)level;
 
+/**
+ Sets the consumer protection attribution level with an option to reset the session.
+
+ @param level The desired consumer protection attribution level, represented by the BranchAttributionLevel enum (Full, Reduced, Minimal, None).
+ @param resetSession If YES, a new session will be initialized when transitioning from BranchAttributionLevelNone to other higher levels.
+                     If NO, the session will not be re-initialized automatically when transitioning from BranchAttributionLevelNone to other higher levels.
+ */
+- (void)setConsumerProtectionAttributionLevel:(BranchAttributionLevel)level resetSession:(BOOL)resetSession;
+
 
 #pragma mark - Session Item methods
 

--- a/Sources/BranchSDK/Public/BranchEvent.h
+++ b/Sources/BranchSDK/Public/BranchEvent.h
@@ -97,20 +97,18 @@ typedef NS_ENUM(NSInteger, BranchEventAdType) {
 /**
  Logs the event on the Branch server.
  This version will callback on success/failure.
-  
+
  This method should only be invoked after initSession.
- If it is invoked before, then we will silently initialize the SDK before the callback has been set, in order to carry out this method's required task.
- As a result, you may experience issues where the initSession callback does not fire. Again, the solution to this issue is to only invoke this method after you have invoked initSession.
+ If invoked before initSession, the event will be dropped and a BNCInitError will be returned.
  */
 - (void)logEventWithCompletion:(void (^_Nullable)(BOOL success, NSError * _Nullable error))completion;
 
 /**
  Logs the event on the Branch server.
  This version automatically caches and retries as necessary.
- 
+
  This method should only be invoked after initSession.
- If it is invoked before, then we will silently initialize the SDK before the callback has been set, in order to carry out this method's required task.
- As a result, you may experience issues where the initSession callback does not fire. Again, the solution to this issue is to only invoke this method after you have invoked initSession.
+ If invoked before initSession, the event will be dropped.
  */
 - (void)logEvent;
 


### PR DESCRIPTION
* Added API - `- (void)setConsumerProtectionAttributionLevel:(BranchAttributionLevel)level resetSession:(BOOL)resetSession` to provide an option to disable resetting session.
 * Removed silent SDK initialization - initSafetyCheck removed.Now APIs will return or log BNCInitError error. 
* Added @synchronized(self) around all 5 init status checks to ensure it waits for any in-progress initSession code (which also uses @synchronized(self)) to finish and update the status before evaluating.

## Reference
SDK-XXXX -- <TITLE>.

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
