### PR TITLE
EMT-3892: stop the duplicate open in the deep-link open lifecycle

### DIFF
--- a/BranchSDKTests/BNCRequestFactoryTests.m
+++ b/BranchSDKTests/BNCRequestFactoryTests.m
@@ -106,9 +106,8 @@
     XCTAssertTrue([universalLinkURL isEqualToString:[json objectForKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL]]);
 }
 
-// EMT-3892 regression: the deferred, unattributed launch/organic open (no resolved link)
-// must not carry universal_link_url or link_data — those belong only to the single
-// attributed open sent once the deep link actually resolves.
+// EMT-3892 regression: the unattributed open must not carry universal_link_url or
+// link_data — those belong only to the attributed open sent once the link resolves.
 - (void)testDataForOpenWithoutResolvedLinkCarriesNoLinkData {
     BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd" UUID:self.requestUUID TimeStamp:self.requestCreationTimeStamp];
     NSDictionary *json = [factory dataForOpenWithURLString:nil];

--- a/BranchSDKTests/BNCRequestFactoryTests.m
+++ b/BranchSDKTests/BNCRequestFactoryTests.m
@@ -95,6 +95,29 @@
     XCTAssertTrue([self.requestUUID isEqualToString:[json objectForKey:BRANCH_REQUEST_KEY_REQUEST_UUID]]);
 }
 
