### PR TITLE
EMT-3754 - replaced inituserSessionAndCallCallback with sendOpen methods

### DIFF
--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -2624,7 +2624,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     [self.requestQueue enqueue:openReq withPriority:NSOperationQueuePriorityHigh];
 }
 
-- (void) sendOpen:(NSDictionary *)responseData callCallback:(BOOL)callCallback {
+- (void) sendOpen:(NSDictionary *)responseData {
     NSURL *URL = (self.preferenceHelper.referringURL.length) ? [NSURL URLWithString:self.preferenceHelper.referringURL] : nil;
     if ([self.delegate respondsToSelector:@selector(branch:willStartSessionWithURL:)]) {
         [self.delegate branch:self willStartSessionWithURL:URL];

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -2608,9 +2608,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         dispatch_async(dispatch_get_main_queue(), ^ {
             if (error) {
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen failed with error: %@", error] error:error];
-                [self handleInitFailure:error callCallback:YES sceneIdentifier:nil];
+                [self handleInitFailure:error callCallback:NO sceneIdentifier:nil];
             } else {
-                [self handleInitSuccessAndCallCallback:YES sceneIdentifier:nil];
+                [self handleInitSuccessAndCallCallback:NO sceneIdentifier:nil];
                 NSDictionary *params = [self getLatestReferringParams];
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen completed with params: %@", params] error:nil];
             }
@@ -2643,9 +2643,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         dispatch_async(dispatch_get_main_queue(), ^ {
             if (error) {
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen failed with error: %@", error] error:error];
-                [self handleInitFailure:error callCallback:YES sceneIdentifier:nil];
+                [self handleInitFailure:error callCallback:NO sceneIdentifier:nil];
             } else {
-                [self handleInitSuccessAndCallCallback:YES sceneIdentifier:nil];
+                [self handleInitSuccessAndCallCallback:NO sceneIdentifier:nil];
                 NSDictionary *params = [self getLatestReferringParams];
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen completed with params: %@", params] error:nil];
             }

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -731,7 +731,9 @@ static NSString *bnc_branchKey = nil;
             if (resetSession) {
                 // Initialize a Branch session:
                 // TODO: Replace with sendOpen API
-                [[Branch getInstance] initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:true];
+                // [[Branch getInstance] initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:true];
+                
+                [[Branch getInstance] sendOpen:NO];
             }
         }
     }
@@ -909,7 +911,8 @@ static NSString *bnc_branchKey = nil;
         self.preferenceHelper.externalIntentURI = urlString;
         self.preferenceHelper.referringURL = urlString;
 
-        [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil reset:YES];
+        //[self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil reset:YES];
+        [self sendOpen:YES];
         return NO;
     }
 
@@ -957,7 +960,8 @@ static NSString *bnc_branchKey = nil;
             self.preferenceHelper.linkClickIdentifier = params[@"link_click_id"];
         }
     }
-    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:url.absoluteString reset:YES];
+    // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:url.absoluteString reset:YES];
+    [self sendOpen:YES];
     return handled;
 }
 
@@ -991,7 +995,8 @@ static NSString *bnc_branchKey = nil;
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Set universalLinkUrl and referringURL to %@", urlString] error:nil];
     }
 
-    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
+    // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
+    [self sendOpen:YES];
 
     return [Branch isBranchLink:urlString];
 }
@@ -1032,7 +1037,8 @@ static NSString *bnc_branchKey = nil;
     }
     #endif
 
-    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:userActivity.webpageURL.absoluteString reset:YES];
+    // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:userActivity.webpageURL.absoluteString reset:YES];
+    [self sendOpen:YES];
 
     return spotlightIdentifier != nil;
 }
@@ -1991,7 +1997,8 @@ static NSString *bnc_branchKey = nil;
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue] error:nil];
             
             // TODO: Replace with sendOpen
-            [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:nil reset:NO];
+            [self sendOpen:YES];
+            // [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:nil reset:NO];
         }
     });
 }
@@ -2591,7 +2598,12 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 }
 #endif
 
