### PR TITLE
[other] NO-TICKET: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BranchMetrics/performance-team


### PR DESCRIPTION
Assigns ownership via CODEOWNERS (* @BranchMetrics/performance-team) as part of the service-catalogue rollout.