### PR TITLE
Removed trackingDisabled code and replaced with BranchAttributionLeve…

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCPreferenceHelperTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCPreferenceHelperTests.m
@@ -344,21 +344,6 @@
     XCTAssertEqual(expectedValue, storedValue);
 }
 
-- (void)testSetTrackingDisabled_YES {
-    [self.prefHelper setTrackingDisabled:YES];
-
-    BOOL storedValue = [self.prefHelper trackingDisabled];
-    XCTAssertTrue(storedValue);
-    [self.prefHelper setTrackingDisabled:NO];
-}
-
-- (void)testSetTrackingDisabled_NO {
-    [self.prefHelper setTrackingDisabled:NO];
-    
-    BOOL storedValue = [self.prefHelper trackingDisabled];
-    XCTAssertFalse(storedValue);
-}
-
 // TODO: rethink this test as these values are not set in a freshly instantiated prefHelper
 - (void)testClearTrackingInformation {
     [self.prefHelper clearTrackingInformation];
@@ -434,6 +419,33 @@
     self.prefHelper.thirdPartyAPIsWaitTime = testTimeout3;
     XCTAssertEqual(self.prefHelper.thirdPartyAPIsWaitTime, testTimeout3,
                    @"Third party APIs timeout should support small values");
+}
+
+- (void)testSetConsumerProtectionAttributionLevel_FULL {
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelFull];
+    BOOL storedValue = [[self.prefHelper attributionLevel] isEqualToString:@"FULL"];
+    XCTAssertTrue(storedValue);
+}
+
+- (void)testSetConsumerProtectionAttributionLevel_REDUCED {
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelReduced];
+    BOOL storedValue = [[self.prefHelper attributionLevel] isEqualToString:@"REDUCED"];
+    XCTAssertTrue(storedValue);
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelFull];
+}
+
+- (void)testSetConsumerProtectionAttributionLevel_MINIMAL {
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelMinimal];
+    BOOL storedValue = [[self.prefHelper attributionLevel] isEqualToString:@"MINIMAL"];
+    XCTAssertTrue(storedValue);
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelFull];
+}
+
+- (void)testSetConsumerProtectionAttributionLevel_NONE {
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelNone];
+    BOOL storedValue = [[self.prefHelper attributionLevel] isEqualToString:@"NONE"];
+    XCTAssertTrue(storedValue);
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelFull];
 }
 
 

--- a/Branch-TestBed/Branch-SDK-Tests/BranchClassTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchClassTests.m
@@ -67,16 +67,6 @@
     XCTAssertEqualObjects(metadata[@"key"], @"value");
 }
 
-- (void)testSetTrackingDisabled {
-    XCTAssertFalse([BNCPreferenceHelper sharedInstance].trackingDisabled);
-
-    [Branch setTrackingDisabled:YES];
-    XCTAssertTrue([BNCPreferenceHelper sharedInstance].trackingDisabled);
-
-    [Branch setTrackingDisabled:NO];
-    XCTAssertFalse([BNCPreferenceHelper sharedInstance].trackingDisabled);
-}
-
 - (void)testCheckPasteboardOnInstall {
     [self.branch checkPasteboardOnInstall];
     BOOL checkOnInstall = [BNCPasteboard sharedInstance].checkOnInstall;

--- a/Branch-TestBed/Branch-TestBed/Main.storyboard
+++ b/Branch-TestBed/Branch-TestBed/Main.storyboard
@@ -721,36 +721,8 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="u4f-10-QLt">
-                                        <rect key="frame" x="16" y="1042" width="343" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="u4f-10-QLt" id="jmn-fV-qvx">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Rz-jF-ETn">
-                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
-                                                    <accessibility key="accessibilityConfiguration" identifier="tracking"/>
-                                                    <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                    <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                    <state key="normal" title="Disable Tracking" image="eye" catalog="system">
-                                                        <color key="titleColor" systemColor="linkColor"/>
-                                                    </state>
-                                                    <connections>
-                                                        <action selector="disableTracking:" destination="i3m-ex-Bu1" eventType="touchUpInside" id="aRv-6b-mHD"/>
-                                                    </connections>
-                                                </button>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="7Rz-jF-ETn" secondAttribute="bottom" id="89b-k6-oFc"/>
-                                                <constraint firstItem="7Rz-jF-ETn" firstAttribute="top" secondItem="jmn-fV-qvx" secondAttribute="top" id="LND-nh-JHa"/>
-                                                <constraint firstItem="7Rz-jF-ETn" firstAttribute="leading" secondItem="jmn-fV-qvx" secondAttribute="leading" id="goN-NY-qmK"/>
-                                                <constraint firstAttribute="trailing" secondItem="7Rz-jF-ETn" secondAttribute="trailing" id="pyH-P6-K8K"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="fvl-Cv-Dng">
-                                        <rect key="frame" x="16" y="1086" width="343" height="44"/>
+                                        <rect key="frame" x="16" y="1042" width="343" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fvl-Cv-Dng" id="AqT-ae-eAc">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
@@ -777,7 +749,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="lmc-TI-I7x">
-                                        <rect key="frame" x="16" y="1130" width="343" height="44"/>
+                                        <rect key="frame" x="16" y="1086" width="343" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="lmc-TI-I7x" id="1XD-bq-Yu8">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
@@ -804,37 +776,8 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="4YV-Fs-BuA">
-                                        <rect key="frame" x="16" y="1174" width="343" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="4YV-Fs-BuA" id="93g-I9-9tZ">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oFC-oS-hU2">
-                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
-                                                    <accessibility key="accessibilityConfiguration" identifier="tracking"/>
-                                                    <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                    <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                    <state key="normal" title="Consumer Protection Preference" image="checkmark.shield" catalog="system">
-                                                        <color key="titleColor" systemColor="linkColor"/>
-                                                    </state>
-                                                    <connections>
-                                                        <action selector="changeConsumerProtectionAttributionLevel:" destination="i3m-ex-Bu1" eventType="touchUpInside" id="eif-fe-3JM"/>
-                                                        <action selector="goToPasteControlPressed:" destination="i3m-ex-Bu1" eventType="touchUpInside" id="oct-dQ-HLq"/>
-                                                    </connections>
-                                                </button>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="oFC-oS-hU2" secondAttribute="trailing" id="0NH-TC-sgu"/>
-                                                <constraint firstAttribute="bottom" secondItem="oFC-oS-hU2" secondAttribute="bottom" id="CKb-dX-4SM"/>
-                                                <constraint firstItem="oFC-oS-hU2" firstAttribute="top" secondItem="93g-I9-9tZ" secondAttribute="top" id="e2p-AN-GfI"/>
-                                                <constraint firstItem="oFC-oS-hU2" firstAttribute="leading" secondItem="93g-I9-9tZ" secondAttribute="leading" id="pTf-ET-lY1"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Fnk-6f-nvv">
-                                        <rect key="frame" x="16" y="1218" width="343" height="44"/>
+                                        <rect key="frame" x="16" y="1130" width="343" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Fnk-6f-nvv" id="67K-H2-Gix">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
@@ -863,7 +806,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="QxR-ER-AVt">
-                                        <rect key="frame" x="16" y="1262" width="343" height="44"/>
+                                        <rect key="frame" x="16" y="1174" width="343" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QxR-ER-AVt" id="TeU-im-aLH">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
@@ -900,7 +843,6 @@
                     <navigationItem key="navigationItem" title="Branch TestBed" largeTitleDisplayMode="always" id="eWU-bT-5CF" userLabel="Branch-TestBed"/>
                     <connections>
                         <outlet property="branchLinkTextField" destination="SOP-3u-nhT" id="H0r-W5-wGG"/>
-                        <outlet property="disableTrackingButton" destination="7Rz-jF-ETn" id="WNq-l3-xiU"/>
                         <outlet property="setParnerParamsButton" destination="4fu-zA-ceg" id="oWP-E3-0uu"/>
                         <segue destination="fQe-6g-cKp" kind="push" identifier="ShowLogOutput" id="0UI-6t-JlA"/>
                         <segue destination="nU2-HM-nNx" kind="push" identifier="GoToPasteControlView" id="a1o-Ia-5wh"/>
@@ -936,7 +878,6 @@
         <image name="checkmark.shield" catalog="system" width="121" height="128"/>
         <image name="doc.text" catalog="system" width="115" height="128"/>
         <image name="doc.viewfinder.fill" catalog="system" width="128" height="115"/>
-        <image name="eye" catalog="system" width="128" height="79"/>
         <image name="folder.badge.plus" catalog="system" width="128" height="93"/>
         <image name="light.beacon.max" catalog="system" width="128" height="102"/>
         <image name="link" catalog="system" width="128" height="124"/>
@@ -954,16 +895,16 @@
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="linkColor">
-            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondarySystemBackgroundColor">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray6Color">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -121,18 +121,6 @@ bool hasSetPartnerParams = false;
         [appDelegate setLogFile:nil];
     };
     