-- (void) sendOpen {
+- (void) sendOpen:(BOOL)callCallback {
+    NSURL *URL = (self.preferenceHelper.referringURL.length) ? [NSURL URLWithString:self.preferenceHelper.referringURL] : nil;
+    if ([self.delegate respondsToSelector:@selector(branch:willStartSessionWithURL:)]) {
+        [self.delegate branch:self willStartSessionWithURL:URL];
+    }
+    
     [[BranchLogger shared] logDebug:@"sendOpen called" error:nil];
 
     if ([_preferenceHelper.attributionLevel isEqualToString:BranchAttributionLevelNone]) {
@@ -2604,9 +2616,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         dispatch_async(dispatch_get_main_queue(), ^ {
             if (error) {
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen failed with error: %@", error] error:error];
-                [self handleInitFailure:error callCallback:YES sceneIdentifier:nil];
+                [self handleInitFailure:error callCallback:callCallback sceneIdentifier:nil];
             } else {
-                [self handleInitSuccessAndCallCallback:YES sceneIdentifier:nil];
+                [self handleInitSuccessAndCallCallback:callCallback sceneIdentifier:nil];
                 NSDictionary *params = [self getLatestReferringParams];
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen completed with params: %@", params] error:nil];
             }
@@ -2618,9 +2630,17 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
     [[BranchLogger shared] logDebug: @"Branch sendOpen network request queued." error:nil];
     [self.requestQueue enqueue:openReq withPriority:NSOperationQueuePriorityHigh];
+    
+    self.initializationStatus = BNCInitStatusInitializing;
+    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"initializationStatus %ld", self.initializationStatus] error:nil];
 }
 
-- (void) sendOpen:(NSDictionary *)responseData {
+- (void) sendOpen:(NSDictionary *)responseData callCallback:(BOOL)callCallback {
+    NSURL *URL = (self.preferenceHelper.referringURL.length) ? [NSURL URLWithString:self.preferenceHelper.referringURL] : nil;
+    if ([self.delegate respondsToSelector:@selector(branch:willStartSessionWithURL:)]) {
+        [self.delegate branch:self willStartSessionWithURL:URL];
+    }
+    
     [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen called with responseData: %@", responseData] error:nil];
 
     if ([_preferenceHelper.attributionLevel isEqualToString:BranchAttributionLevelNone]) {
@@ -2634,9 +2654,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         dispatch_async(dispatch_get_main_queue(), ^ {
             if (error) {
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen failed with error: %@", error] error:error];
-                [self handleInitFailure:error callCallback:YES sceneIdentifier:nil];
+                [self handleInitFailure:error callCallback:callCallback sceneIdentifier:nil];
             } else {
-                [self handleInitSuccessAndCallCallback:YES sceneIdentifier:nil];
+                [self handleInitSuccessAndCallCallback:callCallback sceneIdentifier:nil];
                 NSDictionary *params = [self getLatestReferringParams];
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen completed with params: %@", params] error:nil];
             }
@@ -2649,6 +2669,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
     [[BranchLogger shared] logDebug: @"Branch sendOpen network request queued." error:nil];
     [self.requestQueue enqueue:openReq withPriority:NSOperationQueuePriorityHigh];
+    
+    self.initializationStatus = BNCInitStatusInitializing;
+    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"initializationStatus %ld", self.initializationStatus] error:nil];
 }
 
 @end

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -729,11 +729,7 @@ static NSString *bnc_branchKey = nil;
             [BNCPreferenceHelper sharedInstance].trackingDisabled = NO;
 
             if (resetSession) {
-                // Initialize a Branch session:
-                // TODO: Replace with sendOpen API
-                // [[Branch getInstance] initUserSessionAndCallCallback:NO sceneIdentifier:nil urlString:nil reset:true];
-                
-                [[Branch getInstance] sendOpen:NO];
+                [[Branch getInstance] sendOpen];
             }
         }
     }
@@ -911,8 +907,8 @@ static NSString *bnc_branchKey = nil;
         self.preferenceHelper.externalIntentURI = urlString;
         self.preferenceHelper.referringURL = urlString;
 
-        //[self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil reset:YES];
-        [self sendOpen:YES];
+        [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil reset:YES];
+        
         return NO;
     }
 
@@ -960,8 +956,7 @@ static NSString *bnc_branchKey = nil;
             self.preferenceHelper.linkClickIdentifier = params[@"link_click_id"];
         }
     }
