### PR TITLE
Fix dropped initSession callback when auto sendOpen is in flight (session-ready bridge)

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BranchClassTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchClassTests.m
@@ -18,6 +18,12 @@
 - (void)writeObjectToDefaults:(NSString *)key value:(NSObject *)value;
 @end
 
+
+// Expose private session-state internals used to reproduce the in-flight open window.
+@interface Branch (SessionReadySettleTest)
+- (void)handleInitSuccessAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier;
+@end
+
 @interface BranchClassTests : XCTestCase
 @property (nonatomic, strong) Branch *branch;
 @property (nonatomic, strong, readwrite) BNCPreferenceHelper *prefHelper;
@@ -454,6 +460,36 @@
     NSString *finalAnonID = [BNCPreferenceHelper sharedInstance].anonID;
     XCTAssertTrue([finalAnonID isEqualToString:anonID1] || [finalAnonID isEqualToString:anonID2],
                   @"One of the anonID values should be set");
+}
+
+
+// Regression test for the in-flight auto open window: a handler registered via
+// initSession while an open is in flight (status Initializing == 1) must still
+// be invoked when the open settles silently (callCallback:NO), which is how the
+// automatic sendOpen completes its requests.
+- (void)testInitSessionCallbackRegisteredWhileOpenInFlightIsInvoked {
+    // Force the state an in-flight automatic open leaves us in.
+    [self.branch setValue:@(1) forKey:@"initializationStatus"];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"init callback invoked after silent settle"];
+    __block BOOL alreadyFulfilled = NO;
+    [self.branch initSessionWithLaunchOptions:@{} andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
+        if (!alreadyFulfilled) {
+            alreadyFulfilled = YES;
+            [expectation fulfill];
+        }
+    }];
+
+    // Let the isolation queue process the registration before the open settles.
+    [NSThread sleepForTimeInterval:0.5];
+
+    // Simulate the in-flight automatic open settling the session silently.
+    [self.branch handleInitSuccessAndCallCallback:NO sceneIdentifier:nil];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    // Reset session state so this test does not leak into others.
+    [self.branch setValue:@(0) forKey:@"initializationStatus"];
 }
 
 @end

--- a/BranchSDKTests/BNCRequestFactoryTests.m
+++ b/BranchSDKTests/BNCRequestFactoryTests.m
@@ -106,9 +106,8 @@
     XCTAssertTrue([universalLinkURL isEqualToString:[json objectForKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL]]);
 }
 
-// EMT-3892 regression: the deferred, unattributed launch/organic open (no resolved link)
-// must not carry universal_link_url or link_data — those belong only to the single
-// attributed open sent once the deep link actually resolves.
+// EMT-3892 regression: the unattributed open must not carry universal_link_url or
+// link_data — those belong only to the attributed open sent once the link resolves.
 - (void)testDataForOpenWithoutResolvedLinkCarriesNoLinkData {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd" UUID:self.requestUUID TimeStamp:self.requestCreationTimeStamp];
     NSDictionary *json = [factory dataForOpenWithURLString:nil];

--- a/BranchSDKTests/BNCRequestFactoryTests.m
+++ b/BranchSDKTests/BNCRequestFactoryTests.m
@@ -95,6 +95,29 @@
     XCTAssertTrue([self.requestUUID isEqualToString:[json objectForKey:BRANCH_REQUEST_KEY_REQUEST_UUID]]);
 }
 
