### PR TITLE
Bump actions/checkout from 4 to 6 on 4.0.0-beta.0 (cherry-pick #1547)

### DIFF
--- a/.github/workflows/automation-trigger-test.yml
+++ b/.github/workflows/automation-trigger-test.yml
@@ -23,7 +23,7 @@ jobs:
       BROWSERSTACK_USER: ${{ secrets.BROWSER_STACK_USER }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install the Apple certificate and provisioning profile
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -66,7 +66,7 @@ jobs:
            echo "::add-mask::$parsed"
            echo "BrowserStackIOSBuildKey=$parsed" >> "$GITHUB_ENV"
       - name: Cheout Automation Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: BranchMetrics/qentelli-saas-sdk-testing-automation
           token: ${{ secrets.BRANCHLET_ACCESS_TOKEN_PUBLIC }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/post-release-qa.yml
+++ b/.github/workflows/post-release-qa.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install pod, build project and run tests
         run: |
             mkdir -p test-results
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run carthage command, build project and run tests
         run: |
             mkdir -p test-results
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: build project and run tests
         run: |
             mkdir -p test-results
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install pod, build project and run tests
         run: |
             mkdir -p test-results

--- a/.github/workflows/pre-release-qa.yml
+++ b/.github/workflows/pre-release-qa.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install pod, build project and run tests
         run: |
             mkdir -p test-results
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Create Cart File, run carthage command, build project and run tests
         env:
             BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: build project and run tests
         run: |
             mkdir -p test-results
@@ -99,7 +99,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: build xcframework, then build project and run tests
         run: |
             mkdir -p test-results
@@ -128,7 +128,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: build static xcframework, then build project and run tests
         run: |
             mkdir -p test-results
@@ -157,7 +157,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install pod, build project and run tests
         run: |
             mkdir -p test-results
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Verify Integration using Carthage for tvOS
         run: |
             mkdir -p test-results
@@ -190,7 +190,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: build xcframework, then build project and run tests
         run: |
             mkdir -p test-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run static analysis
         run: |
             xcodebuild analyze -project BranchSDK.xcodeproj
@@ -31,7 +31,7 @@ jobs:
   #   needs: [static-analysis]
   #   steps:
   #     - name: Check out code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v6
   #     - name: Update Version
   #       run: |
   #           if [[ ${{ inputs.version }} == "patch" ]]; then
@@ -56,7 +56,7 @@ jobs:
     needs: [static-analysis]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install the Apple certificate
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -99,7 +99,7 @@ jobs:
     needs: [static-analysis]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install the Apple certificate
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -140,7 +140,7 @@ jobs:
     needs: [static-analysis]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build static xcframework
         run: |
             ./scripts/prep_static_xcframework.sh
@@ -158,7 +158,7 @@ jobs:
     needs: [static-analysis]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build static xcframework
         run: |
             ./scripts/prep_static_xcframework_noidfa.sh
@@ -175,7 +175,7 @@ jobs:
     needs: [build-framework, build-static-framework, build-noidfa-framework, build-static-noidfa-framework]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run unit tests
         run: |
           echo "branch=${{ github.ref }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Reference
No ticket. CI maintenance on the `4.0.0-beta.0` branch.

## Summary
Cherry-pick of #1547 (already merged on master): bumps `actions/checkout` from v4 to v6 across all workflows on the `4.0.0-beta.0` branch.

## Motivation
GitHub will force all actions to run on Node 24 starting June 16th, 2026 ([announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). `checkout@v4` runs on Node 20. Since PR CI runs the workflows from the PR's branch, the open beta PRs (#1592, #1595) could start failing next week for reasons unrelated to their code. Master already received this bump via #1547; this brings the beta branch in line.

Note: `upload-artifact@v4`/`@v3` and `cache@v3` are also Node 20 and still present on both master and this branch. Dependabot should cover those next (#1597 and #1598 are open on master); keeping this PR scoped to the already-validated checkout bump.

## Type Of Change
- [x] CI/build maintenance (no SDK code changes)

## Testing Instructions
CI on this PR is the test: all verify jobs should run and pass with `checkout@v6`, same as they already do on master.

cc @BranchMetrics/saas-sdk-devs for visibility.