-    // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:url.absoluteString reset:YES];
-    [self sendOpen:YES];
+    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:url.absoluteString reset:YES];
     return handled;
 }
 
@@ -996,7 +991,7 @@ static NSString *bnc_branchKey = nil;
     }
 
     // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
-    [self sendOpen:YES];
+    [self sendOpen];
 
     return [Branch isBranchLink:urlString];
 }
@@ -1037,8 +1032,7 @@ static NSString *bnc_branchKey = nil;
     }
     #endif
 
-    // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:userActivity.webpageURL.absoluteString reset:YES];
-    [self sendOpen:YES];
+    [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:userActivity.webpageURL.absoluteString reset:YES];
 
     return spotlightIdentifier != nil;
 }
@@ -1996,9 +1990,7 @@ static NSString *bnc_branchKey = nil;
         if (!Branch.trackingDisabled && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue] error:nil];
             
-            // TODO: Replace with sendOpen
-            [self sendOpen:YES];
-            // [self initUserSessionAndCallCallback:YES sceneIdentifier:nil urlString:nil reset:NO];
+            [self sendOpen];
         }
     });
 }
@@ -2598,7 +2590,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 }
 #endif
 
-- (void) sendOpen:(BOOL)callCallback {
+- (void) sendOpen {
     NSURL *URL = (self.preferenceHelper.referringURL.length) ? [NSURL URLWithString:self.preferenceHelper.referringURL] : nil;
     if ([self.delegate respondsToSelector:@selector(branch:willStartSessionWithURL:)]) {
         [self.delegate branch:self willStartSessionWithURL:URL];
@@ -2616,9 +2608,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         dispatch_async(dispatch_get_main_queue(), ^ {
             if (error) {
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen failed with error: %@", error] error:error];
-                [self handleInitFailure:error callCallback:callCallback sceneIdentifier:nil];
+                [self handleInitFailure:error callCallback:YES sceneIdentifier:nil];
             } else {
-                [self handleInitSuccessAndCallCallback:callCallback sceneIdentifier:nil];
+                [self handleInitSuccessAndCallCallback:YES sceneIdentifier:nil];
                 NSDictionary *params = [self getLatestReferringParams];
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen completed with params: %@", params] error:nil];
             }
@@ -2630,9 +2622,6 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
     [[BranchLogger shared] logDebug: @"Branch sendOpen network request queued." error:nil];
     [self.requestQueue enqueue:openReq withPriority:NSOperationQueuePriorityHigh];
-    
-    self.initializationStatus = BNCInitStatusInitializing;
-    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"initializationStatus %ld", self.initializationStatus] error:nil];
 }
 
 - (void) sendOpen:(NSDictionary *)responseData callCallback:(BOOL)callCallback {
@@ -2654,9 +2643,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         dispatch_async(dispatch_get_main_queue(), ^ {
             if (error) {
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen failed with error: %@", error] error:error];
-                [self handleInitFailure:error callCallback:callCallback sceneIdentifier:nil];
+                [self handleInitFailure:error callCallback:YES sceneIdentifier:nil];
             } else {
-                [self handleInitSuccessAndCallCallback:callCallback sceneIdentifier:nil];
+                [self handleInitSuccessAndCallCallback:YES sceneIdentifier:nil];
                 NSDictionary *params = [self getLatestReferringParams];
                 [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen completed with params: %@", params] error:nil];
             }
@@ -2669,9 +2658,6 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
     [[BranchLogger shared] logDebug: @"Branch sendOpen network request queued." error:nil];
     [self.requestQueue enqueue:openReq withPriority:NSOperationQueuePriorityHigh];
-    
-    self.initializationStatus = BNCInitStatusInitializing;
-    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"initializationStatus %ld", self.initializationStatus] error:nil];
 }
 
 @end

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -2624,11 +2624,6 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 }
 
 - (void) sendOpen:(NSDictionary *)responseData {
-    NSURL *URL = (self.preferenceHelper.referringURL.length) ? [NSURL URLWithString:self.preferenceHelper.referringURL] : nil;
-    if ([self.delegate respondsToSelector:@selector(branch:willStartSessionWithURL:)]) {
-        [self.delegate branch:self willStartSessionWithURL:URL];
-    }
-    
     [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"sendOpen called with responseData: %@", responseData] error:nil];
 
     if ([_preferenceHelper.attributionLevel isEqualToString:BranchAttributionLevelNone]) {

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -908,7 +908,6 @@ static NSString *bnc_branchKey = nil;
         self.preferenceHelper.referringURL = urlString;
 
         [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:nil reset:YES];
-        
         return NO;
     }
 

--- a/Sources/BranchSDK/BranchRequestDeepLink.m
+++ b/Sources/BranchSDK/BranchRequestDeepLink.m
@@ -267,7 +267,7 @@
 
     if (preferenceHelper.referringURL != nil) {
         [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"~referring_link found in response: %@, sending sendOpen network request." ,preferenceHelper.referringURL] error:nil];
-        [[Branch getInstance] sendOpen:response.data];
+        [[Branch getInstance] sendOpen:response.data callCallback:NO];
     } else {
         [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"No referring URL on deeplink data. Not sending sendOpen network request."] error:nil];
     }