+// EMT-3892 regression: an open request built for a resolved universal link must carry
+// universal_link_url so the server can attribute it.
+- (void)testDataForOpenWithUniversalLinkCarriesUniversalLinkURL {
+    BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd" UUID:self.requestUUID TimeStamp:self.requestCreationTimeStamp];
+    NSString *universalLinkURL = @"https://example.app.link/abc123";
+    NSDictionary *json = [factory dataForOpenWithURLString:universalLinkURL];
+    XCTAssertNotNil(json);
+
+    XCTAssertTrue([universalLinkURL isEqualToString:[json objectForKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL]]);
+}
+
+// EMT-3892 regression: the deferred, unattributed launch/organic open (no resolved link)
+// must not carry universal_link_url or link_data — those belong only to the single
+// attributed open sent once the deep link actually resolves.
+- (void)testDataForOpenWithoutResolvedLinkCarriesNoLinkData {
+    BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd" UUID:self.requestUUID TimeStamp:self.requestCreationTimeStamp];
+    NSDictionary *json = [factory dataForOpenWithURLString:nil];
+    XCTAssertNotNil(json);
+
+    XCTAssertNil([json objectForKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL]);
+    XCTAssertNil([json objectForKey:@"link_data"]);
+}
+
 - (void)testDataForEvent {
     NSDictionary *event = @{@"name": @"ADD_TO_CART"};
     

--- a/BranchSDKTests/BranchClassTests.m
+++ b/BranchSDKTests/BranchClassTests.m
@@ -13,6 +13,10 @@
 #import "BNCAppGroupsData.h"
 #import "BNCPartnerParameters.h"
 #import "BNCServerRequestQueue.h"
+#import "BNCServerRequestOperation.h"
+#import "BNCServerResponse.h"
+#import "BranchRequestOpen.h"
+#import "BranchRequestDeepLink.h"
 
 @interface BNCPreferenceHelper(Test)
 // Expose internal private method to clear EEA data
@@ -38,8 +42,25 @@
 - (NSInteger)queueDepth;
 @end
 
+// Expose the underlying NSOperationQueue for deterministic, network-free behavioral testing:
+// suspend it, drive the SDK's real deep-link/open code paths, inspect exactly what got
+// enqueued (class + urlString/linkData) before anything can touch the network, then clear it.
+// No HTTP-stub library exists in this suite; this is the cleanest network-free equivalent.
+@interface BNCServerRequestQueue (OperationsIntrospectionTest)
+@property (strong, nonatomic) NSOperationQueue *operationQueue;
+@end
+
 @interface BranchClassTests : XCTestCase
 @property (nonatomic, strong) Branch *branch;
+// Baseline of the shared singleton state the EMT-3892/3893 behavioral tests mutate,
+// captured per-test in -setUp and fully restored in -tearDown. The behavioral tests drive
+// the real deep-link/open code paths, which write attributionLevel/referringURL/sessionParams
+// on the shared BNCPreferenceHelper and arm an async fallback timer on the shared Branch
+// singleton. Without a hermetic tearDown that leaked state (Full attribution left set, a
+// still-armed fallback timer firing into a later test) polluted order-dependent pre-existing
+// tests in this file. Restoring the captured baseline makes every test self-contained again.
+@property (nonatomic, assign) NSTimeInterval savedTimeout;
+@property (nonatomic, copy) BranchAttributionLevel savedAttributionLevel;
 @end
 
 @implementation BranchClassTests
@@ -47,9 +68,30 @@
 - (void)setUp {
     [super setUp];
     self.branch = [Branch getInstance];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    self.savedTimeout = preferenceHelper.timeout;
+    self.savedAttributionLevel = preferenceHelper.attributionLevel;
 }
 
 - (void)tearDown {
+    // Hermetic reset of everything the behavioral tests touch on the shared singletons, so a
+    // failed/early-returning test can never leak state into the next one. Runs regardless of
+    // per-test inline cleanup (which is now belt-and-suspenders).
+    [self.branch cancelDeepLinkOpenFallback];           // stop any pending async open timer
+    self.branch.deepLinkOpenPending = NO;
+    [self.branch setValue:nil forKey:@"lastAttributedDeepLinkURL"];
+    [self restoreRealRequestQueue];
+
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.referringURL = nil;
+    preferenceHelper.sessionParams = nil;
+    preferenceHelper.timeout = self.savedTimeout;
+    preferenceHelper.attributionLevel = self.savedAttributionLevel;
+
+    // Let any already-scheduled async block drain against this clean baseline rather than
+    // landing mid-way through the next test.
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+
     self.branch = nil;
     [super tearDown];
 }
@@ -330,6 +372,268 @@
     // Cancel the bounded fallback so it doesn't fire a real network open later in the suite.
     [self.branch cancelDeepLinkOpenFallback];
     XCTAssertFalse(self.branch.deepLinkOpenPending, @"Cancelling the fallback should clear the pending flag.");
+}
+
+#pragma mark - EMT-3892/3893 behavioral evidence helpers
+
+// Swaps in a disposable, permanently-suspended BNCServerRequestQueue so a scenario's
+// enqueued requests can be inspected deterministically (class + urlString/linkData)
+// without ever touching the network and without depending on / polluting the shared
+// singleton queue other tests use. No HTTP-stub library exists in this suite; this is the
+// cleanest network-free equivalent. Always pair with -restoreRealRequestQueue.
+//
+// Note: we deliberately never cancel/resume this fake queue. BNCServerRequestOperation's
+// -cancel sets isFinished directly when a suspended (never-started) operation is
+// cancelled, which trips an NSOperationQueue internal consistency check ("went
+// isFinished=YES without being started by the queue it is in") and crashed the test host
+// during development of this test. Simply discarding the whole disposable queue (and its
+// never-started operations) avoids that pre-existing, out-of-scope edge case entirely.
+- (BNCServerRequestQueue *)installFakeRequestQueue {
+    BNCServerRequestQueue *fakeQueue = [BNCServerRequestQueue new];
+    fakeQueue.operationQueue.suspended = YES;
+    [self.branch setValue:fakeQueue forKey:@"requestQueue"];
+    return fakeQueue;
+}
+
+- (void)restoreRealRequestQueue {
+    [self.branch setValue:[BNCServerRequestQueue getInstance] forKey:@"requestQueue"];
+}
+
+// All BNCServerRequestOperation-wrapped requests currently sitting in `queue`, as untyped
+// KVC handles (`.request`, and on that the request's own `urlString`/`linkData`). This
+// project links BranchSDK in a way that loads some classes (confirmed: at least
+// BNCServerRequestOperation) from two different images at once — `isKindOfClass:`/typed
+// casts against a class the test target also references directly are unreliable (the
+// object's real class and the test file's compile-time class symbol can be two distinct
+// Class objects with the same name). `-valueForKey:` and `NSStringFromClass` dispatch by
+// selector/name instead of Class-pointer identity, sidestepping that entirely — the same
+// "queue-introspection pattern" already used via `queueDepth` elsewhere in this file.
+- (NSArray<NSOperation *> *)requestOperationsIn:(BNCServerRequestQueue *)queue {
+    NSMutableArray<NSOperation *> *ops = [NSMutableArray array];
+    for (NSOperation *op in queue.operationQueue.operations) {
+        if ([NSStringFromClass([op class]) isEqualToString:@"BNCServerRequestOperation"]) {
+            [ops addObject:op];
+        }
+    }
+    return ops;
+}
+
+// Deterministically waits for the bounded fallback (deferLaunchOpenPendingDeepLinkResolution's
+// timer) to actually enqueue an open into `queue`, instead of a fixed wall-clock sleep. Uses
+// XCTNSPredicateExpectation, which polls the predicate and resolves the instant it becomes
+// true — so this is as fast as the real event AND has a generous ceiling for slow/loaded CI,
+// eliminating the flakiness of racing a tight fixed-duration sleep against an async GCD timer.
+- (void)waitForFallbackOpenIn:(BNCServerRequestQueue *)queue timeout:(NSTimeInterval)timeout {
+    NSPredicate *fallbackEnqueued = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+        return [self requestOperationsIn:queue].count > 0;
+    }];
+    XCTNSPredicateExpectation *expectation = [[XCTNSPredicateExpectation alloc] initWithPredicate:fallbackEnqueued object:self];
+    XCTWaiterResult result = [XCTWaiter waitForExpectations:@[expectation] timeout:timeout];
+    XCTAssertEqual(result, XCTWaiterResultCompleted, @"The bounded fallback did not enqueue an open within %.1fs.", timeout);
+}
+
+// A stub deep-link resolution response carrying a resolved, clicked Branch link — what
+// BranchRequestDeepLink.processResponse: would receive from a real /v3/deeplink round trip.
+- (BNCServerResponse *)stubDeepLinkResponseForLink:(NSString *)linkURL {
+    BNCServerResponse *response = [BNCServerResponse new];
+    response.statusCode = @200;
+    response.data = @{
+        BRANCH_RESPONSE_KEY_SESSION_DATA: @{
+            BRANCH_RESPONSE_KEY_CLICKED_BRANCH_LINK: @1,
+            BRANCH_RESPONSE_KEY_BRANCH_REFERRING_LINK: linkURL
+        }
+    };
+    return response;
+}
+
+// A stub plain-open response carrying no link click — what a generic /v3/events/open would
+// receive when there is nothing to attribute.
+- (BNCServerResponse *)stubGenericOpenResponse {
+    BNCServerResponse *response = [BNCServerResponse new];
+    response.statusCode = @200;
+    response.data = @{
+        BRANCH_RESPONSE_KEY_SESSION_DATA: @{
+            BRANCH_RESPONSE_KEY_CLICKED_BRANCH_LINK: @0
+        }
+    };
+    return response;
+}
+
+#pragma mark - EMT-3892/3893 behavioral evidence
+
+// Behavior 1: deep link + requestDeepLinkData resolving emits exactly ONE open request for
+// the session, and it carries the resolved link — not an unattributed launch open plus a
+// duplicate attributed one. No HTTP stub library exists in this suite, so the deep-link
+// server round trip is simulated directly on a BranchRequestDeepLink instance (mirrors what
+// requestDeepLinkData: does internally once its network call returns).
+- (void)testDeepLinkResolutionEmitsExactlyOneAttributedOpenCarryingTheLink {
+    NSString *linkURL = @"https://example.app.link/behavioral-resolved";
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.attributionLevel = BranchAttributionLevelFull; // deterministic regardless of ambient state
+
+    BNCServerRequestQueue *fakeQueue = [self installFakeRequestQueue];
+
+    // 1) App receives the deep link: SDK defers the launch open (EMT-3892).
+    [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
+    XCTAssertEqual([self requestOperationsIn:fakeQueue].count, 0u,
+                    @"Nothing should be enqueued yet — the open is deferred pending resolution.");
+
+    // 2) App calls requestDeepLinkData(...), which (a) cancels the bounded fallback and
+    // (b) resolves the link. We simulate step (b)'s network response directly.
+    [self.branch cancelDeepLinkOpenFallback];
+
+    BranchRequestDeepLink *deepLinkRequest = [[BranchRequestDeepLink alloc] initWithCallback:nil];
+    deepLinkRequest.urlString = linkURL;
+    deepLinkRequest.uri = linkURL;
+    [deepLinkRequest processResponse:[self stubDeepLinkResponseForLink:linkURL] error:nil];
+
+    // Exactly one open — the single ATTRIBUTED open sent by
+    // BranchRequestDeepLink.processResponse: (sendOpen:), not a second/duplicate one.
+    NSArray<NSOperation *> *ops = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(ops.count, 1u, @"Exactly one open request must be emitted for a resolved deep link — no duplicate.");
+
+    if (ops.count == 1) {
+        id request = [ops.firstObject valueForKey:@"request"];
+        XCTAssertEqualObjects(NSStringFromClass([request class]), @"BranchRequestOpen");
+        // The attributed open carries the resolved link via linkData (-> link_data on the
+        // wire, see BranchRequestOpen.makeRequest:), not urlString. Documented explicitly
+        // because it differs from the factory-level universal_link_url path.
+        NSDictionary *linkData = [request valueForKey:@"linkData"];
+        XCTAssertNotNil(linkData, @"The attributed open must carry the resolved link's data.");
+        NSDictionary *carriedSessionData = linkData[BRANCH_RESPONSE_KEY_SESSION_DATA];
+        XCTAssertEqualObjects(carriedSessionData[BRANCH_RESPONSE_KEY_BRANCH_REFERRING_LINK], linkURL,
+                               @"The carried link data must be the resolved link, not stale/empty.");
+    }
+
+    [self restoreRealRequestQueue];
+}
+
+// Behavior 2: deep link received, requestDeepLinkData never called → after the bounded
+// fallback window, exactly ONE generic (unattributed) open is emitted so the open isn't
+// lost. preferenceHelper.timeout is temporarily lowered so the test doesn't wait out the
+// real ~5.5s default.
+- (void)testDeepLinkFallbackFiresExactlyOneUnattributedOpenWhenNeverResolved {
+    NSString *linkURL = @"https://example.app.link/behavioral-never-resolved";
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.attributionLevel = BranchAttributionLevelFull;
+    NSTimeInterval originalTimeout = preferenceHelper.timeout;
+    preferenceHelper.timeout = 0.2; // deterministic, fast fallback window for this test only
+
+    BNCServerRequestQueue *fakeQueue = [self installFakeRequestQueue];
+
+    [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
+    XCTAssertTrue(self.branch.deepLinkOpenPending);
+
+    // Do NOT call requestDeepLinkData. Wait for the fallback to actually enqueue the open —
+    // not a fixed wall-clock sleep, which raced under load (observed flaky: sometimes the
+    // 0.2s-configured fallback hadn't fired by a fixed 0.6s deadline). A polling predicate
+    // expectation resolves as soon as the real event happens, with a generous ceiling.
+    [self waitForFallbackOpenIn:fakeQueue timeout:5.0];
+
+    XCTAssertFalse(self.branch.deepLinkOpenPending, @"The fallback should have fired and cleared the pending flag.");
+
+    NSArray<NSOperation *> *ops = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(ops.count, 1u, @"Exactly one open must be emitted by the fallback — the deep link open must not be lost.");
+
+    if (ops.count == 1) {
+        id request = [ops.firstObject valueForKey:@"request"];
+        XCTAssertEqualObjects(NSStringFromClass([request class]), @"BranchRequestOpen");
+        XCTAssertNil([request valueForKey:@"urlString"], @"The fallback open must be unattributed: no urlString.");
+        XCTAssertNil([request valueForKey:@"linkData"], @"The fallback open must be unattributed: no linkData.");
+    }
+
+    [self restoreRealRequestQueue];
+    preferenceHelper.timeout = originalTimeout;
+}
+
+// Behavior 3 (EMT-3893, SDK layer only): once the attributed open's own response settles,
+// referringURL is cleared, so a subsequent open with no new link does not carry the
+// previous link forward. Does NOT prove/disprove server-side stickiness (out of scope).
+- (void)testResolvedLinkDoesNotStickToSubsequentOpen {
+    NSString *linkURL = @"https://example.app.link/behavioral-sticky-check";
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.attributionLevel = BranchAttributionLevelFull;
+
+    [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
+    [self.branch cancelDeepLinkOpenFallback];
+    XCTAssertEqualObjects(preferenceHelper.referringURL, linkURL);
+
+    // The attributed open's own response settling is what clears referringURL today. Use an
+    // isolated request instance (nil callback) so this assertion-only step doesn't also
+    // trigger the production completion path's async main-queue side effects on the shared
+    // Branch singleton.
+    BranchRequestOpen *attributedOpenRequest = [[BranchRequestOpen alloc] initWithCallback:nil];
+    attributedOpenRequest.urlString = nil;
+    attributedOpenRequest.linkData = [self stubDeepLinkResponseForLink:linkURL].data;
+    [attributedOpenRequest processResponse:[self stubGenericOpenResponse] error:nil];
+    XCTAssertNil(preferenceHelper.referringURL,
+                 @"EMT-3893 (SDK layer): referringURL must be cleared once the attributed open settles, not held sticky.");
+
+    // A subsequent open with no new link (e.g. organic foreground) must not carry the
+    // previous link forward.
+    BNCServerRequestQueue *fakeQueue = [self installFakeRequestQueue];
+
+    [self.branch sendOpen];
+
+    NSArray<NSOperation *> *ops = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(ops.count, 1u);
+    if (ops.count == 1) {
+        id request = [ops.firstObject valueForKey:@"request"];
+        XCTAssertNil([request valueForKey:@"urlString"], @"A subsequent organic open must not carry the previous link's URL.");
+        XCTAssertNil([request valueForKey:@"linkData"], @"A subsequent organic open must not carry the previous link's data.");
+    }
+
+    [self restoreRealRequestQueue];
+}
+
+// Behavior 4 (ordering risk, FIXED): requestDeepLinkData resolving a link BEFORE
+// handleUniversalDeepLink_private is invoked for that same link. This can legitimately
+// happen (e.g. a host app resolving from scene-connection options before UIKit separately
+// delivers the universal link). Regression test for the fix: handleUniversalDeepLink_private
+// now recognizes (via lastAttributedDeepLinkURL) that this exact link was already attributed
+// by the earlier resolution and does not re-arm the deferred-open fallback, so only ONE open
+// total is ever emitted — previously this double-emitted (1 attributed + 1 unattributed
+// fallback).
+- (void)testRequestDeepLinkDataBeforeUniversalDeepLinkEmitsExactlyOneOpen {
+    NSString *linkURL = @"https://example.app.link/behavioral-ordering-edge";
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.attributionLevel = BranchAttributionLevelFull;
+    NSTimeInterval originalTimeout = preferenceHelper.timeout;
+    preferenceHelper.timeout = 0.2;
+
+    BNCServerRequestQueue *fakeQueue = [self installFakeRequestQueue];
+
+    // 1) requestDeepLinkData resolves FIRST — the attributed open fires on its own.
+    [self.branch cancelDeepLinkOpenFallback];
+    BranchRequestDeepLink *deepLinkRequest = [[BranchRequestDeepLink alloc] initWithCallback:nil];
+    deepLinkRequest.urlString = linkURL;
+    [deepLinkRequest processResponse:[self stubDeepLinkResponseForLink:linkURL] error:nil];
+
+    NSArray<NSOperation *> *afterResolution = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(afterResolution.count, 1u, @"The early resolution alone must still emit exactly one attributed open.");
+
+    // 2) handleUniversalDeepLink_private fires AFTER, for the same (already-attributed)
+    // link. The fix: it must recognize that and skip arming the deferred-open fallback.
+    [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
+    XCTAssertFalse(self.branch.deepLinkOpenPending,
+                    @"A link already attributed via an earlier resolution must not re-arm the deferred-open fallback.");
+
+    // Deterministically prove no SECOND open ever appears — an inverted expectation, not a
+    // blind sleep: it only fails if a second open actually shows up within the window, so
+    // there is no false-negative risk from finishing "too fast".
+    NSPredicate *secondOpenEnqueued = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+        return [self requestOperationsIn:fakeQueue].count > 1;
+    }];
+    XCTNSPredicateExpectation *noSecondOpen = [[XCTNSPredicateExpectation alloc] initWithPredicate:secondOpenEnqueued object:self];
+    noSecondOpen.inverted = YES;
+    [self waitForExpectations:@[noSecondOpen] timeout:0.5];
+
+    NSArray<NSOperation *> *afterSecondCall = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(afterSecondCall.count, 1u,
+                    @"EMT-3892 ordering fix: resolving before handleUniversalDeepLink_private must still emit exactly ONE open total, not a duplicate.");
+
+    [self restoreRealRequestQueue];
+    preferenceHelper.timeout = originalTimeout;
 }
 
 @end

--- a/BranchSDKTests/BranchClassTests.m
+++ b/BranchSDKTests/BranchClassTests.m
@@ -12,6 +12,7 @@
 #import "BNCPasteboard.h"
 #import "BNCAppGroupsData.h"
 #import "BNCPartnerParameters.h"
+#import "BNCServerRequestQueue.h"
 
 @interface BNCPreferenceHelper(Test)
 // Expose internal private method to clear EEA data
@@ -22,6 +23,19 @@
 // Expose private session-state internals used to reproduce the in-flight open window.
 @interface Branch (SessionReadySettleTest)
 - (void)handleInitSuccessAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier;
+@end
+
+// Expose the EMT-3892 deep-link open deferral internals for regression testing.
+@interface Branch (DeepLinkOpenDeferralTest)
+@property (nonatomic, assign) BOOL deepLinkOpenPending;
+- (BOOL)handleUniversalDeepLink_private:(NSString *)urlString sceneIdentifier:(NSString *)sceneIdentifier;
+- (void)cancelDeepLinkOpenFallback;
+@end
+
+// Expose the private queue-depth accessor to detect a synchronous enqueue without being
+// coupled to leftover install/open state from other tests sharing the Branch singleton.
+@interface BNCServerRequestQueue (QueueDepthTest)
+- (NSInteger)queueDepth;
 @end
 
 @interface BranchClassTests : XCTestCase
@@ -296,6 +310,26 @@
 
     // Reset session state so this test does not leak into others.
     [self.branch setValue:@(0) forKey:@"initializationStatus"];
+}
+
+// EMT-3892 regression: a Branch deep-link (universal link) open must defer the launch
+// open until requestDeepLinkData resolves it, not synchronously enqueue an unattributed
+// generic open. See Branch.m deferLaunchOpenPendingDeepLinkResolution.
+- (void)testUniversalDeepLinkDefersLaunchOpenPendingResolution {
+    BNCServerRequestQueue *requestQueue = [self.branch valueForKey:@"requestQueue"];
+    NSInteger queueDepthBeforeDeepLink = [requestQueue queueDepth];
+
+    BOOL isBranchLink = [self.branch handleUniversalDeepLink_private:@"https://example.app.link/abc123" sceneIdentifier:nil];
+    XCTAssertTrue(isBranchLink, @"example.app.link should be recognized as a Branch link.");
+
+    // Delta-based (not absolute) so this isn't coupled to install/open state left behind by
+    // other tests sharing the Branch singleton and its request queue.
+    XCTAssertEqual([requestQueue queueDepth], queueDepthBeforeDeepLink, @"The launch open must be deferred, not enqueued synchronously before deep-link resolution.");
+    XCTAssertTrue(self.branch.deepLinkOpenPending, @"Deep link resolution should be marked pending after a universal link open.");
+
+    // Cancel the bounded fallback so it doesn't fire a real network open later in the suite.
+    [self.branch cancelDeepLinkOpenFallback];
+    XCTAssertFalse(self.branch.deepLinkOpenPending, @"Cancelling the fallback should clear the pending flag.");
 }
 
 @end

--- a/BranchSDKTests/BranchClassTests.m
+++ b/BranchSDKTests/BranchClassTests.m
@@ -36,29 +36,21 @@
 - (void)cancelDeepLinkOpenFallback;
 @end
 
-// Expose the private queue-depth accessor to detect a synchronous enqueue without being
-// coupled to leftover install/open state from other tests sharing the Branch singleton.
+// Detects a synchronous enqueue via a delta, not an absolute count, so leftover state from
+// other tests sharing the Branch singleton doesn't matter.
 @interface BNCServerRequestQueue (QueueDepthTest)
 - (NSInteger)queueDepth;
 @end
 
-// Expose the underlying NSOperationQueue for deterministic, network-free behavioral testing:
-// suspend it, drive the SDK's real deep-link/open code paths, inspect exactly what got
-// enqueued (class + urlString/linkData) before anything can touch the network, then clear it.
-// No HTTP-stub library exists in this suite; this is the cleanest network-free equivalent.
+// Lets a test suspend the queue and inspect what was enqueued before it can hit the network.
 @interface BNCServerRequestQueue (OperationsIntrospectionTest)
 @property (strong, nonatomic) NSOperationQueue *operationQueue;
 @end
 
 @interface BranchClassTests : XCTestCase
 @property (nonatomic, strong) Branch *branch;
-// Baseline of the shared singleton state the EMT-3892/3893 behavioral tests mutate,
-// captured per-test in -setUp and fully restored in -tearDown. The behavioral tests drive
-// the real deep-link/open code paths, which write attributionLevel/referringURL/sessionParams
-// on the shared BNCPreferenceHelper and arm an async fallback timer on the shared Branch
-// singleton. Without a hermetic tearDown that leaked state (Full attribution left set, a
-// still-armed fallback timer firing into a later test) polluted order-dependent pre-existing
-// tests in this file. Restoring the captured baseline makes every test self-contained again.
+// Shared-singleton baseline captured in -setUp and restored in -tearDown. Without it, the
+// behavioral tests below leaked attribution level and armed timers into later tests.
 @property (nonatomic, assign) NSTimeInterval savedTimeout;
 @property (nonatomic, copy) BranchAttributionLevel savedAttributionLevel;
 @end
@@ -74,9 +66,7 @@
 }
 
 - (void)tearDown {
-    // Hermetic reset of everything the behavioral tests touch on the shared singletons, so a
-    // failed/early-returning test can never leak state into the next one. Runs regardless of
-    // per-test inline cleanup (which is now belt-and-suspenders).
+    // Hermetic reset, so a failed or early-returning test can't leak state into the next one.
     [self.branch cancelDeepLinkOpenFallback];           // stop any pending async open timer
     self.branch.deepLinkOpenPending = NO;
     [self.branch setValue:nil forKey:@"lastAttributedDeepLinkURL"];
@@ -88,8 +78,7 @@
     preferenceHelper.timeout = self.savedTimeout;
     preferenceHelper.attributionLevel = self.savedAttributionLevel;
 
-    // Let any already-scheduled async block drain against this clean baseline rather than
-    // landing mid-way through the next test.
+    // Drain any already-scheduled async block against this clean baseline.
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
 
     self.branch = nil;
@@ -354,9 +343,8 @@
     [self.branch setValue:@(0) forKey:@"initializationStatus"];
 }
 