+// EMT-3892 regression: an open request built for a resolved universal link must carry
+// universal_link_url so the server can attribute it.
+- (void)testDataForOpenWithUniversalLinkCarriesUniversalLinkURL {
+    BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd" UUID:self.requestUUID TimeStamp:self.requestCreationTimeStamp];
+    NSString *universalLinkURL = @"https://example.app.link/abc123";
+    NSDictionary *json = [factory dataForOpenWithURLString:universalLinkURL];
+    XCTAssertNotNil(json);
+
+    XCTAssertTrue([universalLinkURL isEqualToString:[json objectForKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL]]);
+}
+
+// EMT-3892 regression: the deferred, unattributed launch/organic open (no resolved link)
+// must not carry universal_link_url or link_data — those belong only to the single
+// attributed open sent once the deep link actually resolves.
+- (void)testDataForOpenWithoutResolvedLinkCarriesNoLinkData {
+    BNCRequestFactory *factory = [[BNCRequestFactory alloc] initWithBranchKey:@"key_abcd" UUID:self.requestUUID TimeStamp:self.requestCreationTimeStamp];
+    NSDictionary *json = [factory dataForOpenWithURLString:nil];
+    XCTAssertNotNil(json);
+
+    XCTAssertNil([json objectForKey:BRANCH_REQUEST_KEY_UNIVERSAL_LINK_URL]);
+    XCTAssertNil([json objectForKey:@"link_data"]);
+}
+
 - (void)testDataForEvent {
     NSDictionary *event = @{@"name": @"ADD_TO_CART"};
     

--- a/BranchSDKTests/BranchClassTests.m
+++ b/BranchSDKTests/BranchClassTests.m
@@ -13,6 +13,10 @@
 #import "BNCAppGroupsData.h"
 #import "BNCPartnerParameters.h"
 #import "BNCServerRequestQueue.h"
+#import "BNCServerRequestOperation.h"
+#import "BNCServerResponse.h"
+#import "BranchRequestOpen.h"
+#import "BranchRequestDeepLink.h"
 
 @interface BNCPreferenceHelper(Test)
 // Expose internal private method to clear EEA data
@@ -38,8 +42,25 @@
 - (NSInteger)queueDepth;
 @end
 
+// Expose the underlying NSOperationQueue for deterministic, network-free behavioral testing:
+// suspend it, drive the SDK's real deep-link/open code paths, inspect exactly what got
+// enqueued (class + urlString/linkData) before anything can touch the network, then clear it.
+// No HTTP-stub library exists in this suite; this is the cleanest network-free equivalent.
+@interface BNCServerRequestQueue (OperationsIntrospectionTest)
+@property (strong, nonatomic) NSOperationQueue *operationQueue;
+@end
+
 @interface BranchClassTests : XCTestCase
 @property (nonatomic, strong) Branch *branch;
+// Baseline of the shared singleton state the EMT-3892/3893 behavioral tests mutate,
+// captured per-test in -setUp and fully restored in -tearDown. The behavioral tests drive
+// the real deep-link/open code paths, which write attributionLevel/referringURL/sessionParams
+// on the shared BNCPreferenceHelper and arm an async fallback timer on the shared Branch
+// singleton. Without a hermetic tearDown that leaked state (Full attribution left set, a
+// still-armed fallback timer firing into a later test) polluted order-dependent pre-existing
+// tests in this file. Restoring the captured baseline makes every test self-contained again.
+@property (nonatomic, assign) NSTimeInterval savedTimeout;
+@property (nonatomic, copy) BranchAttributionLevel savedAttributionLevel;
 @end
 
 @implementation BranchClassTests
@@ -47,9 +68,30 @@
 - (void)setUp {
     [super setUp];
     self.branch = [Branch getInstance];
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    self.savedTimeout = preferenceHelper.timeout;
+    self.savedAttributionLevel = preferenceHelper.attributionLevel;
 }
 
 - (void)tearDown {
+    // Hermetic reset of everything the behavioral tests touch on the shared singletons, so a
+    // failed/early-returning test can never leak state into the next one. Runs regardless of
+    // per-test inline cleanup (which is now belt-and-suspenders).
+    [self.branch cancelDeepLinkOpenFallback];           // stop any pending async open timer
+    self.branch.deepLinkOpenPending = NO;
+    [self.branch setValue:nil forKey:@"lastAttributedDeepLinkURL"];
+    [self restoreRealRequestQueue];
+
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.referringURL = nil;
+    preferenceHelper.sessionParams = nil;
+    preferenceHelper.timeout = self.savedTimeout;
+    preferenceHelper.attributionLevel = self.savedAttributionLevel;
+
+    // Let any already-scheduled async block drain against this clean baseline rather than
+    // landing mid-way through the next test.
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+
     self.branch = nil;
     [super tearDown];
 }
@@ -330,6 +372,268 @@
     // Cancel the bounded fallback so it doesn't fire a real network open later in the suite.
     [self.branch cancelDeepLinkOpenFallback];
     XCTAssertFalse(self.branch.deepLinkOpenPending, @"Cancelling the fallback should clear the pending flag.");
+}
+
+#pragma mark - EMT-3892/3893 behavioral evidence helpers
+
+// Swaps in a disposable, permanently-suspended BNCServerRequestQueue so a scenario's
+// enqueued requests can be inspected deterministically (class + urlString/linkData)
+// without ever touching the network and without depending on / polluting the shared
+// singleton queue other tests use. No HTTP-stub library exists in this suite; this is the
+// cleanest network-free equivalent. Always pair with -restoreRealRequestQueue.
+//
+// Note: we deliberately never cancel/resume this fake queue. BNCServerRequestOperation's
+// -cancel sets isFinished directly when a suspended (never-started) operation is
+// cancelled, which trips an NSOperationQueue internal consistency check ("went
+// isFinished=YES without being started by the queue it is in") and crashed the test host
+// during development of this test. Simply discarding the whole disposable queue (and its
+// never-started operations) avoids that pre-existing, out-of-scope edge case entirely.
+- (BNCServerRequestQueue *)installFakeRequestQueue {
+    BNCServerRequestQueue *fakeQueue = [BNCServerRequestQueue new];
+    fakeQueue.operationQueue.suspended = YES;
+    [self.branch setValue:fakeQueue forKey:@"requestQueue"];
+    return fakeQueue;
+}
+
+- (void)restoreRealRequestQueue {
+    [self.branch setValue:[BNCServerRequestQueue getInstance] forKey:@"requestQueue"];
+}
+
+// All BNCServerRequestOperation-wrapped requests currently sitting in `queue`, as untyped
+// KVC handles (`.request`, and on that the request's own `urlString`/`linkData`). This
+// project links BranchSDK in a way that loads some classes (confirmed: at least
+// BNCServerRequestOperation) from two different images at once — `isKindOfClass:`/typed
+// casts against a class the test target also references directly are unreliable (the
+// object's real class and the test file's compile-time class symbol can be two distinct
+// Class objects with the same name). `-valueForKey:` and `NSStringFromClass` dispatch by
+// selector/name instead of Class-pointer identity, sidestepping that entirely — the same
+// "queue-introspection pattern" already used via `queueDepth` elsewhere in this file.
+- (NSArray<NSOperation *> *)requestOperationsIn:(BNCServerRequestQueue *)queue {
+    NSMutableArray<NSOperation *> *ops = [NSMutableArray array];
+    for (NSOperation *op in queue.operationQueue.operations) {
+        if ([NSStringFromClass([op class]) isEqualToString:@"BNCServerRequestOperation"]) {
+            [ops addObject:op];
+        }
+    }
+    return ops;
+}
+
+// Deterministically waits for the bounded fallback (deferLaunchOpenPendingDeepLinkResolution's
+// timer) to actually enqueue an open into `queue`, instead of a fixed wall-clock sleep. Uses
+// XCTNSPredicateExpectation, which polls the predicate and resolves the instant it becomes
+// true — so this is as fast as the real event AND has a generous ceiling for slow/loaded CI,
+// eliminating the flakiness of racing a tight fixed-duration sleep against an async GCD timer.
+- (void)waitForFallbackOpenIn:(BNCServerRequestQueue *)queue timeout:(NSTimeInterval)timeout {
+    NSPredicate *fallbackEnqueued = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+        return [self requestOperationsIn:queue].count > 0;
+    }];
+    XCTNSPredicateExpectation *expectation = [[XCTNSPredicateExpectation alloc] initWithPredicate:fallbackEnqueued object:self];
+    XCTWaiterResult result = [XCTWaiter waitForExpectations:@[expectation] timeout:timeout];
+    XCTAssertEqual(result, XCTWaiterResultCompleted, @"The bounded fallback did not enqueue an open within %.1fs.", timeout);
+}
+
+// A stub deep-link resolution response carrying a resolved, clicked Branch link — what
+// BranchRequestDeepLink.processResponse: would receive from a real /v3/deeplink round trip.
+- (BNCServerResponse *)stubDeepLinkResponseForLink:(NSString *)linkURL {
+    BNCServerResponse *response = [BNCServerResponse new];
+    response.statusCode = @200;
+    response.data = @{
+        BRANCH_RESPONSE_KEY_SESSION_DATA: @{
+            BRANCH_RESPONSE_KEY_CLICKED_BRANCH_LINK: @1,
+            BRANCH_RESPONSE_KEY_BRANCH_REFERRING_LINK: linkURL
+        }
+    };
+    return response;
+}
+
+// A stub plain-open response carrying no link click — what a generic /v3/events/open would
+// receive when there is nothing to attribute.
+- (BNCServerResponse *)stubGenericOpenResponse {
+    BNCServerResponse *response = [BNCServerResponse new];
+    response.statusCode = @200;
+    response.data = @{
+        BRANCH_RESPONSE_KEY_SESSION_DATA: @{
+            BRANCH_RESPONSE_KEY_CLICKED_BRANCH_LINK: @0
+        }
+    };
+    return response;
+}
+
+#pragma mark - EMT-3892/3893 behavioral evidence
+
+// Behavior 1: deep link + requestDeepLinkData resolving emits exactly ONE open request for
+// the session, and it carries the resolved link — not an unattributed launch open plus a
+// duplicate attributed one. No HTTP stub library exists in this suite, so the deep-link
+// server round trip is simulated directly on a BranchRequestDeepLink instance (mirrors what
+// requestDeepLinkData: does internally once its network call returns).
+- (void)testDeepLinkResolutionEmitsExactlyOneAttributedOpenCarryingTheLink {
+    NSString *linkURL = @"https://example.app.link/behavioral-resolved";
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.attributionLevel = BranchAttributionLevelFull; // deterministic regardless of ambient state
+
+    BNCServerRequestQueue *fakeQueue = [self installFakeRequestQueue];
+
+    // 1) App receives the deep link: SDK defers the launch open (EMT-3892).
+    [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
+    XCTAssertEqual([self requestOperationsIn:fakeQueue].count, 0u,
+                    @"Nothing should be enqueued yet — the open is deferred pending resolution.");
+
+    // 2) App calls requestDeepLinkData(...), which (a) cancels the bounded fallback and
+    // (b) resolves the link. We simulate step (b)'s network response directly.
+    [self.branch cancelDeepLinkOpenFallback];
+
+    BranchRequestDeepLink *deepLinkRequest = [[BranchRequestDeepLink alloc] initWithCallback:nil];
+    deepLinkRequest.urlString = linkURL;
+    deepLinkRequest.uri = linkURL;
+    [deepLinkRequest processResponse:[self stubDeepLinkResponseForLink:linkURL] error:nil];
+
+    // Exactly one open — the single ATTRIBUTED open sent by
+    // BranchRequestDeepLink.processResponse: (sendOpen:), not a second/duplicate one.
+    NSArray<NSOperation *> *ops = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(ops.count, 1u, @"Exactly one open request must be emitted for a resolved deep link — no duplicate.");
+
+    if (ops.count == 1) {
+        id request = [ops.firstObject valueForKey:@"request"];
+        XCTAssertEqualObjects(NSStringFromClass([request class]), @"BranchRequestOpen");
+        // The attributed open carries the resolved link via linkData (-> link_data on the
+        // wire, see BranchRequestOpen.makeRequest:), not urlString. Documented explicitly
+        // because it differs from the factory-level universal_link_url path.
+        NSDictionary *linkData = [request valueForKey:@"linkData"];
+        XCTAssertNotNil(linkData, @"The attributed open must carry the resolved link's data.");
+        NSDictionary *carriedSessionData = linkData[BRANCH_RESPONSE_KEY_SESSION_DATA];
+        XCTAssertEqualObjects(carriedSessionData[BRANCH_RESPONSE_KEY_BRANCH_REFERRING_LINK], linkURL,
+                               @"The carried link data must be the resolved link, not stale/empty.");
+    }
+
+    [self restoreRealRequestQueue];
+}
+
+// Behavior 2: deep link received, requestDeepLinkData never called → after the bounded
+// fallback window, exactly ONE generic (unattributed) open is emitted so the open isn't
+// lost. preferenceHelper.timeout is temporarily lowered so the test doesn't wait out the
+// real ~5.5s default.
+- (void)testDeepLinkFallbackFiresExactlyOneUnattributedOpenWhenNeverResolved {
+    NSString *linkURL = @"https://example.app.link/behavioral-never-resolved";
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.attributionLevel = BranchAttributionLevelFull;
+    NSTimeInterval originalTimeout = preferenceHelper.timeout;
+    preferenceHelper.timeout = 0.2; // deterministic, fast fallback window for this test only
+
+    BNCServerRequestQueue *fakeQueue = [self installFakeRequestQueue];
+
+    [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
+    XCTAssertTrue(self.branch.deepLinkOpenPending);
+
+    // Do NOT call requestDeepLinkData. Wait for the fallback to actually enqueue the open —
+    // not a fixed wall-clock sleep, which raced under load (observed flaky: sometimes the
+    // 0.2s-configured fallback hadn't fired by a fixed 0.6s deadline). A polling predicate
+    // expectation resolves as soon as the real event happens, with a generous ceiling.
+    [self waitForFallbackOpenIn:fakeQueue timeout:5.0];
+
+    XCTAssertFalse(self.branch.deepLinkOpenPending, @"The fallback should have fired and cleared the pending flag.");
+
+    NSArray<NSOperation *> *ops = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(ops.count, 1u, @"Exactly one open must be emitted by the fallback — the deep link open must not be lost.");
+
+    if (ops.count == 1) {
+        id request = [ops.firstObject valueForKey:@"request"];
+        XCTAssertEqualObjects(NSStringFromClass([request class]), @"BranchRequestOpen");
+        XCTAssertNil([request valueForKey:@"urlString"], @"The fallback open must be unattributed: no urlString.");
+        XCTAssertNil([request valueForKey:@"linkData"], @"The fallback open must be unattributed: no linkData.");
+    }
+
+    [self restoreRealRequestQueue];
+    preferenceHelper.timeout = originalTimeout;
+}
+
+// Behavior 3 (EMT-3893, SDK layer only): once the attributed open's own response settles,
+// referringURL is cleared, so a subsequent open with no new link does not carry the
+// previous link forward. Does NOT prove/disprove server-side stickiness (out of scope).
+- (void)testResolvedLinkDoesNotStickToSubsequentOpen {
+    NSString *linkURL = @"https://example.app.link/behavioral-sticky-check";
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.attributionLevel = BranchAttributionLevelFull;
+
+    [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
+    [self.branch cancelDeepLinkOpenFallback];
+    XCTAssertEqualObjects(preferenceHelper.referringURL, linkURL);
+
+    // The attributed open's own response settling is what clears referringURL today. Use an
+    // isolated request instance (nil callback) so this assertion-only step doesn't also
+    // trigger the production completion path's async main-queue side effects on the shared
+    // Branch singleton.
+    BranchRequestOpen *attributedOpenRequest = [[BranchRequestOpen alloc] initWithCallback:nil];
+    attributedOpenRequest.urlString = nil;
+    attributedOpenRequest.linkData = [self stubDeepLinkResponseForLink:linkURL].data;
+    [attributedOpenRequest processResponse:[self stubGenericOpenResponse] error:nil];
+    XCTAssertNil(preferenceHelper.referringURL,
+                 @"EMT-3893 (SDK layer): referringURL must be cleared once the attributed open settles, not held sticky.");
+
+    // A subsequent open with no new link (e.g. organic foreground) must not carry the
+    // previous link forward.
+    BNCServerRequestQueue *fakeQueue = [self installFakeRequestQueue];
+
+    [self.branch sendOpen];
+
+    NSArray<NSOperation *> *ops = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(ops.count, 1u);
+    if (ops.count == 1) {
+        id request = [ops.firstObject valueForKey:@"request"];
+        XCTAssertNil([request valueForKey:@"urlString"], @"A subsequent organic open must not carry the previous link's URL.");
+        XCTAssertNil([request valueForKey:@"linkData"], @"A subsequent organic open must not carry the previous link's data.");
+    }
+
+    [self restoreRealRequestQueue];
+}
+
+// Behavior 4 (ordering risk, FIXED): requestDeepLinkData resolving a link BEFORE
+// handleUniversalDeepLink_private is invoked for that same link. This can legitimately
+// happen (e.g. a host app resolving from scene-connection options before UIKit separately
+// delivers the universal link). Regression test for the fix: handleUniversalDeepLink_private
+// now recognizes (via lastAttributedDeepLinkURL) that this exact link was already attributed
+// by the earlier resolution and does not re-arm the deferred-open fallback, so only ONE open
+// total is ever emitted — previously this double-emitted (1 attributed + 1 unattributed
+// fallback).
+- (void)testRequestDeepLinkDataBeforeUniversalDeepLinkEmitsExactlyOneOpen {
+    NSString *linkURL = @"https://example.app.link/behavioral-ordering-edge";
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.attributionLevel = BranchAttributionLevelFull;
+    NSTimeInterval originalTimeout = preferenceHelper.timeout;
+    preferenceHelper.timeout = 0.2;
+
+    BNCServerRequestQueue *fakeQueue = [self installFakeRequestQueue];
+
+    // 1) requestDeepLinkData resolves FIRST — the attributed open fires on its own.
+    [self.branch cancelDeepLinkOpenFallback];
+    BranchRequestDeepLink *deepLinkRequest = [[BranchRequestDeepLink alloc] initWithCallback:nil];
+    deepLinkRequest.urlString = linkURL;
+    [deepLinkRequest processResponse:[self stubDeepLinkResponseForLink:linkURL] error:nil];
+
+    NSArray<NSOperation *> *afterResolution = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(afterResolution.count, 1u, @"The early resolution alone must still emit exactly one attributed open.");
+
+    // 2) handleUniversalDeepLink_private fires AFTER, for the same (already-attributed)
+    // link. The fix: it must recognize that and skip arming the deferred-open fallback.
+    [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
+    XCTAssertFalse(self.branch.deepLinkOpenPending,
+                    @"A link already attributed via an earlier resolution must not re-arm the deferred-open fallback.");
+
+    // Deterministically prove no SECOND open ever appears — an inverted expectation, not a
+    // blind sleep: it only fails if a second open actually shows up within the window, so
+    // there is no false-negative risk from finishing "too fast".
+    NSPredicate *secondOpenEnqueued = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+        return [self requestOperationsIn:fakeQueue].count > 1;
+    }];
+    XCTNSPredicateExpectation *noSecondOpen = [[XCTNSPredicateExpectation alloc] initWithPredicate:secondOpenEnqueued object:self];
+    noSecondOpen.inverted = YES;
+    [self waitForExpectations:@[noSecondOpen] timeout:0.5];
+
+    NSArray<NSOperation *> *afterSecondCall = [self requestOperationsIn:fakeQueue];
+    XCTAssertEqual(afterSecondCall.count, 1u,
+                    @"EMT-3892 ordering fix: resolving before handleUniversalDeepLink_private must still emit exactly ONE open total, not a duplicate.");
+
+    [self restoreRealRequestQueue];
+    preferenceHelper.timeout = originalTimeout;
 }
 
 @end

--- a/BranchSDKTests/BranchClassTests.m
+++ b/BranchSDKTests/BranchClassTests.m
@@ -12,6 +12,7 @@
 #import "BNCPasteboard.h"
 #import "BNCAppGroupsData.h"
 #import "BNCPartnerParameters.h"
+#import "BNCServerRequestQueue.h"
 
 @interface BNCPreferenceHelper(Test)
 // Expose internal private method to clear EEA data
@@ -22,6 +23,19 @@
 // Expose private session-state internals used to reproduce the in-flight open window.
 @interface Branch (SessionReadySettleTest)
 - (void)handleInitSuccessAndCallCallback:(BOOL)callCallback sceneIdentifier:(NSString *)sceneIdentifier;
+@end
+
+// Expose the EMT-3892 deep-link open deferral internals for regression testing.
+@interface Branch (DeepLinkOpenDeferralTest)
+@property (nonatomic, assign) BOOL deepLinkOpenPending;
+- (BOOL)handleUniversalDeepLink_private:(NSString *)urlString sceneIdentifier:(NSString *)sceneIdentifier;
+- (void)cancelDeepLinkOpenFallback;
+@end
+
+// Expose the private queue-depth accessor to detect a synchronous enqueue without being
+// coupled to leftover install/open state from other tests sharing the Branch singleton.
+@interface BNCServerRequestQueue (QueueDepthTest)
+- (NSInteger)queueDepth;
 @end
 
 @interface BranchClassTests : XCTestCase
@@ -296,6 +310,26 @@
 
     // Reset session state so this test does not leak into others.
     [self.branch setValue:@(0) forKey:@"initializationStatus"];
+}
+
+// EMT-3892 regression: a Branch deep-link (universal link) open must defer the launch
+// open until requestDeepLinkData resolves it, not synchronously enqueue an unattributed
+// generic open. See Branch.m deferLaunchOpenPendingDeepLinkResolution.
+- (void)testUniversalDeepLinkDefersLaunchOpenPendingResolution {
+    BNCServerRequestQueue *requestQueue = [self.branch valueForKey:@"requestQueue"];
+    NSInteger queueDepthBeforeDeepLink = [requestQueue queueDepth];
+
+    BOOL isBranchLink = [self.branch handleUniversalDeepLink_private:@"https://example.app.link/abc123" sceneIdentifier:nil];
+    XCTAssertTrue(isBranchLink, @"example.app.link should be recognized as a Branch link.");
+
+    // Delta-based (not absolute) so this isn't coupled to install/open state left behind by
+    // other tests sharing the Branch singleton and its request queue.
+    XCTAssertEqual([requestQueue queueDepth], queueDepthBeforeDeepLink, @"The launch open must be deferred, not enqueued synchronously before deep-link resolution.");
+    XCTAssertTrue(self.branch.deepLinkOpenPending, @"Deep link resolution should be marked pending after a universal link open.");
+
+    // Cancel the bounded fallback so it doesn't fire a real network open later in the suite.
+    [self.branch cancelDeepLinkOpenFallback];
+    XCTAssertFalse(self.branch.deepLinkOpenPending, @"Cancelling the fallback should clear the pending flag.");
 }
 
 @end

--- a/BranchSDKTests/BranchClassTests.m
+++ b/BranchSDKTests/BranchClassTests.m
@@ -36,29 +36,21 @@
 - (void)cancelDeepLinkOpenFallback;
 @end
 
-// Expose the private queue-depth accessor to detect a synchronous enqueue without being
-// coupled to leftover install/open state from other tests sharing the Branch singleton.
+// Detects a synchronous enqueue via a delta, not an absolute count, so leftover state from
+// other tests sharing the Branch singleton doesn't matter.
 @interface BNCServerRequestQueue (QueueDepthTest)
 - (NSInteger)queueDepth;
 @end
 
-// Expose the underlying NSOperationQueue for deterministic, network-free behavioral testing:
-// suspend it, drive the SDK's real deep-link/open code paths, inspect exactly what got
-// enqueued (class + urlString/linkData) before anything can touch the network, then clear it.
-// No HTTP-stub library exists in this suite; this is the cleanest network-free equivalent.
+// Lets a test suspend the queue and inspect what was enqueued before it can hit the network.
 @interface BNCServerRequestQueue (OperationsIntrospectionTest)
 @property (strong, nonatomic) NSOperationQueue *operationQueue;
 @end
 
 @interface BranchClassTests : XCTestCase
 @property (nonatomic, strong) Branch *branch;
-// Baseline of the shared singleton state the EMT-3892/3893 behavioral tests mutate,
-// captured per-test in -setUp and fully restored in -tearDown. The behavioral tests drive
-// the real deep-link/open code paths, which write attributionLevel/referringURL/sessionParams
-// on the shared BNCPreferenceHelper and arm an async fallback timer on the shared Branch
-// singleton. Without a hermetic tearDown that leaked state (Full attribution left set, a
-// still-armed fallback timer firing into a later test) polluted order-dependent pre-existing
-// tests in this file. Restoring the captured baseline makes every test self-contained again.
+// Shared-singleton baseline captured in -setUp and restored in -tearDown. Without it, the
+// behavioral tests below leaked attribution level and armed timers into later tests.
 @property (nonatomic, assign) NSTimeInterval savedTimeout;
 @property (nonatomic, copy) BranchAttributionLevel savedAttributionLevel;
 @end
@@ -74,9 +66,7 @@
 }
 
 - (void)tearDown {
-    // Hermetic reset of everything the behavioral tests touch on the shared singletons, so a
-    // failed/early-returning test can never leak state into the next one. Runs regardless of
-    // per-test inline cleanup (which is now belt-and-suspenders).
+    // Hermetic reset, so a failed or early-returning test can't leak state into the next one.
     [self.branch cancelDeepLinkOpenFallback];           // stop any pending async open timer
     self.branch.deepLinkOpenPending = NO;
     [self.branch setValue:nil forKey:@"lastAttributedDeepLinkURL"];
@@ -88,8 +78,7 @@
     preferenceHelper.timeout = self.savedTimeout;
     preferenceHelper.attributionLevel = self.savedAttributionLevel;
 
-    // Let any already-scheduled async block drain against this clean baseline rather than
-    // landing mid-way through the next test.
+    // Drain any already-scheduled async block against this clean baseline.
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
 
     self.branch = nil;
@@ -354,9 +343,8 @@
     [self.branch setValue:@(0) forKey:@"initializationStatus"];
 }
 
