### PR TITLE
Ndixit/revert integration test timeout update

### DIFF
--- a/SDKIntegrationTestApps/Source/IntegrationTests/iOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/Source/IntegrationTests/iOSReleaseTestTests.swift
@@ -62,7 +62,7 @@ final class iOSReleaseTestTests: XCTestCase {
         print("[Test] Disabling tracking again...")
         sdk.setCPPLevel(status: BranchAttributionLevel.full)
         
-        waitForExpectations(timeout: 30, handler: nil)
+        waitForExpectations(timeout: 180, handler: nil)
         print("[Test] testInitSessionAndSetCPPLevel completed")
     }
 

--- a/SDKIntegrationTestApps/Source/IntegrationTests/tvOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/Source/IntegrationTests/tvOSReleaseTestTests.swift
@@ -62,7 +62,7 @@ final class tvOSReleaseTestTests: XCTestCase {
         print("[Test] Disabling tracking again...")
         sdk.setCPPLevel(status: BranchAttributionLevel.full)
         
-        waitForExpectations(timeout: 30, handler: nil)
+        waitForExpectations(timeout: 180, handler: nil)
         print("[Test] testInitSessionAndSetCPPLevel completed")
     }
 


### PR DESCRIPTION
## Reference

Integration tests were failing because of timeout issue. Previously wait time was reduced to 30 seconds. Reverting that change.
<img width="955" height="139" alt="Screenshot 2026-02-23 at 12 41 04 PM" src="https://github.com/user-attachments/assets/88d4994d-f439-4511-95e3-b7738b7dfa22" />



<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