-// EMT-3892 regression: a Branch deep-link (universal link) open must defer the launch
-// open until requestDeepLinkData resolves it, not synchronously enqueue an unattributed
-// generic open. See Branch.m deferLaunchOpenPendingDeepLinkResolution.
+// EMT-3892: a universal link must defer the launch open until resolution, not enqueue an
+// unattributed open synchronously.
 - (void)testUniversalDeepLinkDefersLaunchOpenPendingResolution {
     BNCServerRequestQueue *requestQueue = [self.branch valueForKey:@"requestQueue"];
     NSInteger queueDepthBeforeDeepLink = [requestQueue queueDepth];
@@ -364,8 +352,6 @@
     BOOL isBranchLink = [self.branch handleUniversalDeepLink_private:@"https://example.app.link/abc123" sceneIdentifier:nil];
     XCTAssertTrue(isBranchLink, @"example.app.link should be recognized as a Branch link.");
 
-    // Delta-based (not absolute) so this isn't coupled to install/open state left behind by
-    // other tests sharing the Branch singleton and its request queue.
     XCTAssertEqual([requestQueue queueDepth], queueDepthBeforeDeepLink, @"The launch open must be deferred, not enqueued synchronously before deep-link resolution.");
     XCTAssertTrue(self.branch.deepLinkOpenPending, @"Deep link resolution should be marked pending after a universal link open.");
 
@@ -376,18 +362,11 @@
 
 #pragma mark - EMT-3892/3893 behavioral evidence helpers
 
-// Swaps in a disposable, permanently-suspended BNCServerRequestQueue so a scenario's
-// enqueued requests can be inspected deterministically (class + urlString/linkData)
-// without ever touching the network and without depending on / polluting the shared
-// singleton queue other tests use. No HTTP-stub library exists in this suite; this is the
-// cleanest network-free equivalent. Always pair with -restoreRealRequestQueue.
-//
-// Note: we deliberately never cancel/resume this fake queue. BNCServerRequestOperation's
-// -cancel sets isFinished directly when a suspended (never-started) operation is
-// cancelled, which trips an NSOperationQueue internal consistency check ("went
-// isFinished=YES without being started by the queue it is in") and crashed the test host
-// during development of this test. Simply discarding the whole disposable queue (and its
-// never-started operations) avoids that pre-existing, out-of-scope edge case entirely.
+// A disposable, permanently-suspended queue: enqueued requests can be inspected without
+// touching the network or the shared singleton queue. Pair with -restoreRealRequestQueue.
+// Never cancel/resume it — cancelling a suspended, never-started BNCServerRequestOperation
+// trips an NSOperationQueue consistency check and crashes the test host. Discarding the
+// whole queue avoids that pre-existing, out-of-scope edge case.
 - (BNCServerRequestQueue *)installFakeRequestQueue {
     BNCServerRequestQueue *fakeQueue = [BNCServerRequestQueue new];
     fakeQueue.operationQueue.suspended = YES;
@@ -399,15 +378,9 @@
     [self.branch setValue:[BNCServerRequestQueue getInstance] forKey:@"requestQueue"];
 }
 
-// All BNCServerRequestOperation-wrapped requests currently sitting in `queue`, as untyped
-// KVC handles (`.request`, and on that the request's own `urlString`/`linkData`). This
-// project links BranchSDK in a way that loads some classes (confirmed: at least
-// BNCServerRequestOperation) from two different images at once — `isKindOfClass:`/typed
-// casts against a class the test target also references directly are unreliable (the
-// object's real class and the test file's compile-time class symbol can be two distinct
-// Class objects with the same name). `-valueForKey:` and `NSStringFromClass` dispatch by
-// selector/name instead of Class-pointer identity, sidestepping that entirely — the same
-// "queue-introspection pattern" already used via `queueDepth` elsewhere in this file.
+// The requests currently in `queue`, matched and read by name (NSStringFromClass / KVC)
+// rather than isKindOfClass:. This project loads BNCServerRequestOperation from two images
+// at once, so Class-pointer identity is unreliable here; name-based dispatch is not.
 - (NSArray<NSOperation *> *)requestOperationsIn:(BNCServerRequestQueue *)queue {
     NSMutableArray<NSOperation *> *ops = [NSMutableArray array];
     for (NSOperation *op in queue.operationQueue.operations) {
@@ -418,11 +391,8 @@
     return ops;
 }
 
-// Deterministically waits for the bounded fallback (deferLaunchOpenPendingDeepLinkResolution's
-// timer) to actually enqueue an open into `queue`, instead of a fixed wall-clock sleep. Uses
-// XCTNSPredicateExpectation, which polls the predicate and resolves the instant it becomes
-// true — so this is as fast as the real event AND has a generous ceiling for slow/loaded CI,
-// eliminating the flakiness of racing a tight fixed-duration sleep against an async GCD timer.
+// Waits for the bounded fallback to actually enqueue an open, polling instead of sleeping a
+// fixed duration — as fast as the real event, with a generous ceiling for loaded CI.
 - (void)waitForFallbackOpenIn:(BNCServerRequestQueue *)queue timeout:(NSTimeInterval)timeout {
     NSPredicate *fallbackEnqueued = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
         return [self requestOperationsIn:queue].count > 0;
@@ -461,11 +431,8 @@
 
 #pragma mark - EMT-3892/3893 behavioral evidence
 
-// Behavior 1: deep link + requestDeepLinkData resolving emits exactly ONE open request for
-// the session, and it carries the resolved link — not an unattributed launch open plus a
-// duplicate attributed one. No HTTP stub library exists in this suite, so the deep-link
-// server round trip is simulated directly on a BranchRequestDeepLink instance (mirrors what
-// requestDeepLinkData: does internally once its network call returns).
+// Behavior 1: a resolved deep link emits exactly one open, carrying the link. The server
+// round trip is simulated on a BranchRequestDeepLink — no HTTP stub library in this suite.
 - (void)testDeepLinkResolutionEmitsExactlyOneAttributedOpenCarryingTheLink {
     NSString *linkURL = @"https://example.app.link/behavioral-resolved";
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
@@ -478,8 +445,7 @@
     XCTAssertEqual([self requestOperationsIn:fakeQueue].count, 0u,
                     @"Nothing should be enqueued yet — the open is deferred pending resolution.");
 
-    // 2) App calls requestDeepLinkData(...), which (a) cancels the bounded fallback and
-    // (b) resolves the link. We simulate step (b)'s network response directly.
+    // 2) App calls requestDeepLinkData: it cancels the fallback, then resolves the link.
     [self.branch cancelDeepLinkOpenFallback];
 
     BranchRequestDeepLink *deepLinkRequest = [[BranchRequestDeepLink alloc] initWithCallback:nil];
@@ -487,17 +453,14 @@
     deepLinkRequest.uri = linkURL;
     [deepLinkRequest processResponse:[self stubDeepLinkResponseForLink:linkURL] error:nil];
 
-    // Exactly one open — the single ATTRIBUTED open sent by
-    // BranchRequestDeepLink.processResponse: (sendOpen:), not a second/duplicate one.
     NSArray<NSOperation *> *ops = [self requestOperationsIn:fakeQueue];
     XCTAssertEqual(ops.count, 1u, @"Exactly one open request must be emitted for a resolved deep link — no duplicate.");
 
     if (ops.count == 1) {
         id request = [ops.firstObject valueForKey:@"request"];
         XCTAssertEqualObjects(NSStringFromClass([request class]), @"BranchRequestOpen");
-        // The attributed open carries the resolved link via linkData (-> link_data on the
-        // wire, see BranchRequestOpen.makeRequest:), not urlString. Documented explicitly
-        // because it differs from the factory-level universal_link_url path.
+        // The attributed open carries the link via linkData (-> link_data on the wire), not
+        // urlString — unlike the factory-level universal_link_url path.
         NSDictionary *linkData = [request valueForKey:@"linkData"];
         XCTAssertNotNil(linkData, @"The attributed open must carry the resolved link's data.");
         NSDictionary *carriedSessionData = linkData[BRANCH_RESPONSE_KEY_SESSION_DATA];
@@ -508,10 +471,8 @@
     [self restoreRealRequestQueue];
 }
 
-// Behavior 2: deep link received, requestDeepLinkData never called → after the bounded
-// fallback window, exactly ONE generic (unattributed) open is emitted so the open isn't
-// lost. preferenceHelper.timeout is temporarily lowered so the test doesn't wait out the
-// real ~5.5s default.
+// Behavior 2: requestDeepLinkData never called → the fallback emits exactly one
+// unattributed open, so the open isn't lost. timeout is lowered to keep the test fast.
 - (void)testDeepLinkFallbackFiresExactlyOneUnattributedOpenWhenNeverResolved {
     NSString *linkURL = @"https://example.app.link/behavioral-never-resolved";
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
@@ -524,10 +485,8 @@
     [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
     XCTAssertTrue(self.branch.deepLinkOpenPending);
 
-    // Do NOT call requestDeepLinkData. Wait for the fallback to actually enqueue the open —
-    // not a fixed wall-clock sleep, which raced under load (observed flaky: sometimes the
-    // 0.2s-configured fallback hadn't fired by a fixed 0.6s deadline). A polling predicate
-    // expectation resolves as soon as the real event happens, with a generous ceiling.
+    // Do NOT call requestDeepLinkData. Poll for the fallback rather than sleeping a fixed
+    // duration, which was observed flaky under load.
     [self waitForFallbackOpenIn:fakeQueue timeout:5.0];
 
     XCTAssertFalse(self.branch.deepLinkOpenPending, @"The fallback should have fired and cleared the pending flag.");
@@ -546,9 +505,9 @@
     preferenceHelper.timeout = originalTimeout;
 }
 
-// Behavior 3 (EMT-3893, SDK layer only): once the attributed open's own response settles,
-// referringURL is cleared, so a subsequent open with no new link does not carry the
-// previous link forward. Does NOT prove/disprove server-side stickiness (out of scope).
+// Behavior 3 (EMT-3893, SDK layer only): referringURL clears once the attributed open
+// settles, so a later open doesn't carry the link forward. Server-side stickiness is out
+// of scope here.
 - (void)testResolvedLinkDoesNotStickToSubsequentOpen {
     NSString *linkURL = @"https://example.app.link/behavioral-sticky-check";
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
@@ -558,10 +517,8 @@
     [self.branch cancelDeepLinkOpenFallback];
     XCTAssertEqualObjects(preferenceHelper.referringURL, linkURL);
 
-    // The attributed open's own response settling is what clears referringURL today. Use an
-    // isolated request instance (nil callback) so this assertion-only step doesn't also
-    // trigger the production completion path's async main-queue side effects on the shared
-    // Branch singleton.
+    // The attributed open's response settling is what clears referringURL. An isolated
+    // instance (nil callback) avoids the production path's async side effects on the singleton.
     BranchRequestOpen *attributedOpenRequest = [[BranchRequestOpen alloc] initWithCallback:nil];
     attributedOpenRequest.urlString = nil;
     attributedOpenRequest.linkData = [self stubDeepLinkResponseForLink:linkURL].data;
@@ -586,14 +543,9 @@
     [self restoreRealRequestQueue];
 }
 
-// Behavior 4 (ordering risk, FIXED): requestDeepLinkData resolving a link BEFORE
-// handleUniversalDeepLink_private is invoked for that same link. This can legitimately
-// happen (e.g. a host app resolving from scene-connection options before UIKit separately
-// delivers the universal link). Regression test for the fix: handleUniversalDeepLink_private
-// now recognizes (via lastAttributedDeepLinkURL) that this exact link was already attributed
-// by the earlier resolution and does not re-arm the deferred-open fallback, so only ONE open
-// total is ever emitted — previously this double-emitted (1 attributed + 1 unattributed
-// fallback).
+// Behavior 4: resolution arriving BEFORE handleUniversalDeepLink_private for the same link
+// (e.g. the host app resolves from scene-connection options first). Previously this
+// double-emitted; lastAttributedDeepLinkURL now keeps it at one open.
 - (void)testRequestDeepLinkDataBeforeUniversalDeepLinkEmitsExactlyOneOpen {
     NSString *linkURL = @"https://example.app.link/behavioral-ordering-edge";
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
@@ -612,15 +564,13 @@
     NSArray<NSOperation *> *afterResolution = [self requestOperationsIn:fakeQueue];
     XCTAssertEqual(afterResolution.count, 1u, @"The early resolution alone must still emit exactly one attributed open.");
 
-    // 2) handleUniversalDeepLink_private fires AFTER, for the same (already-attributed)
-    // link. The fix: it must recognize that and skip arming the deferred-open fallback.
+    // 2) handleUniversalDeepLink_private fires after, for the same already-attributed link;
+    // it must skip arming the fallback.
     [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
     XCTAssertFalse(self.branch.deepLinkOpenPending,
                     @"A link already attributed via an earlier resolution must not re-arm the deferred-open fallback.");
 
-    // Deterministically prove no SECOND open ever appears — an inverted expectation, not a
-    // blind sleep: it only fails if a second open actually shows up within the window, so
-    // there is no false-negative risk from finishing "too fast".
+    // Inverted expectation: fails only if a second open actually appears in the window.
     NSPredicate *secondOpenEnqueued = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
         return [self requestOperationsIn:fakeQueue].count > 1;
     }];

--- a/BranchSDKTests/BranchClassTests.m
+++ b/BranchSDKTests/BranchClassTests.m
@@ -18,6 +18,12 @@
 - (void)writeObjectToDefaults:(NSString *)key value:(NSObject *)value;
 @end
 
+
+// Expose private session-state internals used to reproduce the in-flight open window.
+@interface Branch (SessionReadySettleTest)
+- (void)handleInitSuccessAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier;
+@end
+
 @interface BranchClassTests : XCTestCase
 @property (nonatomic, strong) Branch *branch;
 @end
@@ -261,5 +267,35 @@
     
 }
 
+
+
+// Regression test for the in-flight auto open window: a handler registered via
+// initSession while an open is in flight (status Initializing == 1) must still
+// be invoked when the open settles silently (callCallback:NO), which is how the
+// automatic sendOpen completes its requests.
+- (void)testInitSessionCallbackRegisteredWhileOpenInFlightIsInvoked {
+    // Force the state an in-flight automatic open leaves us in.
+    [self.branch setValue:@(1) forKey:@"initializationStatus"];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"init callback invoked after silent settle"];
+    __block BOOL alreadyFulfilled = NO;
+    [self.branch initSessionWithLaunchOptions:@{} andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
+        if (!alreadyFulfilled) {
+            alreadyFulfilled = YES;
+            [expectation fulfill];
+        }
+    }];
+
+    // Let the isolation queue process the registration before the open settles.
+    [NSThread sleepForTimeInterval:0.5];
+
+    // Simulate the in-flight automatic open settling the session silently.
+    [self.branch handleInitSuccessAndCallCallback:NO sceneIdentifier:nil];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    // Reset session state so this test does not leak into others.
+    [self.branch setValue:@(0) forKey:@"initializationStatus"];
+}
 
 @end

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -161,6 +161,13 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 @property (assign, nonatomic) BOOL deepLinkOpenPending;
 // Bounded fallback timer that fires the deferred open (unattributed) if resolution never happens.
 @property (strong, nonatomic) dispatch_source_t deepLinkOpenFallbackTimer;
+// EMT-3892 ordering fix: the link URL an ATTRIBUTED open was last sent for. Lets
+// handleUniversalDeepLink_private: recognize "this link was already resolved and
+// attributed" when requestDeepLinkData wins a race and resolves it first — otherwise the
+// late-arriving handleUniversalDeepLink_private: call would re-arm the deferred-open
+// fallback and emit a second, unattributed open for the same link. Cleared alongside
+// referringURL once the attributed open's own session settles (sendOpenNotificationWithLinkParameters:).
+@property (copy, nonatomic) NSString *lastAttributedDeepLinkURL;
 @property (assign, nonatomic) BOOL shouldAutomaticallyDeepLink;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
 @property (strong, nonatomic) BNCPreferenceHelper *preferenceHelper;
@@ -1003,6 +1010,16 @@ static NSString *bnc_branchKey = nil;
     }
 
     // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
+    // EMT-3892 ordering fix: requestDeepLinkData can win the race and resolve (and attribute)
+    // this exact link before this method runs (e.g. UIKit delivering continueUserActivity:
+    // after a scene-connection-options-driven resolution). If so, the single attributed open
+    // has already been sent — don't re-arm the deferred-open fallback, or it would fire a
+    // second, unattributed open for the same link.
+    if (urlString.length && [self.lastAttributedDeepLinkURL isEqualToString:urlString]) {
+        [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"handleUniversalDeepLink_private: %@ was already attributed via an earlier resolution; not re-arming the deferred open.", urlString] error:nil];
+        return [Branch isBranchLink:urlString];
+    }
+
     // EMT-3892: defer the launch open until requestDeepLinkData resolves this link (see
     // deferLaunchOpenPendingDeepLinkResolution) instead of firing an immediate, unattributed
     // sendOpen here — which previously raced with the attributed sendOpen: fired after