-// EMT-3892 regression: a Branch deep-link (universal link) open must defer the launch
-// open until requestDeepLinkData resolves it, not synchronously enqueue an unattributed
-// generic open. See Branch.m deferLaunchOpenPendingDeepLinkResolution.
+// EMT-3892: a universal link must defer the launch open until resolution, not enqueue an
+// unattributed open synchronously.
 - (void)testUniversalDeepLinkDefersLaunchOpenPendingResolution {
     BNCServerRequestQueue *requestQueue = [self.branch valueForKey:@"requestQueue"];
     NSInteger queueDepthBeforeDeepLink = [requestQueue queueDepth];
@@ -364,8 +352,6 @@
     BOOL isBranchLink = [self.branch handleUniversalDeepLink_private:@"https://example.app.link/abc123" sceneIdentifier:nil];
     XCTAssertTrue(isBranchLink, @"example.app.link should be recognized as a Branch link.");
 
-    // Delta-based (not absolute) so this isn't coupled to install/open state left behind by
-    // other tests sharing the Branch singleton and its request queue.
     XCTAssertEqual([requestQueue queueDepth], queueDepthBeforeDeepLink, @"The launch open must be deferred, not enqueued synchronously before deep-link resolution.");
     XCTAssertTrue(self.branch.deepLinkOpenPending, @"Deep link resolution should be marked pending after a universal link open.");
 
@@ -376,18 +362,11 @@
 
 #pragma mark - EMT-3892/3893 behavioral evidence helpers
 
-// Swaps in a disposable, permanently-suspended BNCServerRequestQueue so a scenario's
-// enqueued requests can be inspected deterministically (class + urlString/linkData)
-// without ever touching the network and without depending on / polluting the shared
-// singleton queue other tests use. No HTTP-stub library exists in this suite; this is the
-// cleanest network-free equivalent. Always pair with -restoreRealRequestQueue.
-//
-// Note: we deliberately never cancel/resume this fake queue. BNCServerRequestOperation's
-// -cancel sets isFinished directly when a suspended (never-started) operation is
-// cancelled, which trips an NSOperationQueue internal consistency check ("went
-// isFinished=YES without being started by the queue it is in") and crashed the test host
-// during development of this test. Simply discarding the whole disposable queue (and its
-// never-started operations) avoids that pre-existing, out-of-scope edge case entirely.
+// A disposable, permanently-suspended queue: enqueued requests can be inspected without
+// touching the network or the shared singleton queue. Pair with -restoreRealRequestQueue.
+// Never cancel/resume it — cancelling a suspended, never-started BNCServerRequestOperation
+// trips an NSOperationQueue consistency check and crashes the test host. Discarding the
+// whole queue avoids that pre-existing, out-of-scope edge case.
 - (BNCServerRequestQueue *)installFakeRequestQueue {
     BNCServerRequestQueue *fakeQueue = [BNCServerRequestQueue new];
     fakeQueue.operationQueue.suspended = YES;
@@ -399,15 +378,9 @@
     [self.branch setValue:[BNCServerRequestQueue getInstance] forKey:@"requestQueue"];
 }
 
-// All BNCServerRequestOperation-wrapped requests currently sitting in `queue`, as untyped
-// KVC handles (`.request`, and on that the request's own `urlString`/`linkData`). This
-// project links BranchSDK in a way that loads some classes (confirmed: at least
-// BNCServerRequestOperation) from two different images at once — `isKindOfClass:`/typed
-// casts against a class the test target also references directly are unreliable (the
-// object's real class and the test file's compile-time class symbol can be two distinct
-// Class objects with the same name). `-valueForKey:` and `NSStringFromClass` dispatch by
-// selector/name instead of Class-pointer identity, sidestepping that entirely — the same
-// "queue-introspection pattern" already used via `queueDepth` elsewhere in this file.
+// The requests currently in `queue`, matched and read by name (NSStringFromClass / KVC)
+// rather than isKindOfClass:. This project loads BNCServerRequestOperation from two images
+// at once, so Class-pointer identity is unreliable here; name-based dispatch is not.
 - (NSArray<NSOperation *> *)requestOperationsIn:(BNCServerRequestQueue *)queue {
     NSMutableArray<NSOperation *> *ops = [NSMutableArray array];
     for (NSOperation *op in queue.operationQueue.operations) {
@@ -418,11 +391,8 @@
     return ops;
 }
 
-// Deterministically waits for the bounded fallback (deferLaunchOpenPendingDeepLinkResolution's
-// timer) to actually enqueue an open into `queue`, instead of a fixed wall-clock sleep. Uses
-// XCTNSPredicateExpectation, which polls the predicate and resolves the instant it becomes
-// true — so this is as fast as the real event AND has a generous ceiling for slow/loaded CI,
-// eliminating the flakiness of racing a tight fixed-duration sleep against an async GCD timer.
+// Waits for the bounded fallback to actually enqueue an open, polling instead of sleeping a
+// fixed duration — as fast as the real event, with a generous ceiling for loaded CI.
 - (void)waitForFallbackOpenIn:(BNCServerRequestQueue *)queue timeout:(NSTimeInterval)timeout {
     NSPredicate *fallbackEnqueued = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
         return [self requestOperationsIn:queue].count > 0;
@@ -461,11 +431,8 @@
 
 #pragma mark - EMT-3892/3893 behavioral evidence
 
-// Behavior 1: deep link + requestDeepLinkData resolving emits exactly ONE open request for
-// the session, and it carries the resolved link — not an unattributed launch open plus a
-// duplicate attributed one. No HTTP stub library exists in this suite, so the deep-link
-// server round trip is simulated directly on a BranchRequestDeepLink instance (mirrors what
-// requestDeepLinkData: does internally once its network call returns).
+// Behavior 1: a resolved deep link emits exactly one open, carrying the link. The server
+// round trip is simulated on a BranchRequestDeepLink — no HTTP stub library in this suite.
 - (void)testDeepLinkResolutionEmitsExactlyOneAttributedOpenCarryingTheLink {
     NSString *linkURL = @"https://example.app.link/behavioral-resolved";
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
@@ -478,8 +445,7 @@
     XCTAssertEqual([self requestOperationsIn:fakeQueue].count, 0u,
                     @"Nothing should be enqueued yet — the open is deferred pending resolution.");
 
-    // 2) App calls requestDeepLinkData(...), which (a) cancels the bounded fallback and
-    // (b) resolves the link. We simulate step (b)'s network response directly.
+    // 2) App calls requestDeepLinkData: it cancels the fallback, then resolves the link.
     [self.branch cancelDeepLinkOpenFallback];
 
     BranchRequestDeepLink *deepLinkRequest = [[BranchRequestDeepLink alloc] initWithCallback:nil];
@@ -487,17 +453,14 @@
     deepLinkRequest.uri = linkURL;
     [deepLinkRequest processResponse:[self stubDeepLinkResponseForLink:linkURL] error:nil];
 
-    // Exactly one open — the single ATTRIBUTED open sent by
-    // BranchRequestDeepLink.processResponse: (sendOpen:), not a second/duplicate one.
     NSArray<NSOperation *> *ops = [self requestOperationsIn:fakeQueue];
     XCTAssertEqual(ops.count, 1u, @"Exactly one open request must be emitted for a resolved deep link — no duplicate.");
 
     if (ops.count == 1) {
         id request = [ops.firstObject valueForKey:@"request"];
         XCTAssertEqualObjects(NSStringFromClass([request class]), @"BranchRequestOpen");
-        // The attributed open carries the resolved link via linkData (-> link_data on the
-        // wire, see BranchRequestOpen.makeRequest:), not urlString. Documented explicitly
-        // because it differs from the factory-level universal_link_url path.
+        // The attributed open carries the link via linkData (-> link_data on the wire), not
+        // urlString — unlike the factory-level universal_link_url path.
         NSDictionary *linkData = [request valueForKey:@"linkData"];
         XCTAssertNotNil(linkData, @"The attributed open must carry the resolved link's data.");
         NSDictionary *carriedSessionData = linkData[BRANCH_RESPONSE_KEY_SESSION_DATA];
@@ -508,10 +471,8 @@
     [self restoreRealRequestQueue];
 }
 
-// Behavior 2: deep link received, requestDeepLinkData never called → after the bounded
-// fallback window, exactly ONE generic (unattributed) open is emitted so the open isn't
-// lost. preferenceHelper.timeout is temporarily lowered so the test doesn't wait out the
-// real ~5.5s default.
+// Behavior 2: requestDeepLinkData never called → the fallback emits exactly one
+// unattributed open, so the open isn't lost. timeout is lowered to keep the test fast.
 - (void)testDeepLinkFallbackFiresExactlyOneUnattributedOpenWhenNeverResolved {
     NSString *linkURL = @"https://example.app.link/behavioral-never-resolved";
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
@@ -524,10 +485,8 @@
     [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
     XCTAssertTrue(self.branch.deepLinkOpenPending);
 
-    // Do NOT call requestDeepLinkData. Wait for the fallback to actually enqueue the open —
-    // not a fixed wall-clock sleep, which raced under load (observed flaky: sometimes the
-    // 0.2s-configured fallback hadn't fired by a fixed 0.6s deadline). A polling predicate
-    // expectation resolves as soon as the real event happens, with a generous ceiling.
+    // Do NOT call requestDeepLinkData. Poll for the fallback rather than sleeping a fixed
+    // duration, which was observed flaky under load.
     [self waitForFallbackOpenIn:fakeQueue timeout:5.0];
 
     XCTAssertFalse(self.branch.deepLinkOpenPending, @"The fallback should have fired and cleared the pending flag.");
@@ -546,9 +505,9 @@
     preferenceHelper.timeout = originalTimeout;
 }
 
-// Behavior 3 (EMT-3893, SDK layer only): once the attributed open's own response settles,
-// referringURL is cleared, so a subsequent open with no new link does not carry the
-// previous link forward. Does NOT prove/disprove server-side stickiness (out of scope).
+// Behavior 3 (EMT-3893, SDK layer only): referringURL clears once the attributed open
+// settles, so a later open doesn't carry the link forward. Server-side stickiness is out
+// of scope here.
 - (void)testResolvedLinkDoesNotStickToSubsequentOpen {
     NSString *linkURL = @"https://example.app.link/behavioral-sticky-check";
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
@@ -558,10 +517,8 @@
     [self.branch cancelDeepLinkOpenFallback];
     XCTAssertEqualObjects(preferenceHelper.referringURL, linkURL);
 
-    // The attributed open's own response settling is what clears referringURL today. Use an
-    // isolated request instance (nil callback) so this assertion-only step doesn't also
-    // trigger the production completion path's async main-queue side effects on the shared
-    // Branch singleton.
+    // The attributed open's response settling is what clears referringURL. An isolated
+    // instance (nil callback) avoids the production path's async side effects on the singleton.
     BranchRequestOpen *attributedOpenRequest = [[BranchRequestOpen alloc] initWithCallback:nil];
     attributedOpenRequest.urlString = nil;
     attributedOpenRequest.linkData = [self stubDeepLinkResponseForLink:linkURL].data;
@@ -586,14 +543,9 @@
     [self restoreRealRequestQueue];
 }
 
-// Behavior 4 (ordering risk, FIXED): requestDeepLinkData resolving a link BEFORE
-// handleUniversalDeepLink_private is invoked for that same link. This can legitimately
-// happen (e.g. a host app resolving from scene-connection options before UIKit separately
-// delivers the universal link). Regression test for the fix: handleUniversalDeepLink_private
-// now recognizes (via lastAttributedDeepLinkURL) that this exact link was already attributed
-// by the earlier resolution and does not re-arm the deferred-open fallback, so only ONE open
-// total is ever emitted — previously this double-emitted (1 attributed + 1 unattributed
-// fallback).
+// Behavior 4: resolution arriving BEFORE handleUniversalDeepLink_private for the same link
+// (e.g. the host app resolves from scene-connection options first). Previously this
+// double-emitted; lastAttributedDeepLinkURL now keeps it at one open.
 - (void)testRequestDeepLinkDataBeforeUniversalDeepLinkEmitsExactlyOneOpen {
     NSString *linkURL = @"https://example.app.link/behavioral-ordering-edge";
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
@@ -612,15 +564,13 @@
     NSArray<NSOperation *> *afterResolution = [self requestOperationsIn:fakeQueue];
     XCTAssertEqual(afterResolution.count, 1u, @"The early resolution alone must still emit exactly one attributed open.");
 
-    // 2) handleUniversalDeepLink_private fires AFTER, for the same (already-attributed)
-    // link. The fix: it must recognize that and skip arming the deferred-open fallback.
+    // 2) handleUniversalDeepLink_private fires after, for the same already-attributed link;
+    // it must skip arming the fallback.
     [self.branch handleUniversalDeepLink_private:linkURL sceneIdentifier:nil];
     XCTAssertFalse(self.branch.deepLinkOpenPending,
                     @"A link already attributed via an earlier resolution must not re-arm the deferred-open fallback.");
 
-    // Deterministically prove no SECOND open ever appears — an inverted expectation, not a
-    // blind sleep: it only fails if a second open actually shows up within the window, so
-    // there is no false-negative risk from finishing "too fast".
+    // Inverted expectation: fails only if a second open actually appears in the window.
     NSPredicate *secondOpenEnqueued = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
         return [self requestOperationsIn:fakeQueue].count > 1;
     }];

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -161,6 +161,13 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 @property (assign, nonatomic) BOOL deepLinkOpenPending;
 // Bounded fallback timer that fires the deferred open (unattributed) if resolution never happens.
 @property (strong, nonatomic) dispatch_source_t deepLinkOpenFallbackTimer;
+// EMT-3892 ordering fix: the link URL an ATTRIBUTED open was last sent for. Lets
+// handleUniversalDeepLink_private: recognize "this link was already resolved and
+// attributed" when requestDeepLinkData wins a race and resolves it first — otherwise the
+// late-arriving handleUniversalDeepLink_private: call would re-arm the deferred-open
+// fallback and emit a second, unattributed open for the same link. Cleared alongside
+// referringURL once the attributed open's own session settles (sendOpenNotificationWithLinkParameters:).
+@property (copy, nonatomic) NSString *lastAttributedDeepLinkURL;
 @property (assign, nonatomic) BOOL shouldAutomaticallyDeepLink;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
 @property (strong, nonatomic) BNCPreferenceHelper *preferenceHelper;
@@ -1003,6 +1010,16 @@ static NSString *bnc_branchKey = nil;
     }
 
     // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
+    // EMT-3892 ordering fix: requestDeepLinkData can win the race and resolve (and attribute)
+    // this exact link before this method runs (e.g. UIKit delivering continueUserActivity:
+    // after a scene-connection-options-driven resolution). If so, the single attributed open
+    // has already been sent — don't re-arm the deferred-open fallback, or it would fire a
+    // second, unattributed open for the same link.
+    if (urlString.length && [self.lastAttributedDeepLinkURL isEqualToString:urlString]) {
+        [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"handleUniversalDeepLink_private: %@ was already attributed via an earlier resolution; not re-arming the deferred open.", urlString] error:nil];
+        return [Branch isBranchLink:urlString];
+    }
+
     // EMT-3892: defer the launch open until requestDeepLinkData resolves this link (see
     // deferLaunchOpenPendingDeepLinkResolution) instead of firing an immediate, unattributed
     // sendOpen here — which previously raced with the attributed sendOpen: fired after
@@ -2425,6 +2442,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         userInfo:userInfo];
 
     self.preferenceHelper.referringURL = nil;
+    // EMT-3892 ordering fix: the session this attribution belonged to has now settled;
+    // a later resolution of the same link URL should be treated as fresh again.
+    self.lastAttributedDeepLinkURL = nil;
 }
 
 - (void)removeViewControllerFromRootNavigationController:(UIViewController*)branchSharingController {
@@ -2799,6 +2819,12 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         [[BranchLogger shared] logDebug: @"Branch Attribution Level set to NONE. Branch sendOpen network request prevented." error:nil];
         return;
     }
