### PR TITLE
Stop a cold WKWebView boot from failing the user agent tests

### DIFF
--- a/Branch-TestBed/Branch-SDK-Tests/BNCDeviceInfoTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCDeviceInfoTests.m
@@ -21,13 +21,22 @@
     self.deviceInfo = [BNCDeviceInfo new];
 }
 
-// user agent needs to be loaded
+// The user agent needs to be loaded before the assertions below run. When it is not
+// cached yet it is collected through a WKWebView, whose first boot on a cold simulator
+// can take well over five seconds.
+//
+// Waiting through the test case made a slow load fail whichever test happened to run
+// first, which is how a timeout here surfaced as a failure in testAdvertiserId. Only
+// testUserAgentString actually depends on the collected value, so a standalone XCTWaiter
+// is used instead: a slow load now fails that test, on its own assertion, and leaves the
+// rest of the class alone. That is what the empty handler on the previous
+// waitForExpectationsWithTimeout: call was trying (and failing) to express.
 - (void)workaroundUserAgentLazyLoad {
-    __block XCTestExpectation *expectation = [self expectationWithDescription:@"setup"];
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"user agent warm-up"];
     [[BNCUserAgentCollector instance] loadUserAgentWithCompletion:^(NSString * _Nullable userAgent) {
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError * _Nullable error) { }];
+    [[XCTWaiter new] waitForExpectations:@[expectation] timeout:30.0];
 }
 
 - (void)tearDown {

--- a/Branch-TestBed/Branch-SDK-Tests/BNCDeviceInfoTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCDeviceInfoTests.m
@@ -29,8 +29,7 @@
 // first, which is how a timeout here surfaced as a failure in testAdvertiserId. Only
 // testUserAgentString actually depends on the collected value, so a standalone XCTWaiter
 // is used instead: a slow load now fails that test, on its own assertion, and leaves the
-// rest of the class alone. That is what the empty handler on the previous
-// waitForExpectationsWithTimeout: call was trying (and failing) to express.
+// rest of the class alone.
 - (void)workaroundUserAgentLazyLoad {
     XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"user agent warm-up"];
     [[BNCUserAgentCollector instance] loadUserAgentWithCompletion:^(NSString * _Nullable userAgent) {

--- a/Branch-TestBed/Branch-SDK-Tests/BNCUserAgentCollectorTests.m
+++ b/Branch-TestBed/Branch-SDK-Tests/BNCUserAgentCollectorTests.m
@@ -70,7 +70,9 @@
         [expectation fulfill];
     }];
 
-    [self waitForExpectationsWithTimeout:4.0 handler:^(NSError * _Nullable error) {
+    // Collection always goes through a WKWebView, whose first boot on a cold CI
+    // simulator can take well over the four seconds this used to allow.
+    [self waitForExpectationsWithTimeout:30.0 handler:^(NSError * _Nullable error) {
         
     }];
 }
@@ -85,7 +87,9 @@
         [expectation fulfill];
     }];
 
-    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError * _Nullable error) {
+    // An empty store falls through to collection, so this waits on the same cold
+    // WKWebView boot as testCollectUserAgent.
+    [self waitForExpectationsWithTimeout:30.0 handler:^(NSError * _Nullable error) {
         
     }];
 }

--- a/BranchSDKTests/BNCDeviceInfoTests.m
+++ b/BranchSDKTests/BNCDeviceInfoTests.m
@@ -21,13 +21,22 @@
     self.deviceInfo = [BNCDeviceInfo new];
 }
 