@@ -2425,6 +2442,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         userInfo:userInfo];
 
     self.preferenceHelper.referringURL = nil;
+    // EMT-3892 ordering fix: the session this attribution belonged to has now settled;
+    // a later resolution of the same link URL should be treated as fresh again.
+    self.lastAttributedDeepLinkURL = nil;
 }
 
 - (void)removeViewControllerFromRootNavigationController:(UIViewController*)branchSharingController {
@@ -2799,6 +2819,12 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         [[BranchLogger shared] logDebug: @"Branch Attribution Level set to NONE. Branch sendOpen network request prevented." error:nil];
         return;
     }
+
+    // EMT-3892 ordering fix: remember which link this ATTRIBUTED open was for, so a
+    // handleUniversalDeepLink_private: call arriving afterward for the SAME link (already
+    // resolved here) does not re-arm the deferred-open fallback. See
+    // handleUniversalDeepLink_private: and lastAttributedDeepLinkURL.
+    self.lastAttributedDeepLinkURL = self.preferenceHelper.referringURL;
 
     // Prepare callback block
     callbackWithStatus openCallback = ^(BOOL success, NSError *error) {

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -155,6 +155,12 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 - (void)notifyWhenSessionReady:(void (^)(NSError * _Nullable error))block;
 - (void)deliverSessionReadyBlocksWithError:(nullable NSError *)error;
 - (void)discardSessionReadyBlocks;
+
+// EMT-3892: true while a Branch deep-link open is deferred, waiting for requestDeepLinkData
+// to resolve it into a single ATTRIBUTED open. See deferLaunchOpenPendingDeepLinkResolution.
+@property (assign, nonatomic) BOOL deepLinkOpenPending;
+// Bounded fallback timer that fires the deferred open (unattributed) if resolution never happens.
+@property (strong, nonatomic) dispatch_source_t deepLinkOpenFallbackTimer;
 @property (assign, nonatomic) BOOL shouldAutomaticallyDeepLink;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
 @property (strong, nonatomic) BNCPreferenceHelper *preferenceHelper;
@@ -997,7 +1003,11 @@ static NSString *bnc_branchKey = nil;
     }
 
     // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