+
+    // EMT-3892 ordering fix: remember which link this ATTRIBUTED open was for, so a
+    // handleUniversalDeepLink_private: call arriving afterward for the SAME link (already
+    // resolved here) does not re-arm the deferred-open fallback. See
+    // handleUniversalDeepLink_private: and lastAttributedDeepLinkURL.
+    self.lastAttributedDeepLinkURL = self.preferenceHelper.referringURL;
 
     // Prepare callback block
     callbackWithStatus openCallback = ^(BOOL success, NSError *error) {

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -155,6 +155,12 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 - (void)notifyWhenSessionReady:(void (^)(NSError * _Nullable error))block;
 - (void)deliverSessionReadyBlocksWithError:(nullable NSError *)error;
 - (void)discardSessionReadyBlocks;
+
+// EMT-3892: true while a Branch deep-link open is deferred, waiting for requestDeepLinkData
+// to resolve it into a single ATTRIBUTED open. See deferLaunchOpenPendingDeepLinkResolution.
+@property (assign, nonatomic) BOOL deepLinkOpenPending;
+// Bounded fallback timer that fires the deferred open (unattributed) if resolution never happens.
+@property (strong, nonatomic) dispatch_source_t deepLinkOpenFallbackTimer;
 @property (assign, nonatomic) BOOL shouldAutomaticallyDeepLink;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
 @property (strong, nonatomic) BNCPreferenceHelper *preferenceHelper;
@@ -997,7 +1003,11 @@ static NSString *bnc_branchKey = nil;
     }
 
     // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