--- a/Sources/BranchSDK/BranchRequestDeepLink.m
+++ b/Sources/BranchSDK/BranchRequestDeepLink.m
@@ -267,7 +267,7 @@
 
     if (preferenceHelper.referringURL != nil) {
         [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"~referring_link found in response: %@, sending sendOpen network request." ,preferenceHelper.referringURL] error:nil];
-        [[Branch getInstance] sendOpen:response.data callCallback:NO];
+        [[Branch getInstance] sendOpen:response.data];
     } else {
         [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"No referring URL on deeplink data. Not sending sendOpen network request."] error:nil];
     }

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -447,7 +447,7 @@ extern NSString * __nonnull const BNCSpotlightFeature;
  
  @warning This function is an internal helper function for session initalization and should not be used by apps.
  **/
-- (void)initUserSessionAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier urlString:(NSString *)urlString reset:(BOOL)reset __attribute__((deprecated("Use sendOpen instead.")));
+- (void)initUserSessionAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier urlString:(NSString *)urlString reset:(BOOL)reset __attribute__((deprecated("Use requestDeepLinkData or sendOpen instead.")));
 
 /**
  Allow Branch to handle a link opening the app, returning whether it was from a Branch link or not.

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -561,9 +561,9 @@ extern NSString * __nonnull const BNCSpotlightFeature;
 /**
  Sends a Branch Open event with attribution to our new route.
  */
-- (void)sendOpen:(BOOL)callCallback;
+- (void)sendOpen;
 
-- (void)sendOpen:(NSDictionary *)responseData callCallback:(BOOL)callCallback;
+- (void)sendOpen:(NSDictionary *)responseData;
 
 #pragma mark - Pre-initialization support
 

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -447,7 +447,7 @@ extern NSString * __nonnull const BNCSpotlightFeature;
  
  @warning This function is an internal helper function for session initalization and should not be used by apps.
  **/
-- (void)initUserSessionAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier urlString:(NSString *)urlString reset:(BOOL)reset;
+- (void)initUserSessionAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier urlString:(NSString *)urlString reset:(BOOL)reset __attribute__((deprecated("Use sendOpen instead.")));
 
 /**
  Allow Branch to handle a link opening the app, returning whether it was from a Branch link or not.
@@ -561,9 +561,9 @@ extern NSString * __nonnull const BNCSpotlightFeature;
 /**
  Sends a Branch Open event with attribution to our new route.
  */
-- (void)sendOpen;
+- (void)sendOpen:(BOOL)callCallback;
 
-- (void)sendOpen:(NSDictionary *)responseData;
+- (void)sendOpen:(NSDictionary *)responseData callCallback:(BOOL)callCallback;
 
 #pragma mark - Pre-initialization support
 


### PR DESCRIPTION
## Reference
EMT-3754 - replaced inituserSessionAndCallCallback with sendOpen methods

## Summary
<!-- Simple summary of what was changed. -->
Replacing old session initialization methods with new functions.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Without session initialization other Branch features would not work.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
1. Start app
2. Click sendCommerceEvent to send event.
3. Click Create Branch Link to create link
4. Confirm 200 responses on each.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