-    [self sendOpen];
+    // EMT-3892: defer the launch open until requestDeepLinkData resolves this link (see
+    // deferLaunchOpenPendingDeepLinkResolution) instead of firing an immediate, unattributed
+    // sendOpen here — which previously raced with the attributed sendOpen: fired after
+    // resolution and produced two /v3/events/open calls for one deep-link open.
+    [self deferLaunchOpenPendingDeepLinkResolution];
 
     return [Branch isBranchLink:urlString];
 }
@@ -1993,9 +2003,11 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        if (!Branch.trackingDisabled && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
-            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue] error:nil];
-            
+        // EMT-3892: don't fire the organic auto-open while a deep-link open is deferred and
+        // waiting on requestDeepLinkData — that would be a second, premature, unattributed open.
+        if (!Branch.trackingDisabled && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue && !self.deepLinkOpenPending) {
+            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d deepLinkOpenPending %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue, self.deepLinkOpenPending] error:nil];
+
             [self sendOpen];
         }
     });
@@ -2464,6 +2476,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [self cancelDeepLinkOpenFallback];
 }
 
 - (void)registerPluginName:(NSString *)name version:(NSString *)version {
@@ -2529,6 +2542,11 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 - (void) requestDeepLinkData:(NSString *)branchLink callback:(nullable callbackWithParams)callback {
     [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"requestDeepLinkData called with branchLink: %@", branchLink] error:nil];
+
+    // EMT-3892: resolution is now underway — cancel the deferred launch open's bounded
+    // fallback so it doesn't also fire once BranchRequestDeepLink.processResponse sends the
+    // real (attributed) open below.
+    [self cancelDeepLinkOpenFallback];
 
     if (branchLink.length > 0) {
         [self.requestQueue cancelPendingDeepLinkRequests];
@@ -2667,6 +2685,76 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 - (void)discardSessionReadyBlocks {
     @synchronized (self.sessionReadyBlocks) {
         [self.sessionReadyBlocks removeAllObjects];
+    }
+}
+
+#pragma mark - Deep Link Open Deferral (EMT-3892 / EMT-3893)
+
+// A Branch deep-link open defers the automatic launch open until requestDeepLinkData
+// resolves it, so BranchRequestDeepLink.processResponse can send the single ATTRIBUTED
+// open (sendOpen:). This replaces the previous behavior of firing an immediate,
+// unattributed sendOpen here *and* a second, attributed sendOpen: after resolution
+// (EMT-3892: duplicate /v3/events/open).
+//
+// Bounded fallback: if the host app never calls requestDeepLinkData, the deferred open
+// would otherwise never fire and the open would be lost. The fallback timer mirrors the
+// network timeout already used for open/deep-link requests (preferenceHelper.timeout,
+// default 5.5s — see BNCServerInterface), so it never fires sooner than a real deep-link
+// resolution attempt could complete.
+- (void)deferLaunchOpenPendingDeepLinkResolution {
+    self.deepLinkOpenPending = YES;
+
+    @synchronized (self) {
+        [self cancelDeepLinkOpenFallbackTimerLocked];
+
+        NSTimeInterval fallbackInterval = self.preferenceHelper.timeout;
+        dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.isolationQueue);
+        dispatch_source_set_timer(timer,
+                                  dispatch_time(DISPATCH_TIME_NOW, (int64_t)(fallbackInterval * NSEC_PER_SEC)),
+                                  DISPATCH_TIME_FOREVER,
+                                  (int64_t)(0.1 * NSEC_PER_SEC));
+
+        // __weak avoids a retain cycle (self -> timer -> event handler block -> self).
+        __weak Branch *weakSelf = self;
+        dispatch_source_set_event_handler(timer, ^{
+            Branch *strongSelf = weakSelf;
+            if (!strongSelf) return;
+
+            @synchronized (strongSelf) {
+                if (!strongSelf.deepLinkOpenPending) return;
+                strongSelf.deepLinkOpenPending = NO;
+                [strongSelf cancelDeepLinkOpenFallbackTimerLocked];
+            }
+
+            [[BranchLogger shared] logVerbose:@"Deep link resolution fallback fired: requestDeepLinkData was not called in time. Sending the deferred open unattributed so it is not lost." error:nil];
+
+            // EMT-3893: this open gave up waiting for resolution, so it must not report a
+            // link it never actually attributed. Note: the server MAY still echo a prior
+            // click's ~referring_link in the session response (residual server-side
+            // stickiness) — that is a backend concern tracked separately and not fixed here.
+            strongSelf.preferenceHelper.referringURL = nil;
+            [strongSelf sendOpen];
+        });
+
+        self.deepLinkOpenFallbackTimer = timer;
+        dispatch_resume(timer);
+    }
+}
+
+// Called once deep-link resolution is actually underway (requestDeepLinkData was invoked)
+// so the bounded fallback above does not also fire a redundant, unattributed open.
+- (void)cancelDeepLinkOpenFallback {
+    self.deepLinkOpenPending = NO;
+    @synchronized (self) {
+        [self cancelDeepLinkOpenFallbackTimerLocked];
+    }
+}
+
+// Must be called while holding @synchronized(self).
+- (void)cancelDeepLinkOpenFallbackTimerLocked {
+    if (self.deepLinkOpenFallbackTimer) {
+        dispatch_source_cancel(self.deepLinkOpenFallbackTimer);
+        self.deepLinkOpenFallbackTimer = nil;
     }
 }
 

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -156,17 +156,11 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 - (void)deliverSessionReadyBlocksWithError:(nullable NSError *)error;
 - (void)discardSessionReadyBlocks;
 
-// EMT-3892: true while a Branch deep-link open is deferred, waiting for requestDeepLinkData
-// to resolve it into a single ATTRIBUTED open. See deferLaunchOpenPendingDeepLinkResolution.
+// EMT-3892: a deep-link open is deferred until requestDeepLinkData resolves it into one
+// attributed open. lastAttributedDeepLinkURL guards the reverse order (resolution first),
+// where re-arming the fallback would emit a second, unattributed open.
 @property (assign, nonatomic) BOOL deepLinkOpenPending;
-// Bounded fallback timer that fires the deferred open (unattributed) if resolution never happens.
 @property (strong, nonatomic) dispatch_source_t deepLinkOpenFallbackTimer;
-// EMT-3892 ordering fix: the link URL an ATTRIBUTED open was last sent for. Lets
-// handleUniversalDeepLink_private: recognize "this link was already resolved and
-// attributed" when requestDeepLinkData wins a race and resolves it first — otherwise the
-// late-arriving handleUniversalDeepLink_private: call would re-arm the deferred-open
-// fallback and emit a second, unattributed open for the same link. Cleared alongside
-// referringURL once the attributed open's own session settles (sendOpenNotificationWithLinkParameters:).
 @property (copy, nonatomic) NSString *lastAttributedDeepLinkURL;
 @property (assign, nonatomic) BOOL shouldAutomaticallyDeepLink;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
@@ -1010,20 +1004,15 @@ static NSString *bnc_branchKey = nil;
     }
 
     // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