-    [self sendOpen];
+    // EMT-3892: defer the launch open until requestDeepLinkData resolves this link (see
+    // deferLaunchOpenPendingDeepLinkResolution) instead of firing an immediate, unattributed
+    // sendOpen here — which previously raced with the attributed sendOpen: fired after
+    // resolution and produced two /v3/events/open calls for one deep-link open.
+    [self deferLaunchOpenPendingDeepLinkResolution];
 
     return [Branch isBranchLink:urlString];
 }
@@ -1993,9 +2003,11 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        if (!Branch.trackingDisabled && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue) {
-            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue] error:nil];
-            
+        // EMT-3892: don't fire the organic auto-open while a deep-link open is deferred and
+        // waiting on requestDeepLinkData — that would be a second, premature, unattributed open.
+        if (!Branch.trackingDisabled && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue && !self.deepLinkOpenPending) {
+            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d deepLinkOpenPending %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue, self.deepLinkOpenPending] error:nil];
+
             [self sendOpen];
         }
     });
@@ -2464,6 +2476,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [self cancelDeepLinkOpenFallback];
 }
 
 - (void)registerPluginName:(NSString *)name version:(NSString *)version {
@@ -2529,6 +2542,11 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 - (void) requestDeepLinkData:(NSString *)branchLink callback:(nullable callbackWithParams)callback {
     [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"requestDeepLinkData called with branchLink: %@", branchLink] error:nil];
+
+    // EMT-3892: resolution is now underway — cancel the deferred launch open's bounded
+    // fallback so it doesn't also fire once BranchRequestDeepLink.processResponse sends the
+    // real (attributed) open below.
+    [self cancelDeepLinkOpenFallback];
 
     if (branchLink.length > 0) {
         [self.requestQueue cancelPendingDeepLinkRequests];
@@ -2667,6 +2685,76 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 - (void)discardSessionReadyBlocks {
     @synchronized (self.sessionReadyBlocks) {
         [self.sessionReadyBlocks removeAllObjects];
+    }
+}
+
+#pragma mark - Deep Link Open Deferral (EMT-3892 / EMT-3893)
+
+// A Branch deep-link open defers the automatic launch open until requestDeepLinkData
+// resolves it, so BranchRequestDeepLink.processResponse can send the single ATTRIBUTED
+// open (sendOpen:). This replaces the previous behavior of firing an immediate,
+// unattributed sendOpen here *and* a second, attributed sendOpen: after resolution
+// (EMT-3892: duplicate /v3/events/open).
+//
+// Bounded fallback: if the host app never calls requestDeepLinkData, the deferred open
+// would otherwise never fire and the open would be lost. The fallback timer mirrors the
+// network timeout already used for open/deep-link requests (preferenceHelper.timeout,
+// default 5.5s — see BNCServerInterface), so it never fires sooner than a real deep-link
+// resolution attempt could complete.
+- (void)deferLaunchOpenPendingDeepLinkResolution {
+    self.deepLinkOpenPending = YES;
+
+    @synchronized (self) {
+        [self cancelDeepLinkOpenFallbackTimerLocked];
+
+        NSTimeInterval fallbackInterval = self.preferenceHelper.timeout;
+        dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.isolationQueue);
+        dispatch_source_set_timer(timer,
+                                  dispatch_time(DISPATCH_TIME_NOW, (int64_t)(fallbackInterval * NSEC_PER_SEC)),
+                                  DISPATCH_TIME_FOREVER,
+                                  (int64_t)(0.1 * NSEC_PER_SEC));
+
+        // __weak avoids a retain cycle (self -> timer -> event handler block -> self).
+        __weak Branch *weakSelf = self;
+        dispatch_source_set_event_handler(timer, ^{
+            Branch *strongSelf = weakSelf;
+            if (!strongSelf) return;
+
+            @synchronized (strongSelf) {
+                if (!strongSelf.deepLinkOpenPending) return;
+                strongSelf.deepLinkOpenPending = NO;
+                [strongSelf cancelDeepLinkOpenFallbackTimerLocked];
+            }
+
+            [[BranchLogger shared] logVerbose:@"Deep link resolution fallback fired: requestDeepLinkData was not called in time. Sending the deferred open unattributed so it is not lost." error:nil];
+
+            // EMT-3893: this open gave up waiting for resolution, so it must not report a
+            // link it never actually attributed. Note: the server MAY still echo a prior
+            // click's ~referring_link in the session response (residual server-side
+            // stickiness) — that is a backend concern tracked separately and not fixed here.
+            strongSelf.preferenceHelper.referringURL = nil;
+            [strongSelf sendOpen];
+        });
+
+        self.deepLinkOpenFallbackTimer = timer;
+        dispatch_resume(timer);
+    }
+}
+
+// Called once deep-link resolution is actually underway (requestDeepLinkData was invoked)
+// so the bounded fallback above does not also fire a redundant, unattributed open.
+- (void)cancelDeepLinkOpenFallback {
+    self.deepLinkOpenPending = NO;
+    @synchronized (self) {
+        [self cancelDeepLinkOpenFallbackTimerLocked];
+    }
+}
+
+// Must be called while holding @synchronized(self).
+- (void)cancelDeepLinkOpenFallbackTimerLocked {
+    if (self.deepLinkOpenFallbackTimer) {
+        dispatch_source_cancel(self.deepLinkOpenFallbackTimer);
+        self.deepLinkOpenFallbackTimer = nil;
     }
 }
 

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -156,17 +156,11 @@ typedef NS_ENUM(NSInteger, BNCInitStatus) {
 - (void)deliverSessionReadyBlocksWithError:(nullable NSError *)error;
 - (void)discardSessionReadyBlocks;
 
-// EMT-3892: true while a Branch deep-link open is deferred, waiting for requestDeepLinkData
-// to resolve it into a single ATTRIBUTED open. See deferLaunchOpenPendingDeepLinkResolution.
+// EMT-3892: a deep-link open is deferred until requestDeepLinkData resolves it into one
+// attributed open. lastAttributedDeepLinkURL guards the reverse order (resolution first),
+// where re-arming the fallback would emit a second, unattributed open.
 @property (assign, nonatomic) BOOL deepLinkOpenPending;
-// Bounded fallback timer that fires the deferred open (unattributed) if resolution never happens.
 @property (strong, nonatomic) dispatch_source_t deepLinkOpenFallbackTimer;
-// EMT-3892 ordering fix: the link URL an ATTRIBUTED open was last sent for. Lets
-// handleUniversalDeepLink_private: recognize "this link was already resolved and
-// attributed" when requestDeepLinkData wins a race and resolves it first — otherwise the
-// late-arriving handleUniversalDeepLink_private: call would re-arm the deferred-open
-// fallback and emit a second, unattributed open for the same link. Cleared alongside
-// referringURL once the attributed open's own session settles (sendOpenNotificationWithLinkParameters:).
 @property (copy, nonatomic) NSString *lastAttributedDeepLinkURL;
 @property (assign, nonatomic) BOOL shouldAutomaticallyDeepLink;
 @property (strong, nonatomic) BNCLinkCache *linkCache;
@@ -1010,20 +1004,15 @@ static NSString *bnc_branchKey = nil;
     }
 
     // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
-    // EMT-3892 ordering fix: requestDeepLinkData can win the race and resolve (and attribute)
-    // this exact link before this method runs (e.g. UIKit delivering continueUserActivity:
-    // after a scene-connection-options-driven resolution). If so, the single attributed open
-    // has already been sent — don't re-arm the deferred-open fallback, or it would fire a
-    // second, unattributed open for the same link.
+    // EMT-3892: resolution may have already attributed this link (race).
+    // Re-arming the fallback here would emit a second, unattributed open.
     if (urlString.length && [self.lastAttributedDeepLinkURL isEqualToString:urlString]) {
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"handleUniversalDeepLink_private: %@ was already attributed via an earlier resolution; not re-arming the deferred open.", urlString] error:nil];
         return [Branch isBranchLink:urlString];
     }
 
