### PR TITLE
Fixed tests to use new API to disable auto init.

### DIFF
--- a/SDKIntegrationTestApps/Source/IntegrationTests/iOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/Source/IntegrationTests/iOSReleaseTestTests.swift
@@ -60,7 +60,7 @@ final class iOSReleaseTestTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(timeout: 30, handler: nil)
+        waitForExpectations(timeout: 90, handler: nil)
         
         print("Setting CPP Level to none.")
         sdk.setCPPLevel(status: BranchAttributionLevel.none)

--- a/SDKIntegrationTestApps/Source/IntegrationTests/iOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/Source/IntegrationTests/iOSReleaseTestTests.swift
@@ -45,24 +45,29 @@ final class iOSReleaseTestTests: XCTestCase {
     func testInitSessionAndSetCPPLevel() throws {
         print("[Test] Starting testInitSessionAndSetCPPLevel")
 
+        Branch.enableLogging(at: .verbose, withCallback: { message, logLevel, error in
+            print(message)
+            if let error = error {
+                print(error)
+            }
+        })
         let expectation = expectation(description: "InitSession should complete.")
-
-        let sdk = BranchSDKTest(){  params, error in
-            print(params as? [String: AnyObject] ?? {})
+        Branch.getInstance().setConsumerProtectionAttributionLevel(BranchAttributionLevel.none)
+        Branch.getInstance().setConsumerProtectionAttributionLevel(BranchAttributionLevel.full, resetSession:false)
+        let sdk = BranchSDKTest() { params, error in
+            print(params as? [String: AnyObject] ?? [:])
+            print("InitSession callback called.")
             expectation.fulfill()
         }
+        
+        waitForExpectations(timeout: 30, handler: nil)
+        
         print("Setting CPP Level to none.")
         sdk.setCPPLevel(status: BranchAttributionLevel.none)
         
         let cppLevel = BNCPreferenceHelper.sharedInstance().attributionLevel
-        print("[Test] CPP Level: \(String(describing: cppLevel))")
-        
-        XCTAssertTrue(cppLevel!.isEqual(to: BranchAttributionLevel.none.rawValue) , "Tracking should be disabled (true)")
-        
-        print("[Test] Disabling tracking again...")
-        sdk.setCPPLevel(status: BranchAttributionLevel.full)
-        
-        waitForExpectations(timeout: 180, handler: nil)
+        XCTAssertNotNil(cppLevel, "CPP level should not be nil")
+        XCTAssertEqual(cppLevel as? String, BranchAttributionLevel.none.rawValue, "CPP level should be none")
         print("[Test] testInitSessionAndSetCPPLevel completed")
     }
 

--- a/SDKIntegrationTestApps/Source/IntegrationTests/tvOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/Source/IntegrationTests/tvOSReleaseTestTests.swift
@@ -60,7 +60,7 @@ final class tvOSReleaseTestTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(timeout: 30, handler: nil)
+        waitForExpectations(timeout: 90, handler: nil)
         
         print("Setting CPP Level to none.")
         sdk.setCPPLevel(status: BranchAttributionLevel.none)

--- a/SDKIntegrationTestApps/Source/IntegrationTests/tvOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/Source/IntegrationTests/tvOSReleaseTestTests.swift
@@ -45,24 +45,30 @@ final class tvOSReleaseTestTests: XCTestCase {
     func testInitSessionAndSetCPPLevel() throws {
         print("[Test] Starting testInitSessionAndSetCPPLevel")
 
+        Branch.enableLogging(at: .verbose, withCallback: { message, logLevel, error in
+            print(message)
+            if let error = error {
+                print(error)
+            }
+        })
         let expectation = expectation(description: "InitSession should complete.")
-
-        let sdk = BranchSDKTest(){  params, error in
-            print(params as? [String: AnyObject] ?? {})
+        Branch.getInstance().setConsumerProtectionAttributionLevel(BranchAttributionLevel.none)
+        Branch.getInstance().setConsumerProtectionAttributionLevel(BranchAttributionLevel.full, resetSession:false)
+        let sdk = BranchSDKTest() { params, error in
+            print(params as? [String: AnyObject] ?? [:])
+            print("InitSession callback called.")
             expectation.fulfill()
         }
+        
+        waitForExpectations(timeout: 30, handler: nil)
+        
         print("Setting CPP Level to none.")
         sdk.setCPPLevel(status: BranchAttributionLevel.none)
         
         let cppLevel = BNCPreferenceHelper.sharedInstance().attributionLevel
-        print("[Test] CPP Level: \(String(describing: cppLevel))")
+        XCTAssertNotNil(cppLevel, "CPP level should not be nil")
+        XCTAssertEqual(cppLevel as? String, BranchAttributionLevel.none.rawValue, "CPP level should be none")
         
-        XCTAssertTrue(cppLevel!.isEqual(to: BranchAttributionLevel.none.rawValue) , "Tracking should be disabled (true)")
-        
-        print("[Test] Disabling tracking again...")
-        sdk.setCPPLevel(status: BranchAttributionLevel.full)
-        
-        waitForExpectations(timeout: 180, handler: nil)
         print("[Test] testInitSessionAndSetCPPLevel completed")
     }
 


### PR DESCRIPTION
## Reference

## Summary
SDK Binary Integration tests were using API - setConsumerProtectionAttributionLevel along with initSession. Because of autoinitialization in setConsumerProtectionAttributionLevel initsession was losing deep link data.
This PR includes fix for above issue - it uses new API - `- (void)setConsumerProtectionAttributionLevel:(BranchAttributionLevel)level resetSession:(BOOL)resetSession;` - to avoid auto initialization.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