-    // EMT-3892 ordering fix: requestDeepLinkData can win the race and resolve (and attribute)
-    // this exact link before this method runs (e.g. UIKit delivering continueUserActivity:
-    // after a scene-connection-options-driven resolution). If so, the single attributed open
-    // has already been sent — don't re-arm the deferred-open fallback, or it would fire a
-    // second, unattributed open for the same link.
+    // EMT-3892: resolution may have already attributed this link (race).
+    // Re-arming the fallback here would emit a second, unattributed open.
     if (urlString.length && [self.lastAttributedDeepLinkURL isEqualToString:urlString]) {
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"handleUniversalDeepLink_private: %@ was already attributed via an earlier resolution; not re-arming the deferred open.", urlString] error:nil];
         return [Branch isBranchLink:urlString];
     }
 
-    // EMT-3892: defer the launch open until requestDeepLinkData resolves this link (see
-    // deferLaunchOpenPendingDeepLinkResolution) instead of firing an immediate, unattributed
-    // sendOpen here — which previously raced with the attributed sendOpen: fired after
-    // resolution and produced two /v3/events/open calls for one deep-link open.
+    // EMT-3892: defer the launch open until requestDeepLinkData resolves it, instead of
+    // firing an unattributed sendOpen that races the attributed one.
     [self deferLaunchOpenPendingDeepLinkResolution];
 
     return [Branch isBranchLink:urlString];
@@ -2020,8 +2009,8 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        // EMT-3892: don't fire the organic auto-open while a deep-link open is deferred and
-        // waiting on requestDeepLinkData — that would be a second, premature, unattributed open.
+        // EMT-3892: a deferred deep-link open is still pending; firing here would be a
+        // second, unattributed open.
         if (!Branch.trackingDisabled && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue && !self.deepLinkOpenPending) {
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d deepLinkOpenPending %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue, self.deepLinkOpenPending] error:nil];
 
@@ -2442,8 +2431,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         userInfo:userInfo];
 
     self.preferenceHelper.referringURL = nil;
-    // EMT-3892 ordering fix: the session this attribution belonged to has now settled;
-    // a later resolution of the same link URL should be treated as fresh again.
+    // EMT-3892: the session settled, so the same link URL is fresh again.
     self.lastAttributedDeepLinkURL = nil;
 }
 
@@ -2563,9 +2551,8 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 - (void) requestDeepLinkData:(NSString *)branchLink callback:(nullable callbackWithParams)callback {
     [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"requestDeepLinkData called with branchLink: %@", branchLink] error:nil];
 
-    // EMT-3892: resolution is now underway — cancel the deferred launch open's bounded
-    // fallback so it doesn't also fire once BranchRequestDeepLink.processResponse sends the
-    // real (attributed) open below.
+    // EMT-3892: resolution is underway; the attributed open comes from
+    // BranchRequestDeepLink.processResponse, so the fallback must not also fire.
     [self cancelDeepLinkOpenFallback];
 
     if (branchLink.length > 0) {
@@ -2710,17 +2697,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 #pragma mark - Deep Link Open Deferral (EMT-3892 / EMT-3893)
 
-// A Branch deep-link open defers the automatic launch open until requestDeepLinkData
-// resolves it, so BranchRequestDeepLink.processResponse can send the single ATTRIBUTED
-// open (sendOpen:). This replaces the previous behavior of firing an immediate,
-// unattributed sendOpen here *and* a second, attributed sendOpen: after resolution
-// (EMT-3892: duplicate /v3/events/open).
-//
-// Bounded fallback: if the host app never calls requestDeepLinkData, the deferred open
-// would otherwise never fire and the open would be lost. The fallback timer mirrors the
-// network timeout already used for open/deep-link requests (preferenceHelper.timeout,
-// default 5.5s — see BNCServerInterface), so it never fires sooner than a real deep-link
-// resolution attempt could complete.
+// Defers the launch open so BranchRequestDeepLink.processResponse sends the single
+// attributed open. Bounded fallback (preferenceHelper.timeout, default 5.5s) fires an
+// unattributed open if the host app never calls requestDeepLinkData. EMT-3892.
 - (void)deferLaunchOpenPendingDeepLinkResolution {
     self.deepLinkOpenPending = YES;
 
@@ -2748,10 +2727,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
             [[BranchLogger shared] logVerbose:@"Deep link resolution fallback fired: requestDeepLinkData was not called in time. Sending the deferred open unattributed so it is not lost." error:nil];
 
-            // EMT-3893: this open gave up waiting for resolution, so it must not report a
-            // link it never actually attributed. Note: the server MAY still echo a prior
-            // click's ~referring_link in the session response (residual server-side
-            // stickiness) — that is a backend concern tracked separately and not fixed here.
+            // EMT-3893: this open never attributed a link, so it must not report one.
             strongSelf.preferenceHelper.referringURL = nil;
             [strongSelf sendOpen];
         });
@@ -2761,8 +2737,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     }
 }
 