-    // EMT-3892: defer the launch open until requestDeepLinkData resolves this link (see
-    // deferLaunchOpenPendingDeepLinkResolution) instead of firing an immediate, unattributed
-    // sendOpen here — which previously raced with the attributed sendOpen: fired after
-    // resolution and produced two /v3/events/open calls for one deep-link open.
+    // EMT-3892: defer the launch open until requestDeepLinkData resolves it, instead of
+    // firing an unattributed sendOpen that races the attributed one.
     [self deferLaunchOpenPendingDeepLinkResolution];
 
     return [Branch isBranchLink:urlString];
@@ -2020,8 +2009,8 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        // EMT-3892: don't fire the organic auto-open while a deep-link open is deferred and
-        // waiting on requestDeepLinkData — that would be a second, premature, unattributed open.
+        // EMT-3892: a deferred deep-link open is still pending; firing here would be a
+        // second, unattributed open.
         if (!Branch.trackingDisabled && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue && !self.deepLinkOpenPending) {
             [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive trackingDisabled %d initializationStatus %d installOrOpenInQueue %d deepLinkOpenPending %d", Branch.trackingDisabled, self.initializationStatus, installOrOpenInQueue, self.deepLinkOpenPending] error:nil];
 
@@ -2442,8 +2431,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         userInfo:userInfo];
 
     self.preferenceHelper.referringURL = nil;
-    // EMT-3892 ordering fix: the session this attribution belonged to has now settled;
-    // a later resolution of the same link URL should be treated as fresh again.
+    // EMT-3892: the session settled, so the same link URL is fresh again.
     self.lastAttributedDeepLinkURL = nil;
 }
 