-    if ([Branch trackingDisabled]) {
-        [self.disableTrackingButton setTitle:@"Enable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
-            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.fill"] forState:UIControlStateNormal];
-        }
-    } else {
-        [self.disableTrackingButton setTitle:@"Disable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
-            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.slash.fill"] forState:UIControlStateNormal];
-        }
-    }
-    
     if (hasSetPartnerParams) {
         [self.setParnerParamsButton setTitle:@"Clear Partner Params" forState:UIControlStateNormal];
         if (@available(iOS 13.0, macCatalyst 13.1, *)) {
@@ -828,26 +816,6 @@ static inline void BNCPerformBlockOnMainThread(void (^ block)(void)) {
     NSString *logFileContents = [NSString stringWithContentsOfFile:appDelegate.logFileName encoding:NSUTF8StringEncoding error:nil];
     NSLog(@"Got log file (%@) contents: %@", appDelegate.logFileName, logFileContents);
     logOutputViewController.logOutput = [NSString stringWithFormat:@"%@", logFileContents];
-}
-
-- (IBAction)disableTracking:(id)sender {
-    
-    NSString *title = [self.disableTrackingButton titleForState:UIControlStateNormal];
-    
-    if ([title isEqualToString:@"Disable Tracking"]) {
-        [Branch setTrackingDisabled:YES];
-        [self.disableTrackingButton setTitle:@"Enable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
-            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.fill"] forState:UIControlStateNormal];
-        }
-    } else {
-        [Branch setTrackingDisabled:NO];
-        [self.disableTrackingButton setTitle:@"Disable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
-            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.slash.fill"] forState:UIControlStateNormal];
-        }
-    }
-    
 }
 
 - (IBAction)createQRCode:(id)sender {

--- a/BranchSDKTests/BNCPreferenceHelperTests.m
+++ b/BranchSDKTests/BNCPreferenceHelperTests.m
@@ -344,21 +344,6 @@
     XCTAssertEqual(expectedValue, storedValue);
 }
 
-- (void)testSetTrackingDisabled_YES {
-    [self.prefHelper setTrackingDisabled:YES];
-
-    BOOL storedValue = [self.prefHelper trackingDisabled];
-    XCTAssertTrue(storedValue);
-    [self.prefHelper setTrackingDisabled:NO];
-}
-
-- (void)testSetTrackingDisabled_NO {
-    [self.prefHelper setTrackingDisabled:NO];
-    
-    BOOL storedValue = [self.prefHelper trackingDisabled];
-    XCTAssertFalse(storedValue);
-}
-
 // TODO: rethink this test as these values are not set in a freshly instantiated prefHelper
 - (void)testClearTrackingInformation {
     [self.prefHelper clearTrackingInformation];
@@ -412,6 +397,33 @@
     NSDictionary *retrievedManifest = [self.prefHelper getContentAnalyticsManifest];
     
     XCTAssertEqualObjects(retrievedManifest, dummyManifest);
+}
+
+- (void)testSetConsumerProtectionAttributionLevel_FULL {
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelFull];
+    BOOL storedValue = [[self.prefHelper attributionLevel] isEqualToString:@"FULL"];
+    XCTAssertTrue(storedValue);
+}
+
+- (void)testSetConsumerProtectionAttributionLevel_REDUCED {
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelReduced];
+    BOOL storedValue = [[self.prefHelper attributionLevel] isEqualToString:@"REDUCED"];
+    XCTAssertTrue(storedValue);
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelFull];
+}
+
+- (void)testSetConsumerProtectionAttributionLevel_MINIMAL {
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelMinimal];
+    BOOL storedValue = [[self.prefHelper attributionLevel] isEqualToString:@"MINIMAL"];
+    XCTAssertTrue(storedValue);
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelFull];
+}
+
+- (void)testSetConsumerProtectionAttributionLevel_NONE {
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelNone];
+    BOOL storedValue = [[self.prefHelper attributionLevel] isEqualToString:@"NONE"];
+    XCTAssertTrue(storedValue);
+    [self.prefHelper setAttributionLevel:BranchAttributionLevelFull];
 }
 
 @end