-// user agent needs to be loaded
+// The user agent needs to be loaded before the assertions below run. When it is not
+// cached yet it is collected through a WKWebView, whose first boot on a cold simulator
+// can take well over five seconds.
+//
+// Waiting through the test case made a slow load fail whichever test happened to run
+// first, which is how a timeout here surfaced as a failure in testAdvertiserId. Only
+// testUserAgentString actually depends on the collected value, so a standalone XCTWaiter
+// is used instead: a slow load now fails that test, on its own assertion, and leaves the
+// rest of the class alone. That is what the empty handler on the previous
+// waitForExpectationsWithTimeout: call was trying (and failing) to express.
 - (void)workaroundUserAgentLazyLoad {
-    __block XCTestExpectation *expectation = [self expectationWithDescription:@"setup"];
+    XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"user agent warm-up"];
     [[BNCUserAgentCollector instance] loadUserAgentWithCompletion:^(NSString * _Nullable userAgent) {
         [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError * _Nullable error) { }];
+    [[XCTWaiter new] waitForExpectations:@[expectation] timeout:30.0];
 }
 
 - (void)tearDown {

--- a/BranchSDKTests/BNCDeviceInfoTests.m
+++ b/BranchSDKTests/BNCDeviceInfoTests.m
@@ -29,8 +29,7 @@
 // first, which is how a timeout here surfaced as a failure in testAdvertiserId. Only
 // testUserAgentString actually depends on the collected value, so a standalone XCTWaiter
 // is used instead: a slow load now fails that test, on its own assertion, and leaves the
-// rest of the class alone. That is what the empty handler on the previous
-// waitForExpectationsWithTimeout: call was trying (and failing) to express.
+// rest of the class alone.
 - (void)workaroundUserAgentLazyLoad {
     XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"user agent warm-up"];
     [[BNCUserAgentCollector instance] loadUserAgentWithCompletion:^(NSString * _Nullable userAgent) {

--- a/BranchSDKTests/BNCUserAgentCollectorTests.m
+++ b/BranchSDKTests/BNCUserAgentCollectorTests.m
@@ -70,7 +70,9 @@
         [expectation fulfill];
     }];
 
-    [self waitForExpectationsWithTimeout:4.0 handler:^(NSError * _Nullable error) {
+    // Collection always goes through a WKWebView, whose first boot on a cold CI
+    // simulator can take well over the four seconds this used to allow.
+    [self waitForExpectationsWithTimeout:30.0 handler:^(NSError * _Nullable error) {
         
     }];
 }
@@ -85,7 +87,9 @@
         [expectation fulfill];
     }];
 
-    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError * _Nullable error) {
+    // An empty store falls through to collection, so this waits on the same cold
+    // WKWebView boot as testCollectUserAgent.
+    [self waitForExpectationsWithTimeout:30.0 handler:^(NSError * _Nullable error) {
         
     }];
 }


### PR DESCRIPTION
## Problem

`verify` fails intermittently across the 4.0 branches with:

```
✗ testAdvertiserId, Asynchronous wait failed: Exceeded timeout of 5 seconds,
  with unfulfilled expectations: "setup".
```

Same signature on `bboothe-branch/EMT-3977-2` (2026-07-22 and 2026-07-23) and on the current EMT-3808 stack. `testAdvertiserId` appears in the failure logs of 5 of the 7 most recent red `verify` runs, on branches with no code in common.

`testAdvertiserId` does not use the user agent. The failure comes from `setUp`.

## Cause

`BNCDeviceInfoTests.setUp` calls `workaroundUserAgentLazyLoad`, which warms up the user agent. `BNCUserAgentCollector.loadUserAgentWithCompletion:` returns immediately when a value is cached in preferences for the current system build; otherwise it collects one through a **WKWebView**. On a freshly erased CI simulator nothing is cached, and that first WebView boot can exceed the five second budget.

Because the wait went through the test case (`waitForExpectationsWithTimeout:`), the timeout was recorded as a failure of whichever test ran first — which is why an unrelated test carries the blame. The empty `handler:` block shows the author already intended the wait to be non-fatal; that call fails the test regardless of the handler.

## Change

Wait with a standalone `XCTWaiter` on a detached expectation, and give the load 30 seconds.

The timeout increase gives the cold WebView room; the `XCTWaiter` puts the failure in the right place if it ever does run out. Only `testUserAgentString` actually depends on the collected value, so that is the test that should fail.

Applied to both copies of the file (`BranchSDKTests/` and `Branch-TestBed/Branch-SDK-Tests/`), which are identical in this respect.

## Testing

All runs on a **freshly erased** simulator, so the WKWebView path is actually exercised rather than served from cache — with a warm cache the completion fires synchronously and the wait is a no-op, which makes the test vacuous.

| Scenario | Result |
| --- | --- |
| Full suite, this change, cold simulator | **483 tests, 0 failures** |
| `BNCDeviceInfoTests`, this change, cold simulator | 26 tests, 0 failures |

To show the misattribution is actually fixed rather than merely made less likely, the warm-up timeout was temporarily forced to `0.0001` so it always expires, on a cold simulator:

| Implementation | Forced timeout result |
| --- | --- |
| Previous (`waitForExpectationsWithTimeout:`) | 26 tests, **27 failures** — the whole class falls over |
| This change (`XCTWaiter`) | 26 tests, **1 failure** — only `testUserAgentString` |

That is the behavior this PR is claiming: a slow load fails the test that depends on it and leaves the rest of the class alone.

## Notes

- This does not make a genuinely broken user agent load pass silently. It relocates the failure to `testUserAgentString`, where the assertion is meaningful.
- `master` carries the same pattern in `Branch-TestBed/Branch-SDK-Tests/BNCDeviceInfoTests.m`. This PR targets `4.0.0-beta.0`, where the failing `verify` job runs. A separate PR can carry it to `master` if wanted.
- No Jira ticket was referenced since this came out of CI triage rather than a ticket. Happy to retitle with one.

## Type Of Change

- [x] Bug fix (non-breaking change which fixes an issue)