@@ -2563,9 +2551,8 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 - (void) requestDeepLinkData:(NSString *)branchLink callback:(nullable callbackWithParams)callback {
     [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"requestDeepLinkData called with branchLink: %@", branchLink] error:nil];
 
-    // EMT-3892: resolution is now underway — cancel the deferred launch open's bounded
-    // fallback so it doesn't also fire once BranchRequestDeepLink.processResponse sends the
-    // real (attributed) open below.
+    // EMT-3892: resolution is underway; the attributed open comes from
+    // BranchRequestDeepLink.processResponse, so the fallback must not also fire.
     [self cancelDeepLinkOpenFallback];
 
     if (branchLink.length > 0) {
@@ -2710,17 +2697,9 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 #pragma mark - Deep Link Open Deferral (EMT-3892 / EMT-3893)
 
-// A Branch deep-link open defers the automatic launch open until requestDeepLinkData
-// resolves it, so BranchRequestDeepLink.processResponse can send the single ATTRIBUTED
-// open (sendOpen:). This replaces the previous behavior of firing an immediate,
-// unattributed sendOpen here *and* a second, attributed sendOpen: after resolution
-// (EMT-3892: duplicate /v3/events/open).
-//
-// Bounded fallback: if the host app never calls requestDeepLinkData, the deferred open
-// would otherwise never fire and the open would be lost. The fallback timer mirrors the
-// network timeout already used for open/deep-link requests (preferenceHelper.timeout,
-// default 5.5s — see BNCServerInterface), so it never fires sooner than a real deep-link
-// resolution attempt could complete.
+// Defers the launch open so BranchRequestDeepLink.processResponse sends the single
+// attributed open. Bounded fallback (preferenceHelper.timeout, default 5.5s) fires an
+// unattributed open if the host app never calls requestDeepLinkData. EMT-3892.
 - (void)deferLaunchOpenPendingDeepLinkResolution {
     self.deepLinkOpenPending = YES;
 
@@ -2748,10 +2727,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
             [[BranchLogger shared] logVerbose:@"Deep link resolution fallback fired: requestDeepLinkData was not called in time. Sending the deferred open unattributed so it is not lost." error:nil];
 
-            // EMT-3893: this open gave up waiting for resolution, so it must not report a
-            // link it never actually attributed. Note: the server MAY still echo a prior
-            // click's ~referring_link in the session response (residual server-side
-            // stickiness) — that is a backend concern tracked separately and not fixed here.
+            // EMT-3893: this open never attributed a link, so it must not report one.
             strongSelf.preferenceHelper.referringURL = nil;
             [strongSelf sendOpen];
         });
@@ -2761,8 +2737,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     }
 }
 
-// Called once deep-link resolution is actually underway (requestDeepLinkData was invoked)
-// so the bounded fallback above does not also fire a redundant, unattributed open.
+// Called once resolution is underway, so the fallback does not fire a redundant open.
 - (void)cancelDeepLinkOpenFallback {
     self.deepLinkOpenPending = NO;
     @synchronized (self) {
@@ -2820,10 +2795,8 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
         return;
     }
 
-    // EMT-3892 ordering fix: remember which link this ATTRIBUTED open was for, so a
-    // handleUniversalDeepLink_private: call arriving afterward for the SAME link (already
-    // resolved here) does not re-arm the deferred-open fallback. See
-    // handleUniversalDeepLink_private: and lastAttributedDeepLinkURL.
+    // EMT-3892: remember the link this attributed open was for, so a later
+    // handleUniversalDeepLink_private: for the same link skips the fallback.
     self.lastAttributedDeepLinkURL = self.preferenceHelper.referringURL;
 
     // Prepare callback block

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -2679,6 +2679,13 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
 #pragma mark - Deep Link Open Deferral (EMT-3892 / EMT-3893)
 
+// Records the link an attributed open is for. Called by BranchRequestDeepLink once it has
+// resolved one, so a later handleUniversalDeepLink_private: for that same link skips
+// re-arming the fallback instead of producing a second open.
+- (void)markDeepLinkAttributed:(NSString *)urlString {
+    self.lastAttributedDeepLinkURL = urlString;
+}
+
 // Defers the launch open so BranchRequestDeepLink.processResponse sends the single
 // attributed open. Bounded fallback (preferenceHelper.timeout, default 5.5s) fires an
 // unattributed open if the host app never calls requestDeepLinkData. EMT-3892.
@@ -2783,7 +2790,12 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
     // EMT-3892: remember the link this attributed open was for, so a later
     // handleUniversalDeepLink_private: for the same link skips the fallback.
-    self.lastAttributedDeepLinkURL = self.preferenceHelper.referringURL;
+    // Only when we actually have one: in the resolution-first ordering
+    // BranchRequestDeepLink has already called markDeepLinkAttributed: with the resolved
+    // link, and referringURL is still nil here — overwriting would drop that mark.
+    if (self.preferenceHelper.referringURL.length) {
+        self.lastAttributedDeepLinkURL = self.preferenceHelper.referringURL;
+    }
 
     // Prepare callback block
     callbackWithStatus openCallback = ^(BOOL success, NSError *error) {

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -966,16 +966,13 @@ static NSString *bnc_branchKey = nil;
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"Set universalLinkUrl and referringURL to %@", urlString] error:nil];
     }
 
-    // [self initUserSessionAndCallCallback:YES sceneIdentifier:sceneIdentifier urlString:urlString reset:YES];
-    // EMT-3892: resolution may have already attributed this link (race).
-    // Re-arming the fallback here would emit a second, unattributed open.
+    // Skips re-arming the fallback if this link was already attributed.
     if (urlString.length && [self.lastAttributedDeepLinkURL isEqualToString:urlString]) {
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"handleUniversalDeepLink_private: %@ was already attributed via an earlier resolution; not re-arming the deferred open.", urlString] error:nil];
         return [Branch isBranchLink:urlString];
     }
 
-    // EMT-3892: defer the launch open until requestDeepLinkData resolves it, instead of
-    // firing an unattributed sendOpen that races the attributed one.
+    // Defers the launch open until requestDeepLinkData resolves it.
     [self deferLaunchOpenPendingDeepLinkResolution];
 
     return [Branch isBranchLink:urlString];