--- a/BranchSDKTests/BranchClassTests.m
+++ b/BranchSDKTests/BranchClassTests.m
@@ -65,16 +65,6 @@
     XCTAssertEqualObjects(metadata[@"key"], @"value");
 }
 
-- (void)testSetTrackingDisabled {
-    XCTAssertFalse([BNCPreferenceHelper sharedInstance].trackingDisabled);
-
-    [Branch setTrackingDisabled:YES];
-    XCTAssertTrue([BNCPreferenceHelper sharedInstance].trackingDisabled);
-
-    [Branch setTrackingDisabled:NO];
-    XCTAssertFalse([BNCPreferenceHelper sharedInstance].trackingDisabled);
-}
-
 - (void)testCheckPasteboardOnInstall {
     [self.branch checkPasteboardOnInstall];
     BOOL checkOnInstall = [BNCPasteboard sharedInstance].checkOnInstall;

--- a/SDKIntegrationTestApps/tvOSReleaseTest-Carthage/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
+++ b/SDKIntegrationTestApps/tvOSReleaseTest-Carthage/tvOSReleaseTestTests/tvOSReleaseTestTests.swift
@@ -20,21 +20,14 @@ final class tvOSReleaseTestTests: XCTestCase {
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
-    func testSetTrackingDisabled() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-        
-        Branch.setTrackingDisabled(true)
-        let x = Branch.trackingDisabled()
-        assert( x == true)
-        Branch.setTrackingDisabled(false)
+    
+    func testSetConsumerProtectionAttributionLevelNone() throws {
+        Branch.setConsumerProtectionAttributionLevel(BranchAttributionLevel.none)
+        let x = Branch.attributionLevelNone()
+        assert(x == true)
+        Branch.setConsumerProtectionAttributionLevel(BranchAttributionLevel.full)
         print("Test completed.")
     }
-
 
     func testPerformanceExample() throws {
         // This is an example of a performance test case.

--- a/Sources/BranchSDK/BNCPreferenceHelper.m
+++ b/Sources/BranchSDK/BNCPreferenceHelper.m
@@ -892,7 +892,7 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
 }
 
 - (void)setAttributionLevel:(BranchAttributionLevel)level {
-    if (level == BranchAttributionLevelNone) {
+    if ([level isEqualToString:BranchAttributionLevelNone]) {
         [self clearTrackingInformation];
     }
     [self writeObjectToDefaults:BRANCH_PREFS_KEY_ATTRIBUTION_LEVEL value:level];

--- a/Sources/BranchSDK/BNCPreferenceHelper.m
+++ b/Sources/BranchSDK/BNCPreferenceHelper.m
@@ -892,11 +892,14 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
 }
 
 - (void)setAttributionLevel:(BranchAttributionLevel)level {
+    if (level == BranchAttributionLevelNone) {
+        [self clearTrackingInformation];
+    }
     [self writeObjectToDefaults:BRANCH_PREFS_KEY_ATTRIBUTION_LEVEL value:level];
 }
 
 - (BOOL)attributionLevelNone {
-    return [_attributionLevel isEqualToString:@"NONE"];
+    return [[self attributionLevel] isEqualToString:BranchAttributionLevelNone];
 }
 
 - (NSString *) uxType {

--- a/Sources/BranchSDK/BNCPreferenceHelper.m
+++ b/Sources/BranchSDK/BNCPreferenceHelper.m
@@ -895,19 +895,7 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
     [self writeObjectToDefaults:BRANCH_PREFS_KEY_ATTRIBUTION_LEVEL value:level];
 }
 
-- (BOOL)attributionLevelFull:(BranchAttributionLevel)level {
-    return [_attributionLevel isEqualToString:@"FULL"];
-}
-
-- (BOOL)attributionLevelReduced:(BranchAttributionLevel)level {
-    return [_attributionLevel isEqualToString:@"REDUCED"];
-}
-
-- (BOOL)attributionLevelMinimal:(BranchAttributionLevel)level {
-    return [_attributionLevel isEqualToString:@"MINIMAL"];
-}
-
-- (BOOL)attributionLevelNone:(BranchAttributionLevel)level {
+- (BOOL)attributionLevelNone {
     return [_attributionLevel isEqualToString:@"NONE"];
 }
 

--- a/Sources/BranchSDK/BNCPreferenceHelper.m
+++ b/Sources/BranchSDK/BNCPreferenceHelper.m
@@ -514,7 +514,7 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
 
 - (NSMutableString*) sanitizedMutableBaseURL:(NSString*)baseUrl_ {
     NSMutableString *baseUrl = [baseUrl_ mutableCopy];
-    if (self.trackingDisabled) {
+    if (self.attributionLevelNone) {
         NSString *id_string = [NSString stringWithFormat:@"%%24randomized_bundle_token=%@", self.randomizedBundleToken];
         NSRange range = [baseUrl rangeOfString:id_string];
         if (range.location != NSNotFound) [baseUrl replaceCharactersInRange:range withString:@""];
@@ -643,22 +643,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
 - (void) setDropURLOpen:(BOOL)value {
     @synchronized(self) {
         [self writeBoolToDefaults:@"dropURLOpen" value:value];
-    }
-}
-
-- (BOOL) trackingDisabled {
-    @synchronized(self) {
-        NSNumber *b = (id) [self readObjectFromDefaults:@"trackingDisabled"];
-        if ([b isKindOfClass:NSNumber.class]) return [b boolValue];
-        return false;
-    }
-}
-
-- (void) setTrackingDisabled:(BOOL)disabled {
-    @synchronized(self) {
-        NSNumber *b = [NSNumber numberWithBool:disabled];
-        [self writeObjectToDefaults:@"trackingDisabled" value:b];
-        if (disabled) [self clearTrackingInformation];
     }
 }
 
@@ -909,6 +893,22 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory_Unthreaded(void);
 
 - (void)setAttributionLevel:(BranchAttributionLevel)level {
     [self writeObjectToDefaults:BRANCH_PREFS_KEY_ATTRIBUTION_LEVEL value:level];
+}
+
+- (BOOL)attributionLevelFull:(BranchAttributionLevel)level {
+    return [_attributionLevel isEqualToString:@"FULL"];
+}
+
+- (BOOL)attributionLevelReduced:(BranchAttributionLevel)level {
+    return [_attributionLevel isEqualToString:@"REDUCED"];
+}
+
+- (BOOL)attributionLevelMinimal:(BranchAttributionLevel)level {
+    return [_attributionLevel isEqualToString:@"MINIMAL"];
+}
+
+- (BOOL)attributionLevelNone:(BranchAttributionLevel)level {
+    return [_attributionLevel isEqualToString:@"NONE"];
 }
 
 - (NSString *) uxType {

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -110,7 +110,7 @@
 // When YES, only link creation and resolution calls are allowed.
 // NO by default.
 - (BOOL)isAttributionLevelNone {
-    return Branch.attributionLevelNone;
+    return [Branch attributionLevelNone];
 }
 
 - (NSDictionary *)dataForInstallWithURLString:(NSString *)urlString {

--- a/Sources/BranchSDK/BNCRequestFactory.m
+++ b/Sources/BranchSDK/BNCRequestFactory.m
@@ -106,11 +106,11 @@
     
 }
 
-// SDK level tracking control
-// When set to YES, only link creation and resolution calls are allowed.
+// SDK attribution level control
+// When YES, only link creation and resolution calls are allowed.
 // NO by default.
-- (BOOL)isTrackingDisabled {
-    return Branch.trackingDisabled;
+- (BOOL)isAttributionLevelNone {
+    return Branch.attributionLevelNone;
 }
 
 - (NSDictionary *)dataForInstallWithURLString:(NSString *)urlString {
@@ -311,7 +311,7 @@
 - (NSDictionary *)dataForEventWithEventDictionary:(NSMutableDictionary *)dictionary {
     
     // Event requests are not valid when tracking is disabled
-    if ([self isTrackingDisabled]) {
+    if ([self isAttributionLevelNone]) {
         return [NSMutableDictionary new];
     }
     
@@ -367,7 +367,7 @@
 - (NSDictionary *)dataForLATDWithDataDictionary:(NSMutableDictionary *)dictionary {
     
     // LATD requests are not valid when tracking is disabled
-    if ([self isTrackingDisabled]) {
+    if ([self isAttributionLevelNone]) {
         return [NSMutableDictionary new];
     }
     
@@ -393,7 +393,7 @@
 
 - (void)addOpenTokensToJSON:(NSMutableDictionary *)json {
     // Tokens are not valid when tracking is disabled
-    if ([self isTrackingDisabled]) {
+    if ([self isAttributionLevelNone]) {
         return;
     }
     
@@ -411,7 +411,7 @@
 
 - (void)addShortURLTokensToJSON:(NSMutableDictionary *)json isSpotlightRequest:(BOOL)isSpotlightRequest {
     // Tokens are not valid when tracking is disabled
-    if ([self isTrackingDisabled]) {
+    if ([self isAttributionLevelNone]) {
         return;
     }
     
@@ -465,7 +465,7 @@
 
 - (void)addPartnerParametersToJSON:(NSMutableDictionary *)json {
     // Partner parameters are not valid when tracking is disabled
-    if ([self isTrackingDisabled]) {
+    if ([self isAttributionLevelNone]) {
         return;
     }
     NSDictionary *partnerParameters = [[BNCPartnerParameters shared] parameterJson];
@@ -533,7 +533,7 @@
 
 - (void)addTimestampsToJSON:(NSMutableDictionary *)json {
     // timestamps are not valid when tracking is disabled
-    if ([self isTrackingDisabled]) {
+    if ([self isAttributionLevelNone]) {
         return;
     }
     
@@ -563,7 +563,7 @@
     json[BRANCH_REQUEST_KEY_REQUEST_CREATION_TIME_STAMP] = self.requestCreationTimeStamp;
     
     // omit field if value is NO
-    if ([self isTrackingDisabled]) {
+    if ([self isAttributionLevelNone]) {
         json[@"tracking_disabled"] = @(1);
     }
 }
@@ -744,7 +744,7 @@
     @synchronized (self.deviceInfo) {
         
         // These fields are not necessary for link resolution calls
-        if (![self isTrackingDisabled]) {
+        if (![self isAttributionLevelNone]) {
             [self.deviceInfo checkAdvertisingIdentifier];
             
             // Only include hardware ID fields for Full Attribution Level

--- a/Sources/BranchSDK/BNCServerInterface.m
+++ b/Sources/BranchSDK/BNCServerInterface.m
@@ -66,7 +66,7 @@
     // TODO: confirm it's ok to send full URL instead of with the domain trimmed off
     self.requestEndpoint = url;
     
-    if (Branch.attributionLevelNone && ![url containsString:@"/v3/deeplink"]) {
+    if ([Branch attributionLevelNone] && ![url containsString:@"/v3/deeplink"]) {
     
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Tracking is disabled, checking if %@ is linking request.", url] error:nil];
 

--- a/Sources/BranchSDK/BNCServerInterface.m
+++ b/Sources/BranchSDK/BNCServerInterface.m
@@ -66,13 +66,13 @@
     // TODO: confirm it's ok to send full URL instead of with the domain trimmed off
     self.requestEndpoint = url;
     
-    if (Branch.trackingDisabled && ![url containsString:@"/v3/deeplink"]) {
+    if (Branch.attributionLevelNone && ![url containsString:@"/v3/deeplink"]) {
     
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Tracking is disabled, checking if %@ is linking request.", url] error:nil];
 
         if (![self isLinkingRelatedRequest:url postParams:post]) {
             [[BNCPreferenceHelper sharedInstance] clearTrackingInformation];
-            NSError *error = [NSError branchErrorWithCode:BNCTrackingDisabledError];
+            NSError *error = [NSError branchErrorWithCode:BNCAttributionLevelNoneError];
             [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"Dropping non-linking request"] error:error];
             if (callback) {
                 callback(nil, error);

--- a/Sources/BranchSDK/BNCServerRequestOperation.m
+++ b/Sources/BranchSDK/BNCServerRequestOperation.m
@@ -65,10 +65,9 @@
 
     BNCPreferenceHelper *preferenceHelper = self.preferenceHelper ?: [BNCPreferenceHelper sharedInstance];
 
-    // TEMPORARILY WRAPPING TrackingDisabled in old class name
     if (![self.request isKindOfClass:[BranchRequestDeepLink class]]) {
-        if (preferenceHelper.trackingDisabled) {
-            [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"Tracking disabled. Skipping request: %@", self.request.requestUUID] error:nil];
+        if ([preferenceHelper.attributionLevel isEqualToString:BranchAttributionLevelNone]) {
+            [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"Attribution Level is 'NONE'. Skipping request: %@", self.request.requestUUID] error:nil];
             self.executing = NO;
             self.finished = YES;
             return;

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -690,12 +690,10 @@ static NSString *bnc_branchKey = nil;
         //Enable Tracking
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Enabling attribution events due to Consumer Protection Attribution Level being %@.", level] error:nil];
 
-            if (resetSession) {
-                [[Branch getInstance] sendOpen];
-            }
+        if (resetSession) {
+            [[Branch getInstance] sendOpen];
         }
     }
-    
 }
 
 #pragma mark - InitSession Permutation methods

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -1123,13 +1123,13 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)addFacebookPartnerParameterWithName:(NSString *)name value:(NSString *)value {
-    if (![Branch attributionLevelNone]) {
+    if (!Branch.attributionLevelNone) {
         [[BNCPartnerParameters shared] addFacebookParameterWithName:name value:value];
     }
 }
 
 - (void)addSnapPartnerParameterWithName:(NSString *)name value:(NSString *)value {
-    if (![Branch attributionLevelNone]) {
+    if (!Branch.attributionLevelNone) {
         [[BNCPartnerParameters shared] addSnapParameterWithName:name value:value];
     }
 }
@@ -1948,7 +1948,7 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        if (![Branch attributionLevelNone] && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
+        if (!Branch.attributionLevelNone && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive attributionLevelNone %d initializationStatus %d installOrOpenInQueue %d", Branch.attributionLevelNone, self.initializationStatus, installOrOpenInQueue] error:nil];
             
             // TODO: Replace with sendOpen
@@ -1961,7 +1961,7 @@ static NSString *bnc_branchKey = nil;
     [[BranchLogger shared] logVerbose:@"applicationWillResignActive" error:nil];
 
     dispatch_async(self.isolationQueue, ^(){
-        if (![Branch attributionLevelNone]) {
+        if (!Branch.attributionLevelNone) {
             self.initializationStatus = BNCInitStatusUninitialized;
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationWillResignActive initializationStatus %ld", self.initializationStatus] error:nil];
             [BranchOpenRequest setWaitNeededForOpenResponseLock];

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -564,39 +564,27 @@ static NSString *bnc_branchKey = nil;
     [self.preferenceHelper setRequestMetadataKey:key value:value];
 }
 
-
-+ (BOOL)trackingDisabled {
-    @synchronized(self) {
-        return [BNCPreferenceHelper sharedInstance].trackingDisabled;
++ (BOOL)attributionLevelFull {
+    @synchronized (self) {
+        return [[BNCPreferenceHelper sharedInstance].attributionLevel isEqualToString:BranchAttributionLevelFull];
     }
 }
 
-+ (void)setTrackingDisabled:(BOOL)disabled {
-    @synchronized(self) {
-        [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"setTrackingDisabled to %d", disabled] error:nil];
++ (BOOL)attributionLevelReduced {
+    @synchronized (self) {
+        return [[BNCPreferenceHelper sharedInstance].attributionLevel isEqualToString:BranchAttributionLevelReduced];
+    }
+}
 
-        BOOL currentSetting = self.trackingDisabled;
-        if (!!currentSetting == !!disabled)
-            return;
-        if (disabled) {
-            [[BNCPartnerParameters shared] clearAllParameters];
-            
-            // Set the flag (which also clears the settings):
-            [BNCPreferenceHelper sharedInstance].trackingDisabled = YES;
-            Branch *branch = Branch.getInstance;
-            [branch clearNetworkQueue];
-            branch.initializationStatus = BNCInitStatusUninitialized;
-            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"initializationStatus %ld", branch.initializationStatus] error:nil];
++ (BOOL)attributionLevelMinimal {
+    @synchronized (self) {
+        return [[BNCPreferenceHelper sharedInstance].attributionLevel isEqualToString:BranchAttributionLevelMinimal];
+    }
+}
 
-            [branch.linkCache clear];
-            // Release the lock in case it's locked:
-            [BranchOpenRequest releaseOpenResponseLock];
-        } else {
-            // Set the flag:
-            [BNCPreferenceHelper sharedInstance].trackingDisabled = NO;
-            // Initialize a Branch session:
-            [Branch.getInstance initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:NO];
-        }
++ (BOOL)attributionLevelNone {
+    @synchronized (self) {
+        return [[BNCPreferenceHelper sharedInstance].attributionLevel isEqualToString:BranchAttributionLevelNone];
     }
 }
 
@@ -704,35 +692,26 @@ static NSString *bnc_branchKey = nil;
     
     //Set tracking to disabled if consumer protection attribution level is changed to BranchAttributionLevelNone. Otherwise, keep tracking enabled.
     if (level == BranchAttributionLevelNone) {
-        if ([Branch trackingDisabled] == false) {
-            //Disable Tracking
-            [[BranchLogger shared] logVerbose:@"Disabling attribution events due to Consumer Protection Attribution Level being BranchAttributionLevelNone." error:nil];
-            
-            // Clear partner parameters
-            [[BNCPartnerParameters shared] clearAllParameters];
-            
-            // Set the flag (which also clears the settings):
-            [BNCPreferenceHelper sharedInstance].trackingDisabled = YES;
-            Branch *branch = Branch.getInstance;
-            [branch clearNetworkQueue];
-            branch.initializationStatus = BNCInitStatusUninitialized;
-            [branch.linkCache clear];
-            // Release the lock in case it's locked:
-            [BranchOpenRequest releaseOpenResponseLock];
-        }
+        //Disable Tracking
+        [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Disabling attribution events due to Consumer Protection Attribution Level being %@.", level] error:nil];
+        
+        // Clear partner parameters
+        [[BNCPartnerParameters shared] clearAllParameters];
+        
+        Branch *branch = Branch.getInstance;
+        [branch clearNetworkQueue];
+        branch.initializationStatus = BNCInitStatusUninitialized;
+        [branch.linkCache clear];
+        // Release the lock in case it's locked:
+        [BranchOpenRequest releaseOpenResponseLock];
     } else {
-        if ([Branch trackingDisabled]) {
-            //Enable Tracking
-            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Enabling attribution events due to Consumer Protection Attribution Level being %@.", level] error:nil];
-            
-            // Set the flag:
-            [BNCPreferenceHelper sharedInstance].trackingDisabled = NO;
+        //Enable Tracking
+        [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Enabling attribution events due to Consumer Protection Attribution Level being %@.", level] error:nil];
 
-            if (resetSession) {
-                // Initialize a Branch session:
-                // TODO: Replace with sendOpen API
-                [[Branch getInstance] initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:true];
-            }
+        if (resetSession) {
+            // Initialize a Branch session:
+            // TODO: Replace with sendOpen API
+            [[Branch getInstance] initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:true];
         }
     }
     
@@ -1162,13 +1141,13 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)addFacebookPartnerParameterWithName:(NSString *)name value:(NSString *)value {
-    if (![Branch trackingDisabled]) {
+    if (![Branch attributionLevelNone]) {
         [[BNCPartnerParameters shared] addFacebookParameterWithName:name value:value];
     }
 }
 
 - (void)addSnapPartnerParameterWithName:(NSString *)name value:(NSString *)value {
-    if (![Branch trackingDisabled]) {
+    if (![Branch attributionLevelNone]) {
         [[BNCPartnerParameters shared] addSnapParameterWithName:name value:value];
     }
 }
@@ -1218,8 +1197,8 @@ static NSString *bnc_branchKey = nil;
 - (void)logoutWithCallback:(callbackWithStatus)callback {
     if (self.initializationStatus == BNCInitStatusUninitialized) {
         NSError *error =
-            (Branch.trackingDisabled)
-            ? [NSError branchErrorWithCode:BNCTrackingDisabledError]
+            (Branch.attributionLevelNone)
+            ? [NSError branchErrorWithCode:BNCAttributionLevelNoneError]
             : [NSError branchErrorWithCode:BNCInitError];
         [[BranchLogger shared] logWarning:@"Branch is not initialized, cannot logout." error:error];
         if (callback) {callback(NO, error);}
@@ -1987,8 +1966,8 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        if (!Branch.trackingDisabled && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
-            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue] error:nil];
+        if (!Branch.attributionLevelNone && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
+            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive attributionLevelNone %d initializationStatus %d installOrOpenInQueue %d", Branch.attributionLevelNone, self.initializationStatus, installOrOpenInQueue] error:nil];
             
             // TODO: Replace with sendOpen
             [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:nil reset:NO];
@@ -2000,7 +1979,7 @@ static NSString *bnc_branchKey = nil;
     [[BranchLogger shared] logVerbose:@"applicationWillResignActive" error:nil];
 
     dispatch_async(self.isolationQueue, ^(){
-        if (!Branch.trackingDisabled) {
+        if (!Branch.attributionLevelNone) {
             self.initializationStatus = BNCInitStatusUninitialized;
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationWillResignActive initializationStatus %ld", self.initializationStatus] error:nil];
             [BranchOpenRequest setWaitNeededForOpenResponseLock];

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -564,24 +564,6 @@ static NSString *bnc_branchKey = nil;
     [self.preferenceHelper setRequestMetadataKey:key value:value];
 }
 
-+ (BOOL)attributionLevelFull {
-    @synchronized (self) {
-        return [[BNCPreferenceHelper sharedInstance].attributionLevel isEqualToString:BranchAttributionLevelFull];
-    }
-}
-
-+ (BOOL)attributionLevelReduced {
-    @synchronized (self) {
-        return [[BNCPreferenceHelper sharedInstance].attributionLevel isEqualToString:BranchAttributionLevelReduced];
-    }
-}
-
-+ (BOOL)attributionLevelMinimal {
-    @synchronized (self) {
-        return [[BNCPreferenceHelper sharedInstance].attributionLevel isEqualToString:BranchAttributionLevelMinimal];
-    }
-}
-
 + (BOOL)attributionLevelNone {
     @synchronized (self) {
         return [[BNCPreferenceHelper sharedInstance].attributionLevel isEqualToString:BranchAttributionLevelNone];
@@ -1966,7 +1948,7 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        if (!Branch.attributionLevelNone && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
+        if (![Branch attributionLevelNone] && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive attributionLevelNone %d initializationStatus %d installOrOpenInQueue %d", Branch.attributionLevelNone, self.initializationStatus, installOrOpenInQueue] error:nil];
             
             // TODO: Replace with sendOpen
@@ -1979,7 +1961,7 @@ static NSString *bnc_branchKey = nil;
     [[BranchLogger shared] logVerbose:@"applicationWillResignActive" error:nil];
 
     dispatch_async(self.isolationQueue, ^(){
-        if (!Branch.attributionLevelNone) {
+        if (![Branch attributionLevelNone]) {
             self.initializationStatus = BNCInitStatusUninitialized;
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationWillResignActive initializationStatus %ld", self.initializationStatus] error:nil];
             [BranchOpenRequest setWaitNeededForOpenResponseLock];

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -1123,13 +1123,13 @@ static NSString *bnc_branchKey = nil;
 }
 
 - (void)addFacebookPartnerParameterWithName:(NSString *)name value:(NSString *)value {
-    if (!Branch.attributionLevelNone) {
+    if (![Branch attributionLevelNone]) {
         [[BNCPartnerParameters shared] addFacebookParameterWithName:name value:value];
     }
 }
 
 - (void)addSnapPartnerParameterWithName:(NSString *)name value:(NSString *)value {
-    if (!Branch.attributionLevelNone) {
+    if (![Branch attributionLevelNone]) {
         [[BNCPartnerParameters shared] addSnapParameterWithName:name value:value];
     }
 }
@@ -1179,7 +1179,7 @@ static NSString *bnc_branchKey = nil;
 - (void)logoutWithCallback:(callbackWithStatus)callback {
     if (self.initializationStatus == BNCInitStatusUninitialized) {
         NSError *error =
-            (Branch.attributionLevelNone)
+            ([Branch attributionLevelNone])
             ? [NSError branchErrorWithCode:BNCAttributionLevelNoneError]
             : [NSError branchErrorWithCode:BNCInitError];
         [[BranchLogger shared] logWarning:@"Branch is not initialized, cannot logout." error:error];
@@ -1948,8 +1948,8 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        if (!Branch.attributionLevelNone && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
-            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive attributionLevelNone %d initializationStatus %d installOrOpenInQueue %d", Branch.attributionLevelNone, self.initializationStatus, installOrOpenInQueue] error:nil];
+        if (![Branch attributionLevelNone] && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
+            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive attributionLevelNone %d initializationStatus %d installOrOpenInQueue %d", [Branch attributionLevelNone], self.initializationStatus, installOrOpenInQueue] error:nil];
             
             // TODO: Replace with sendOpen
             [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:nil reset:NO];
@@ -1961,7 +1961,7 @@ static NSString *bnc_branchKey = nil;
     [[BranchLogger shared] logVerbose:@"applicationWillResignActive" error:nil];
 
     dispatch_async(self.isolationQueue, ^(){
-        if (!Branch.attributionLevelNone) {
+        if (![Branch attributionLevelNone]) {
             self.initializationStatus = BNCInitStatusUninitialized;
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationWillResignActive initializationStatus %ld", self.initializationStatus] error:nil];
             [BranchOpenRequest setWaitNeededForOpenResponseLock];

--- a/Sources/BranchSDK/NSError+Branch.m
+++ b/Sources/BranchSDK/NSError+Branch.m
@@ -39,7 +39,7 @@ __attribute__((constructor)) void BNCForceNSErrorCategoryToLoad(void) {
         [messages setObject:@"Spotlight indexing requires a title." forKey:@(BNCSpotlightTitleError)];
         [messages setObject:@"The Spotlight identifier is required to remove indexing from spotlight." forKey:@(BNCSpotlightIdentifierError)];
         [messages setObject:@"Spotlight cannot remove publicly indexed content." forKey:@(BNCSpotlightPublicIndexError)];
-        [messages setObject:@"User tracking is disabled and the request is not allowed" forKey:@(BNCTrackingDisabledError)];
+        [messages setObject:@"Cannot process className. Attribution Level is set to \"NONE\". To process this className call setConsumerProtectionAttributionLevel(\"FULL\")." forKey:@(BNCAttributionLevelNoneError)];
         [messages setObject:@"Possible DNS Ad Blocker. Giving up on request." forKey:@(BNCDNSAdBlockerError)];
         [messages setObject:@"Possible VPN Ad Blocker. Giving up on request." forKey:@(BNCVPNAdBlockerError)];
         [messages setObject:@"Class not found (for Dynamic Method invocation)." forKey:@(BNCClassNotFoundError)];

--- a/Sources/BranchSDK/NSError+Branch.m
+++ b/Sources/BranchSDK/NSError+Branch.m
@@ -39,7 +39,7 @@ __attribute__((constructor)) void BNCForceNSErrorCategoryToLoad(void) {
         [messages setObject:@"Spotlight indexing requires a title." forKey:@(BNCSpotlightTitleError)];
         [messages setObject:@"The Spotlight identifier is required to remove indexing from spotlight." forKey:@(BNCSpotlightIdentifierError)];
         [messages setObject:@"Spotlight cannot remove publicly indexed content." forKey:@(BNCSpotlightPublicIndexError)];
-        [messages setObject:@"Cannot process className. Attribution Level is set to \"NONE\". To process this className call setConsumerProtectionAttributionLevel(\"FULL\")." forKey:@(BNCAttributionLevelNoneError)];
+        [messages setObject:@"Cannot process request. Attribution Level is set to \"NONE\". To process this request call [Branch setConsumerProtectionAttributionLevel:BranchAttributionLevelFull resetSession:YES]." forKey:@(BNCAttributionLevelNoneError)];
         [messages setObject:@"Possible DNS Ad Blocker. Giving up on request." forKey:@(BNCDNSAdBlockerError)];
         [messages setObject:@"Possible VPN Ad Blocker. Giving up on request." forKey:@(BNCVPNAdBlockerError)];
         [messages setObject:@"Class not found (for Dynamic Method invocation)." forKey:@(BNCClassNotFoundError)];

--- a/Sources/BranchSDK/Private/NSError+Branch.h
+++ b/Sources/BranchSDK/Private/NSError+Branch.h
@@ -30,7 +30,7 @@ typedef NS_ENUM(NSInteger, BNCErrorCode) {
     BNCSpotlightTitleError          = 1011,
     BNCSpotlightIdentifierError     = 1013,
     BNCSpotlightPublicIndexError    = 1014,
-    BNCTrackingDisabledError        = 1015,
+    BNCAttributionLevelNoneError        = 1015,
     BNCGeneralError                 = 1016, // General Branch SDK Error
     BNCDNSAdBlockerError                 = 1017,
     BNCVPNAdBlockerError                 = 1018,

--- a/Sources/BranchSDK/Public/BNCPreferenceHelper.h
+++ b/Sources/BranchSDK/Public/BNCPreferenceHelper.h
@@ -61,8 +61,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 @property (assign, nonatomic) NSInteger savedURLPatternListVersion;
 @property (assign, nonatomic) BOOL dropURLOpen;
 
-@property (assign, nonatomic) BOOL trackingDisabled;
-
 @property (copy, nonatomic) NSString *referrerGBRAID;
 @property (assign, nonatomic) NSTimeInterval referrerGBRAIDValidityWindow;
 @property (strong, nonatomic) NSDate *referrerGBRAIDInitDate;
@@ -82,6 +80,10 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 @property (assign, nonatomic) BOOL adUserDataUsageConsent;
 
 @property (nonatomic, assign) NSString *attributionLevel;
+@property (nonatomic, assign) BOOL attributionLevelFull;
+@property (nonatomic, assign) BOOL attributionLevelReduced;
+@property (nonatomic, assign) BOOL attributionLevelMinimal;
+@property (nonatomic, assign) BOOL attributionLevelNone;
 
 @property (copy, nonatomic) NSString *uxType;
 @property (strong, nonatomic) NSDate *urlLoadMs;

--- a/Sources/BranchSDK/Public/BNCPreferenceHelper.h
+++ b/Sources/BranchSDK/Public/BNCPreferenceHelper.h
@@ -80,9 +80,6 @@ NSURL* /* _Nonnull */ BNCURLForBranchDirectory(void);
 @property (assign, nonatomic) BOOL adUserDataUsageConsent;
 
 @property (nonatomic, assign) NSString *attributionLevel;
-@property (nonatomic, assign) BOOL attributionLevelFull;
-@property (nonatomic, assign) BOOL attributionLevelReduced;
-@property (nonatomic, assign) BOOL attributionLevelMinimal;
 @property (nonatomic, assign) BOOL attributionLevelNone;
 
 @property (copy, nonatomic) NSString *uxType;

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -944,15 +944,6 @@ extern BranchAttributionLevel const BranchAttributionLevelNone;
  */
 - (void)setConsumerProtectionAttributionLevel:(BranchAttributionLevel)level resetSession:(BOOL)resetSession;
 
-/// Returns a boolean based on if the current Attribution Level is set to "FULL".
-+ (BOOL) attributionLevelFull;
-
-/// Returns a boolean based on if the current Attribution Level is set to "REDUCED".
-+ (BOOL) attributionLevelReduced;
-
-/// Returns a boolean based on if the current Attribution Level is set to "MINIMAL".
-+ (BOOL) attributionLevelMinimal;
-
 /// Returns a boolean based on if the current Attribution Level is set to "NONE".
 + (BOOL) attributionLevelNone;
 

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -811,28 +811,6 @@ Sets a custom base safetrack URL for non-linking calls to the Branch API.
 - (void)setRequestMetadataKey:(NSString *)key value:(nullable NSString *)value;
 
 /**
- Disables the Branch SDK from tracking the user. This is useful for GDPR privacy compliance.
-
- When tracking is disabled, the Branch SDK will clear the Branch defaults of user identifying
- information and prevent Branch from making any Branch network calls that will track the user.
-
- Note that:
-
- * Opening Branch deep links with an explicit URL will work.
- * Deferred deep linking will not work.
- * Generating short links will not work and will return long links instead.
- * Sending user tracking events such as `BranchEvents` will fail.
- * Setting a user identity and logging a user identity out will not work.
-
- @param disabled    If set to `true` then tracking will be disabled.
- @warning This will prevent most of the Branch SDK functionality.
-*/
-+ (void)setTrackingDisabled:(BOOL)disabled __attribute__((deprecated("This method has been deprecated. Use `setConsumerProtectionAttributionLevel:` with `BranchAttributionLevelNone` instead.")));
-
-///Returns the current tracking state.
-+ (BOOL) trackingDisabled;
-
-/**
  Disables automatic session open tracking for the next foreground event with a default timeout of 30 seconds.
  This is useful for scenarios like Bio Auth Dialogs, Apple Pay Dialogs or other cases where the app may briefly go to
  background and return without needing a new session open.
@@ -966,6 +944,17 @@ extern BranchAttributionLevel const BranchAttributionLevelNone;
  */
 - (void)setConsumerProtectionAttributionLevel:(BranchAttributionLevel)level resetSession:(BOOL)resetSession;
 
+/// Returns a boolean based on if the current Attribution Level is set to "FULL".
++ (BOOL) attributionLevelFull;
+
+/// Returns a boolean based on if the current Attribution Level is set to "REDUCED".
++ (BOOL) attributionLevelReduced;
+
+/// Returns a boolean based on if the current Attribution Level is set to "MINIMAL".
++ (BOOL) attributionLevelMinimal;
+
+/// Returns a boolean based on if the current Attribution Level is set to "NONE".
++ (BOOL) attributionLevelNone;
 
 #pragma mark - Session Item methods
 


### PR DESCRIPTION
## Reference
EMT-3679 -- iOS - Remove trackingDisabled from 4.0.0-beta.0.

## Summary
trackingDisabled() is deprecated and will be removed from public references in favor of the setConsumerProtectionAttributionLevel() functions. 

All trackingDisabled() calls will be replaced with the new method.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
- Run app and set consumer protection attribution level to none either using AppDelegate or button on home page.
- Check to confirm logs.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
