### PR TITLE
Added check for `_branch_referrer` query param in Branch Links.

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BranchClassTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BranchClassTests.m
@@ -456,4 +456,27 @@
                   @"One of the anonID values should be set");
 }
 
+- (void)testHandleDeepLink_UniversalLinkWithBranchReferrer_ReturnsYes {
+    // Universal link path: handleDeepLink -> handleUniversalDeepLink_private -> isBranchLink.
+    // The link is not on a Branch domain, but carries the _branch_referrer param that Branch
+    // appends to third-party/redirected links, so it should be recognized as a Branch link.
+    NSString *urlString = @"https://open.testdomain.com/track/1a2b3c4d5e6f7g8h9i0jkl?si=AbCdEfGhIjKlMnOpQrStUv&nd=1&utm_medium=organic&_branch_referrer=H4sIAAAAAAAAA1234567890abcdefTESTREFERRERVALUE%3D%3D&product=open&%24full_url=https%3A%2F%2Fopen.testdomain.com%2Ftrack%2F1a2b3c4d5e6f7g8h9i0jkl%3Fsi%3DAbCdEfGhIjKlMnOpQrStUv&feature=organic&_branch_match_id=1234567890123456789";
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    BOOL result = [self.branch handleDeepLink:url];
+    XCTAssertTrue(result, @"handleDeepLink should return YES for a universal link containing the _branch_referrer param");
+}
+
+- (void)testHandleDeepLink_URISchemeWithBranchReferrer_ReturnsYes {
+    // URI scheme path: handleDeepLink -> handleSchemeDeepLink_private.
+    // The link is not on a Branch domain, but carries the _branch_referrer param that Branch
+    // appends to third-party/redirected links, so it should be recognized as a Branch link.
+    
+    NSString *urlString = @"testapp://open/track/1a2b3c4d5e6f7g8h9i0jkl?si=AbCdEfGhIjKlMnOpQrStUv&nd=1&utm_medium=organic&_branch_referrer=H4sIAAAAAAAAA1234567890abcdefTESTREFERRERVALUE%3D%3D&product=open&feature=organic&_branch_match_id=1234567890123456789";
+    NSURL *url = [NSURL URLWithString:urlString];
+
+    BOOL result = [self.branch handleDeepLink:url];
+    XCTAssertTrue(result, @"handleDeepLink should return YES for a URI scheme link containing the _branch_referrer param");
+}
+
 @end

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -938,6 +938,11 @@ static NSString *bnc_branchKey = nil;
             handled = YES;
             self.preferenceHelper.linkClickIdentifier = params[@"link_click_id"];
         }
+
+        // Check for _branch_referrer added to third-party/redirected links
+        if (params[@"_branch_referrer"]) {
+            handled = YES;
+        }
     }
     [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:url.absoluteString reset:YES];
     return handled;
@@ -1042,6 +1047,15 @@ static NSString *bnc_branchKey = nil;
             return YES;
         }
     }
+
+    // check for the Branch referrer param appended to third-party/redirected links
+    NSURLComponents *components = [NSURLComponents componentsWithString:urlString];
+    for (NSURLQueryItem *item in components.queryItems) {
+        if ([item.name isEqualToString:@"_branch_referrer"]) {
+            return YES;
+        }
+    }
+
     return NO;
 }
 


### PR DESCRIPTION
## Reference
https://branch.atlassian.net/browse/EMT-3721

## Summary
Branch appends a _branch_referrer query parameter to third-party or redirected links. Previously, the SDK did not recognize these URLs as Branch links because they don't use a known Branch domain. This meant handleDeepLink: would return NO and the link data would not be processed.

Changes

1. +[Branch isBranchLink:] — added a check that parses the URL's query items and returns YES if a _branch_referrer parameter is present. This is the universal link path (handleDeepLink → handleUniversalDeepLink_private → isBranchLink).
2. -[Branch handleSchemeDeepLink_private:sceneIdentifier:] — added a parallel check in the URI scheme handling path: if the parsed query params contain _branch_referrer, the link is marked as handled = YES (ensuring initUserSession processes it).
3. Unit tests — two new tests in BranchClassTests.m:
  - testHandleDeepLink_UniversalLinkWithBranchReferrer_ReturnsYes — verifies a non-Branch-domain universal link with _branch_referrer is recognized.
  - testHandleDeepLink_URISchemeWithBranchReferrer_ReturnsYes — verifies a custom URI scheme link with _branch_referrer is recognized.

cc @BranchMetrics/saas-sdk-devs for visibility.