-// Called once deep-link resolution is actually underway (requestDeepLinkData was invoked)
-// so the bounded fallback above does not also fire a redundant, unattributed open.
+// Called once resolution is underway, so the fallback does not fire a redundant open.
 - (void)cancelDeepLinkOpenFallback {
     self.deepLinkOpenPending = NO;
     @synchronized (self) {
@@ -2820,10 +2795,8 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         return;
     }
 
-    // EMT-3892 ordering fix: remember which link this ATTRIBUTED open was for, so a
-    // handleUniversalDeepLink_private: call arriving afterward for the SAME link (already
-    // resolved here) does not re-arm the deferred-open fallback. See
-    // handleUniversalDeepLink_private: and lastAttributedDeepLinkURL.
+    // EMT-3892: remember the link this attributed open was for, so a later
+    // handleUniversalDeepLink_private: for the same link skips the fallback.
     self.lastAttributedDeepLinkURL = self.preferenceHelper.referringURL;
 
     // Prepare callback block

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -149,6 +149,12 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 @property (strong, nonatomic) dispatch_semaphore_t processing_sema;
 @property (assign, nonatomic) NSInteger networkCount;
 @property (assign, nonatomic) BNCInitStatus initializationStatus;
+// Blocks waiting for the in-flight session open to settle. See notifyWhenSessionReady:.
+@property (strong, nonatomic) NSMutableArray<void (^)(NSError * _Nullable)> *sessionReadyBlocks;
+
+- (void)notifyWhenSessionReady:(void (^)(NSError * _Nullable error))block;
+- (void)flushSessionReadyBlocksWithError:(nullable NSError *)error;
+- (void)discardSessionReadyBlocks;
 @property (assign, nonatomic) BOOL shouldAutomaticallyDeepLink;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
 @property (strong, nonatomic) BNCPreferenceHelper *preferenceHelper;
@@ -217,6 +223,7 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
     _initializationStatus = BNCInitStatusUninitialized;
     _processing_sema = dispatch_semaphore_create(1);
     _networkCount = 0;
+    _sessionReadyBlocks = [NSMutableArray new];
     _deepLinkControllers = [[NSMutableDictionary alloc] init];
     _allowedSchemeList = [[NSMutableArray alloc] init];
     _serverAPI = [BNCServerAPI sharedInstance];
@@ -2114,6 +2121,28 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
                 }
             });
         }
+        // If an open is already in flight (status Initializing), its completion runs with
+        // callCallback:NO and would never invoke a handler registered here. Queue the
+        // callback on the session-ready list; the settle handlers flush it.
+        else if (callCallback && self.initializationStatus == BNCInitStatusInitializing) {
+            [[BranchLogger shared] logVerbose:@"Session open already in flight, queueing init callback until it settles." error:nil];
+            [self notifyWhenSessionReady:^(NSError * _Nullable error) {
+                if (!self.sceneSessionInitWithCallback) return;
+                BNCInitSessionResponse *response = [BNCInitSessionResponse new];
+                response.sceneIdentifier = sceneIdentifier;
+                if (error) {
+                    response.error = error;
+                    response.params = [NSDictionary new];
+                    response.universalObject = [BranchUniversalObject new];
+                    response.linkProperties = [BranchLinkProperties new];
+                } else {
+                    response.params = [self getLatestReferringParams];
+                    response.universalObject = [self getLatestReferringBranchUniversalObject];
+                    response.linkProperties = [self getLatestReferringBranchLinkProperties];
+                }
+                self.sceneSessionInitWithCallback(response, error);
+            }];
+        }
     });
 }
 
@@ -2220,6 +2249,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
             response.sceneIdentifier = sceneIdentifier;
             self.sceneSessionInitWithCallback(response, nil);
         }
+        [self discardSessionReadyBlocks];
+    } else {
+        [self flushSessionReadyBlocksWithError:nil];
     }
     [self sendOpenNotificationWithLinkParameters:latestReferringParams error:nil];
 
@@ -2422,6 +2454,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
             response.sceneIdentifier = sceneIdentifier;
             self.sceneSessionInitWithCallback(response, error);
         }
+        [self discardSessionReadyBlocks];
+    } else {
+        [self flushSessionReadyBlocksWithError:error];
     }
 
     [self sendOpenNotificationWithLinkParameters:@{} error:error];
@@ -2588,6 +2623,52 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     }
 }
 #endif
+
+#pragma mark - Session Ready Notification
+
+// Internal primitive for "the session has settled" notifications.
+// Blocks queued here are flushed (or discarded, see below) by
+// handleInitSuccessAndCallCallback: / handleInitFailure:, which every open
+// completion funnels through. The legacy initSession flow uses this as a
+// bridge while an auto open is in flight; the mechanism is independent of
+// initUserSessionAndCallCallback and survives its planned removal.
+- (void)notifyWhenSessionReady:(void (^)(NSError * _Nullable error))block {
+    if (!block) return;
+    BOOL callNow = NO;
+    @synchronized (self.sessionReadyBlocks) {
+        if (self.initializationStatus == BNCInitStatusInitialized) {
+            callNow = YES;
+        } else {
+            [self.sessionReadyBlocks addObject:[block copy]];
+        }
+    }
+    if (callNow) {
+        dispatch_async(dispatch_get_main_queue(), ^{ block(nil); });
+    }
+}
+
+- (void)flushSessionReadyBlocksWithError:(nullable NSError *)error {
+    NSArray *blocks;
+    @synchronized (self.sessionReadyBlocks) {
+        if (self.sessionReadyBlocks.count == 0) return;
+        blocks = [self.sessionReadyBlocks copy];
+        [self.sessionReadyBlocks removeAllObjects];
+    }
+    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Flushing %lu session-ready block(s).", (unsigned long)blocks.count] error:error];
+    for (void (^block)(NSError * _Nullable) in blocks) {
+        dispatch_async(dispatch_get_main_queue(), ^{ block(error); });
+    }
+}
+
+// Used on the callCallback:YES settle paths: the registered handler was just
+// invoked directly, and queued blocks all target that same single
+// sceneSessionInitWithCallback property, so flushing them too would call the
+// handler twice for one settle.
+- (void)discardSessionReadyBlocks {
+    @synchronized (self.sessionReadyBlocks) {
+        [self.sessionReadyBlocks removeAllObjects];
+    }
+}
 
 - (void) sendOpen {
     NSURL *URL = (self.preferenceHelper.referringURL.length) ? [NSURL URLWithString:self.preferenceHelper.referringURL] : nil;

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -2679,6 +2679,13 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 #pragma mark - Deep Link Open Deferral (EMT-3892 / EMT-3893)
 
+// Records the link an attributed open is for. Called by BranchRequestDeepLink once it has
+// resolved one, so a later handleUniversalDeepLink_private: for that same link skips
+// re-arming the fallback instead of producing a second open.
+- (void)markDeepLinkAttributed:(NSString *)urlString {
+    self.lastAttributedDeepLinkURL = urlString;
+}
+
 // Defers the launch open so BranchRequestDeepLink.processResponse sends the single
 // attributed open. Bounded fallback (preferenceHelper.timeout, default 5.5s) fires an
 // unattributed open if the host app never calls requestDeepLinkData. EMT-3892.
@@ -2783,7 +2790,12 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
     // EMT-3892: remember the link this attributed open was for, so a later
     // handleUniversalDeepLink_private: for the same link skips the fallback.
-    self.lastAttributedDeepLinkURL = self.preferenceHelper.referringURL;
+    // Only when we actually have one: in the resolution-first ordering
+    // BranchRequestDeepLink has already called markDeepLinkAttributed: with the resolved
+    // link, and referringURL is still nil here — overwriting would drop that mark.
+    if (self.preferenceHelper.referringURL.length) {
+        self.lastAttributedDeepLinkURL = self.preferenceHelper.referringURL;
+    }
 
     // Prepare callback block
     callbackWithStatus openCallback = ^(BOOL success, NSError *error) {

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -966,16 +966,13 @@ static NSString *bnc_branchKey = nil;
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Set universalLinkUrl and referringURL to %@", urlString] error:nil];
     }
 
-    // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
-    // EMT-3892: resolution may have already attributed this link (race).
-    // Re-arming the fallback here would emit a second, unattributed open.
+    // Skips re-arming the fallback if this link was already attributed.
     if (urlString.length && [self.lastAttributedDeepLinkURL isEqualToString:urlString]) {
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"handleUniversalDeepLink_private: %@ was already attributed via an earlier resolution; not re-arming the deferred open.", urlString] error:nil];
         return [Branch isBranchLink:urlString];
     }
 
-    // EMT-3892: defer the launch open until requestDeepLinkData resolves it, instead of
-    // firing an unattributed sendOpen that races the attributed one.
+    // Defers the launch open until requestDeepLinkData resolves it.
     [self deferLaunchOpenPendingDeepLinkResolution];
 
     return [Branch isBranchLink:urlString];
@@ -1989,10 +1986,9 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        // EMT-3892: a deferred deep-link open is still pending; firing here would be a
-        // second, unattributed open.
-        if (![Branch attributionLevelNone] && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue && !self.deepLinkOpenPending) {
-            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive attributionLevelNone %d initializationStatus %d installOrOpenInQueue %d deepLinkOpenPending %d", [Branch attributionLevelNone], self.initializationStatus, installOrOpenInQueue, self.deepLinkOpenPending] error:nil];
+        // Skips sending an open while a deferred deep-link open is still pending.
+        if (![Branch attributionLevelNone] && !installOrOpenInQueue && !self.deepLinkOpenPending) {
+            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive attributionLevelNone %d installOrOpenInQueue %d deepLinkOpenPending %d", [Branch attributionLevelNone], installOrOpenInQueue, self.deepLinkOpenPending] error:nil];
 
             [self sendOpen];
         }
@@ -2677,22 +2673,20 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     }
 }
 
-#pragma mark - Deep Link Open Deferral (EMT-3892 / EMT-3893)
+#pragma mark - Deep Link Open Deferral
 
-// Records the link an attributed open is for. Called by BranchRequestDeepLink once it has
-// resolved one, so a later handleUniversalDeepLink_private: for that same link skips
-// re-arming the fallback instead of producing a second open.
+// Records the link an attributed open is for, so a later handleUniversalDeepLink_private:
+// for the same link skips re-arming the fallback.
 - (void)markDeepLinkAttributed:(NSString *)urlString {
     self.lastAttributedDeepLinkURL = urlString;
 }
 
-// Defers the launch open so BranchRequestDeepLink.processResponse sends the single
-// attributed open. Bounded fallback (preferenceHelper.timeout, default 5.5s) fires an
-// unattributed open if the host app never calls requestDeepLinkData. EMT-3892.
+// Defers the launch open until the deep link resolves. Fallback fires after
+// preferenceHelper.timeout (default 5.5s) if requestDeepLinkData is never called.
 - (void)deferLaunchOpenPendingDeepLinkResolution {
-    self.deepLinkOpenPending = YES;
-
     @synchronized (self) {
+        self.deepLinkOpenPending = YES;
+
         [self cancelDeepLinkOpenFallbackTimerLocked];
 
         NSTimeInterval fallbackInterval = self.preferenceHelper.timeout;
@@ -2716,7 +2710,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
             [[BranchLogger shared] logVerbose:@"Deep link resolution fallback fired: requestDeepLinkData was not called in time. Sending the deferred open unattributed so it is not lost." error:nil];
 
-            // EMT-3893: this open never attributed a link, so it must not report one.
+            // Clears the referring URL so this open is not reported as attributed.
             strongSelf.preferenceHelper.referringURL = nil;
             [strongSelf sendOpen];
         });