@@ -1989,10 +1986,9 @@ static NSString *bnc_branchKey = nil;
         
         [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive installOrOpenInQueue %d", installOrOpenInQueue] error:nil];
 
-        // EMT-3892: a deferred deep-link open is still pending; firing here would be a
-        // second, unattributed open.
-        if (![Branch attributionLevelNone] && self.initializationStatus == BNCInitStatusUninitialized && !installOrOpenInQueue && !self.deepLinkOpenPending) {
-            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive attributionLevelNone %d initializationStatus %d installOrOpenInQueue %d deepLinkOpenPending %d", [Branch attributionLevelNone], self.initializationStatus, installOrOpenInQueue, self.deepLinkOpenPending] error:nil];
+        // Skips sending an open while a deferred deep-link open is still pending.
+        if (![Branch attributionLevelNone] && !installOrOpenInQueue && !self.deepLinkOpenPending) {
+            [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"applicationDidBecomeActive attributionLevelNone %d installOrOpenInQueue %d deepLinkOpenPending %d", [Branch attributionLevelNone], installOrOpenInQueue, self.deepLinkOpenPending] error:nil];
 
             [self sendOpen];
         }
@@ -2677,22 +2673,20 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     }
 }
 
-#pragma mark - Deep Link Open Deferral (EMT-3892 / EMT-3893)
+#pragma mark - Deep Link Open Deferral
 
-// Records the link an attributed open is for. Called by BranchRequestDeepLink once it has
-// resolved one, so a later handleUniversalDeepLink_private: for that same link skips
-// re-arming the fallback instead of producing a second open.
+// Records the link an attributed open is for, so a later handleUniversalDeepLink_private:
+// for the same link skips re-arming the fallback.
 - (void)markDeepLinkAttributed:(NSString *)urlString {
     self.lastAttributedDeepLinkURL = urlString;
 }
 
-// Defers the launch open so BranchRequestDeepLink.processResponse sends the single
-// attributed open. Bounded fallback (preferenceHelper.timeout, default 5.5s) fires an
-// unattributed open if the host app never calls requestDeepLinkData. EMT-3892.
+// Defers the launch open until the deep link resolves. Fallback fires after
+// preferenceHelper.timeout (default 5.5s) if requestDeepLinkData is never called.
 - (void)deferLaunchOpenPendingDeepLinkResolution {
-    self.deepLinkOpenPending = YES;
-
     @synchronized (self) {
+        self.deepLinkOpenPending = YES;
+
         [self cancelDeepLinkOpenFallbackTimerLocked];
 
         NSTimeInterval fallbackInterval = self.preferenceHelper.timeout;
@@ -2716,7 +2710,7 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
 
             [[BranchLogger shared] logVerbose:@"Deep link resolution fallback fired: requestDeepLinkData was not called in time. Sending the deferred open unattributed so it is not lost." error:nil];
 
-            // EMT-3893: this open never attributed a link, so it must not report one.
+            // Clears the referring URL so this open is not reported as attributed.
             strongSelf.preferenceHelper.referringURL = nil;
             [strongSelf sendOpen];
         });
@@ -2726,10 +2720,10 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
     }
 }
 
-// Called once resolution is underway, so the fallback does not fire a redundant open.
+// Cancels the pending fallback.
 - (void)cancelDeepLinkOpenFallback {
-    self.deepLinkOpenPending = NO;
     @synchronized (self) {
+        self.deepLinkOpenPending = NO;
         [self cancelDeepLinkOpenFallbackTimerLocked];
     }
 }

--- a/Sources/BranchSDK/BranchRequestDeepLink.m
+++ b/Sources/BranchSDK/BranchRequestDeepLink.m
@@ -16,9 +16,10 @@
 #import "BNCServerAPI.h"
 #import "BNCInAppBrowser.h"
 
-// Forward declaration of private Branch method
+// Forward declaration of private Branch methods
 @interface Branch (PrivateMethods)
 - (void)sendOpen:(NSDictionary *)responseData skipCallback:(BOOL)skipCallback;
+- (void)markDeepLinkAttributed:(NSString *)urlString;
 @end
 
 @implementation BranchRequestDeepLink
@@ -254,6 +255,12 @@ static BOOL deepLinkRequestWaitQueueIsSuspended = NO;
 
     if (referringURL != nil) {
         [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"~referring_link found in response: %@, sending sendOpen network request." ,referringURL] error:nil];
+        // EMT-3892: tell Branch which link this open attributes, so a later
+        // handleUniversalDeepLink_private: for the same link does not re-arm the
+        // deferred-open fallback and emit a second open. It has to be passed
+        // explicitly: this class no longer writes preferenceHelper.referringURL,
+        // so Branch cannot read the value back out in this ordering.
+        [[Branch getInstance] markDeepLinkAttributed:referringURL];
         [[Branch getInstance] sendOpen:response.data skipCallback:skipCallback];
     } else {
         [[BranchLogger shared] logDebug:@"No ~referring_link on deeplink data. Not sending sendOpen network request. Clearing link identifiers to prevent reuse." error:nil];

--- a/Sources/BranchSDK/BranchRequestOpen.m
+++ b/Sources/BranchSDK/BranchRequestOpen.m
@@ -148,7 +148,14 @@
         [sessionDataDict addEntriesFromDictionary:spotlightDic];
         sessionData = [BNCEncodingUtils encodeDictionaryToJsonString:sessionDataDict];
     }
-    
+
+    // EMT-3893: rewritten verbatim from every open's server response, by design (this is how
+    // getLatestReferringParams stays current for the session). The SDK clears its own link
+    // identifiers/referringURL after each open (see the "Clear link identifiers" block below
+    // and Branch.m sendOpenNotificationWithLinkParameters:), but the server MAY still echo a
+    // previous click's ~referring_link in session_data for an unrelated open (residual
+    // server-side stickiness). That is a backend behavior question tracked separately
+    // (EMT-3893) and intentionally not worked around here.
     preferenceHelper.sessionParams = sessionData;
 
     // Scenarios:

--- a/Sources/BranchSDK/BranchRequestOpen.m
+++ b/Sources/BranchSDK/BranchRequestOpen.m
@@ -149,13 +149,8 @@
         sessionData = [BNCEncodingUtils encodeDictionaryToJsonString:sessionDataDict];
     }
 
-    // EMT-3893: rewritten verbatim from every open's server response, by design (this is how
-    // getLatestReferringParams stays current for the session). The SDK clears its own link
-    // identifiers/referringURL after each open (see the "Clear link identifiers" block below
-    // and Branch.m sendOpenNotificationWithLinkParameters:), but the server MAY still echo a
-    // previous click's ~referring_link in session_data for an unrelated open (residual
-    // server-side stickiness). That is a backend behavior question tracked separately
-    // (EMT-3893) and intentionally not worked around here.
+    // EMT-3893: the server may still echo a previous click's ~referring_link here. The SDK
+    // clears its own link identifiers below; the server-side stickiness is a backend issue.
     preferenceHelper.sessionParams = sessionData;
 
     // Scenarios:


### PR DESCRIPTION
Fixes the duplicate `/v3/events/open` on a Branch deep-link launch. The launch open is deferred until `requestDeepLinkData` resolves, so `BranchRequestDeepLink.processResponse` sends a single attributed open, instead of one unattributed open firing immediately and a second attributed one landing after resolution. A bounded fallback (`preferenceHelper.timeout`) still sends the open unattributed if the host app never calls `requestDeepLinkData`, so it is never lost.

## Scope change

This was opened as EMT-3892 + EMT-3893. **EMT-3893 (link stickiness) is no longer part of the fix.** `2bd5e040` on `4.0.0-beta.0` already clears the link identifiers on the attributed open path — `BranchRequestOpen.processResponse` nils `linkClickIdentifier`, `spotlightIdentifier`, `universalLinkUrl`, `externalIntentURI` and sets `referringURL` from the response, which is nil when no link came back.

What this PR still contributes for 3893 is a **regression test** guarding that behaviour, since `2bd5e040` landed without one. No production change.

## Ordering fix after catching up with beta

The guard marked `lastAttributedDeepLinkURL` by reading `preferenceHelper.referringURL` back inside `sendOpen:skipCallback:`. That worked while `BranchRequestDeepLink` wrote `referringURL` into the preference helper, but `a03b72a4` made it a local variable. In the resolution-first ordering the mark then read nil, the guard in `handleUniversalDeepLink_private:` never matched, the fallback re-armed, and a second open went out — the exact duplicate this ticket exists to fix.

`BranchRequestDeepLink` now passes the resolved link to `markDeepLinkAttributed:` explicitly. The read in `sendOpen:` is kept for the reverse ordering (universal link first, which does populate `referringURL`) but no longer overwrites an existing mark with nil.

## Verification

`xcodebuild test -project BranchSDK.xcodeproj -scheme BranchSDKTests` — **491 tests, 0 failures.**

The suite aborts intermittently on this machine before completing, with WebKit/simulator process churn in the log; the QR-code tests reach `api3.branch.io` over the real network. Every run that ran to completion reported 491/0, and no run recorded a test failure. Pre-existing, not introduced here.

Synced with `4.0.0-beta.0` by merge, per the convention on this line. No force push, so the review threads above are intact.