@@ -2726,10 +2720,10 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     }
 }
 
-// Called once resolution is underway, so the fallback does not fire a redundant open.
+// Cancels the pending fallback.
 - (void)cancelDeepLinkOpenFallback {
-    self.deepLinkOpenPending = NO;
     @synchronized (self) {
+        self.deepLinkOpenPending = NO;
         [self cancelDeepLinkOpenFallbackTimerLocked];
     }
 }

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -153,7 +153,7 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 @property (strong, nonatomic) NSMutableArray<void (^)(NSError * _Nullable)> *sessionReadyBlocks;
 
 - (void)notifyWhenSessionReady:(void (^)(NSError * _Nullable error))block;
-- (void)flushSessionReadyBlocksWithError:(nullable NSError *)error;
+- (void)deliverSessionReadyBlocksWithError:(nullable NSError *)error;
 - (void)discardSessionReadyBlocks;
 @property (assign, nonatomic) BOOL shouldAutomaticallyDeepLink;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
@@ -2123,7 +2123,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         }
         // If an open is already in flight (status Initializing), its completion runs with
         // callCallback:NO and would never invoke a handler registered here. Queue the
-        // callback on the session-ready list; the settle handlers flush it.
+        // callback on the session-ready list; the settle handlers deliver it.
         else if (callCallback && self.initializationStatus == BNCInitStatusInitializing) {
             [[BranchLogger shared] logVerbose:@"Session open already in flight, queueing init callback until it settles." error:nil];
             [self notifyWhenSessionReady:^(NSError * _Nullable error) {
@@ -2251,7 +2251,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         }
         [self discardSessionReadyBlocks];
     } else {
-        [self flushSessionReadyBlocksWithError:nil];
+        [self deliverSessionReadyBlocksWithError:nil];
     }
     [self sendOpenNotificationWithLinkParameters:latestReferringParams error:nil];
 
@@ -2456,7 +2456,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         }
         [self discardSessionReadyBlocks];
     } else {
-        [self flushSessionReadyBlocksWithError:error];
+        [self deliverSessionReadyBlocksWithError:error];
     }
 
     [self sendOpenNotificationWithLinkParameters:@{} error:error];
@@ -2627,7 +2627,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 #pragma mark - Session Ready Notification
 
 // Internal primitive for "the session has settled" notifications.
-// Blocks queued here are flushed (or discarded, see below) by
+// Blocks queued here are delivered (or discarded, see below) by
 // handleInitSuccessAndCallCallback: / handleInitFailure:, which every open
 // completion funnels through. The legacy initSession flow uses this as a
 // bridge while an auto open is in flight; the mechanism is independent of
@@ -2647,14 +2647,14 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     }
 }
 
-- (void)flushSessionReadyBlocksWithError:(nullable NSError *)error {
+- (void)deliverSessionReadyBlocksWithError:(nullable NSError *)error {
     NSArray *blocks;
     @synchronized (self.sessionReadyBlocks) {
         if (self.sessionReadyBlocks.count == 0) return;
         blocks = [self.sessionReadyBlocks copy];
         [self.sessionReadyBlocks removeAllObjects];
     }
-    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Flushing %lu session-ready block(s).", (unsigned long)blocks.count] error:error];
+    [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Delivering %lu session-ready block(s).", (unsigned long)blocks.count] error:error];
     for (void (^block)(NSError * _Nullable) in blocks) {
         dispatch_async(dispatch_get_main_queue(), ^{ block(error); });
     }
@@ -2662,7 +2662,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 // Used on the callCallback:YES settle paths: the registered handler was just
 // invoked directly, and queued blocks all target that same single
-// sceneSessionInitWithCallback property, so flushing them too would call the
+// sceneSessionInitWithCallback property, so delivering them too would call the
 // handler twice for one settle.
 - (void)discardSessionReadyBlocks {
     @synchronized (self.sessionReadyBlocks) {

--- a/Sources/BranchSDK/BranchRequestDeepLink.m
+++ b/Sources/BranchSDK/BranchRequestDeepLink.m
@@ -16,9 +16,10 @@
 #import "BNCServerAPI.h"
 #import "BNCInAppBrowser.h"
 
-// Forward declaration of private Branch method
+// Forward declaration of private Branch methods
 @interface Branch (PrivateMethods)
 - (void)sendOpen:(NSDictionary *)responseData skipCallback:(BOOL)skipCallback;
+- (void)markDeepLinkAttributed:(NSString *)urlString;
 @end
 
 @implementation BranchRequestDeepLink
@@ -254,6 +255,12 @@ static BOOL deepLinkRequestWaitQueueIsSuspended = NO;
 
     if (referringURL != nil) {
         [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"~referring_link found in response: %@, sending sendOpen network request." ,referringURL] error:nil];
+        // EMT-3892: tell Branch which link this open attributes, so a later
+        // handleUniversalDeepLink_private: for the same link does not re-arm the
+        // deferred-open fallback and emit a second open. It has to be passed
+        // explicitly: this class no longer writes preferenceHelper.referringURL,
+        // so Branch cannot read the value back out in this ordering.
+        [[Branch getInstance] markDeepLinkAttributed:referringURL];
         [[Branch getInstance] sendOpen:response.data skipCallback:skipCallback];
     } else {
         [[BranchLogger shared] logDebug:@"No ~referring_link on deeplink data. Not sending sendOpen network request. Clearing link identifiers to prevent reuse." error:nil];

--- a/Sources/BranchSDK/BranchRequestOpen.m
+++ b/Sources/BranchSDK/BranchRequestOpen.m
@@ -148,7 +148,14 @@
         [sessionDataDict addEntriesFromDictionary:spotlightDic];
         sessionData = [BNCEncodingUtils encodeDictionaryToJsonString:sessionDataDict];
     }
-    
+
+    // EMT-3893: rewritten verbatim from every open's server response, by design (this is how
+    // getLatestReferringParams stays current for the session). The SDK clears its own link
+    // identifiers/referringURL after each open (see the "Clear link identifiers" block below
+    // and Branch.m sendOpenNotificationWithLinkParameters:), but the server MAY still echo a
+    // previous click's ~referring_link in session_data for an unrelated open (residual
+    // server-side stickiness). That is a backend behavior question tracked separately
+    // (EMT-3893) and intentionally not worked around here.
     preferenceHelper.sessionParams = sessionData;
 
     // Scenarios:

--- a/Sources/BranchSDK/BranchRequestOpen.m
+++ b/Sources/BranchSDK/BranchRequestOpen.m
@@ -149,13 +149,8 @@
         sessionData = [BNCEncodingUtils encodeDictionaryToJsonString:sessionDataDict];
     }
 
-    // EMT-3893: rewritten verbatim from every open's server response, by design (this is how
-    // getLatestReferringParams stays current for the session). The SDK clears its own link
-    // identifiers/referringURL after each open (see the "Clear link identifiers" block below
-    // and Branch.m sendOpenNotificationWithLinkParameters:), but the server MAY still echo a
-    // previous click's ~referring_link in session_data for an unrelated open (residual
-    // server-side stickiness). That is a backend behavior question tracked separately
-    // (EMT-3893) and intentionally not worked around here.
+    // EMT-3893: the server may still echo a previous click's ~referring_link here. The SDK
+    // clears its own link identifiers below; the server-side stickiness is a backend issue.
     preferenceHelper.sessionParams = sessionData;
 
     // Scenarios:


### PR DESCRIPTION
## Reference
No ticket yet (follow-up of EMT-3754 / #1596). Found while investigating the CI failure on #1599.

## Summary
Draft PR to discuss the fix direction for a race introduced on `4.0.0-beta.0`: a deep link handler registered via the legacy `initSession` while the automatic `sendOpen` is still in flight is never invoked.

## The race
1. App becomes active. Since #1596, `applicationDidBecomeActive` auto-fires `sendOpen` and the session status goes to `Initializing`.
2. The app calls `initSession(launchOptions:andRegisterDeepLinkHandler:)`. `initUserSessionAndCallCallback` only handles `Uninitialized` (starts an init) and `Initialized` (calls back immediately). In the `Initializing` state it silently does nothing.
3. The auto open completes with `handleInitSuccessAndCallCallback:NO`, intentionally skipping developer callbacks (opens should not return data to the app).
4. The handler registered in step 2 is never invoked. `testInitSessionAndSetCPPLevel` times out exactly here, which is why the integration suite has been flaky since #1596 merged (it passes or fails depending on which side of the in-flight window `initSession` lands).

The old flow did not have this gap because the auto path was `initUserSessionAndCallCallback:YES`, so the in-flight open invoked registered handlers on completion.

## Proposed fix (this PR)
Keep the principle that opens stay silent and do not return data to the app. Instead, separate "deep link data" (exclusive to `requestDeepLinkData`) from "the session has settled" (owned by the open flow), via a small internal primitive:

- `notifyWhenSessionReady:` queues blocks while an open is in flight (invokes immediately if the session is already initialized).
- `handleInitSuccessAndCallCallback:` / `handleInitFailure:` flush the queue on silent settles, and discard it on `callCallback:YES` settles (the single registered handler was already invoked directly, flushing would double-call it).
- The legacy `initSession` flow bridges through it: the previously-missing `Initializing` branch in `initUserSessionAndCallCallback` now queues the callback instead of dropping it.

This also moves session-state ownership into the `sendOpen` flow in the current build, and the primitive is independent of `initUserSessionAndCallCallback`, so it survives that function's planned removal.

## Alternative considered
Restoring `YES` in the auto `sendOpen` completion is a two-word fix that recreates the 3.x behavior, but it re-couples opens to developer callbacks, which is what the rewrite is moving away from. Listed here for completeness; happy to switch if preferred.

## Testing Instructions
- `testInitSessionAndSetCPPLevel` in the integration suite covers the race (it is the test that exposed it on #1599's CI). Re-running the suite a few times is the meaningful check, since the failure is timing dependent.
- Manual: launch TestBed, let the app go active (auto open fires), then call `initSession` and confirm the callback arrives.

Would appreciate a review of the direction before this leaves draft.

