### PR TITLE
EMT-3998: port the GPTDriver hybrid test suite to 4.0.0-beta.0

### DIFF
--- a/.github/workflows/gptdriver-e2e.yml
+++ b/.github/workflows/gptdriver-e2e.yml
@@ -1,0 +1,131 @@
+name: GPTDriver E2E (iOS)
+
+# The GPTDriver suite has two halves with very different costs, so this
+# workflow has two jobs.
+#
+#   deterministic — no credential, no network beyond SPM resolution. Runs on
+#                   every push to the beta line and every PR targeting it.
+#   full-suite    — drives the MobileBoost device farm and needs the
+#                   MOBILEBOOST_API_KEY secret. Manual dispatch, or a push to
+#                   a Release-* branch once a release candidate is cut. This
+#                   follows the trigger precedent set by Android #1382 and is
+#                   deliberately kept off ordinary pushes.
+
+on:
+  push:
+    branches:
+      - "4.0.0-beta.*"
+      - "Release-*"
+  pull_request:
+    branches:
+      - "4.0.0-beta.0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deterministic:
+    name: Deterministic gate (no credential)
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Select simulator
+        run: |
+          # A hardcoded `name=iPhone 16` destination does not resolve on this
+          # repo's runners; scripts/getSimulator picks whatever iPhone image
+          # the image actually ships and writes the name to ./iphoneSim.
+          # Same pattern as verify.yml.
+          ./scripts/getSimulator
+          echo "IPHONE_SIM=$(cat ./iphoneSim)" >> "$GITHUB_ENV"
+
+      - name: Run L1WireValidationTest
+        run: |
+          # L1WireValidationTest deliberately does not inherit from
+          # BaseGptDriverTest, so it needs no MOBILEBOOST_API_KEY. What it
+          # proves: the TestBed builds against the beta SDK, the GPTDriver
+          # test target compiles, gptd-swift resolves, and the host app
+          # reaches runningForeground and stays there while the SDK fires
+          # /v1/install. It does NOT parse the wire payload — that is the
+          # log-scraping L1 pipeline, which does not exist on this branch
+          # and belongs to its own ticket.
+          #
+          # -only-testing rather than -testPlan: the scheme references only
+          # Release.xctestplan (default) and Smoke.xctestplan.
+          # L1Validation.xctestplan is not wired into the scheme, so
+          # `-testPlan L1Validation` would not resolve.
+          xcodebuild test \
+            -project Branch-TestBed/Branch-TestBed.xcodeproj \
+            -scheme TestBed-GPTDriverTests \
+            -destination "platform=iOS Simulator,name=$IPHONE_SIM,OS=latest" \
+            -only-testing:TestBed-GPTDriverTests/L1WireValidationTest \
+            CODE_SIGNING_ALLOWED=NO | xcpretty && exit ${PIPESTATUS[0]}
+
+  full-suite:
+    name: Full suite (MobileBoost device farm)
+    needs: deterministic
+    # Never on an ordinary push. Only a manual dispatch or a Release-* branch,
+    # both of which imply someone intends to spend device-farm time.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.ref, 'refs/heads/Release-')
+    runs-on: macos-15
+    # The suite has never been run end to end on this branch, so this bound is
+    # an estimate, not a measured ceiling. Adjust once there is a real number.
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Select simulator
+        run: |
+          ./scripts/getSimulator
+          echo "IPHONE_SIM=$(cat ./iphoneSim)" >> "$GITHUB_ENV"
+
+      - name: Configure MobileBoost credential
+        env:
+          MOBILEBOOST_API_KEY: ${{ secrets.MOBILEBOOST_API_KEY }}
+        run: |
+          # BaseGptDriverTest.resolveApiKey() reads the key from the test
+          # bundle's Info.plist, which carries $(MOBILEBOOST_API_KEY) and is
+          # substituted at build time from Config/MobileBoost.xcconfig, which
+          # `#include?`s this gitignored local file.
+          #
+          # Written via heredoc rather than passed as an xcodebuild build
+          # setting: an argv value lives in the process table for the whole
+          # build and is readable by anything that can run `ps` on the runner.
+          # A heredoc never puts the value in argv, and *.local.xcconfig is
+          # gitignored, so it cannot be committed by accident.
+          if [ -z "$MOBILEBOOST_API_KEY" ]; then
+            echo "::error::MOBILEBOOST_API_KEY is not available to this run."
+            exit 1
+          fi
+          cat > Branch-TestBed/TestBed-GPTDriverTests/Config/MobileBoost.local.xcconfig <<EOF
+          MOBILEBOOST_API_KEY = ${MOBILEBOOST_API_KEY}
+          EOF
+
+      - name: Run Release test plan
+        run: |
+          # Release.xctestplan selects the whole TestBed-GPTDriverTests target
+          # with no selectedTests filter, so it is the full suite. Smoke is a
+          # 4-test subset and L1Validation is the keyless single test the
+          # deterministic job above already covers.
+          xcodebuild test \
+            -project Branch-TestBed/Branch-TestBed.xcodeproj \
+            -scheme TestBed-GPTDriverTests \
+            -destination "platform=iOS Simulator,name=$IPHONE_SIM,OS=latest" \
+            -testPlan Release \
+            CODE_SIGNING_ALLOWED=NO | xcpretty && exit ${PIPESTATUS[0]}
+
+      - name: Remove MobileBoost credential
+        if: always()
+        run: rm -f Branch-TestBed/TestBed-GPTDriverTests/Config/MobileBoost.local.xcconfig
+
+# No result-bundle artifact is uploaded from full-suite: MOBILEBOOST_API_KEY is
+# a build setting, so it can surface in an .xcresult build log. GitHub masks
+# secrets in logs but not inside artifacts.

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ fastlane/test_output
 vendor
 .bundle
 DeepLinkDemo/DeepLinkDemo.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+
+# MobileBoost — contains API key, never commit
+mobileboost.config.json
+*.local.xcconfig

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -567,6 +567,7 @@
 			packageReferences = (
 				E7AC74792DB0700D002D8C40 /* XCLocalSwiftPackageReference "../../ios-branch-deep-linking-attribution" */,
 				E732827D2E5F7D92005CACC8 /* XCRemoteSwiftPackageReference "google-ads-on-device-conversion-ios-sdk" */,
+				D0973F95A101C4673FDC92A1 /* XCRemoteSwiftPackageReference "gptd-swift" */,
 			);
 			productRefGroup = 670016611940F51400A9E103 /* Products */;
 			projectDirPath = "";
@@ -1166,6 +1167,14 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		D0973F95A101C4673FDC92A1 /* XCRemoteSwiftPackageReference "gptd-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/MobileBoostHQ/gptd-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.9.1;
+			};
+		};
 		E732827D2E5F7D92005CACC8 /* XCRemoteSwiftPackageReference "google-ads-on-device-conversion-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk";

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0CD19A4FAAC3DC790D05398E /* gptd-swift in Frameworks */ = {isa = PBXBuildFile; productRef = 84BBC5418F3C729A5F490A07 /* gptd-swift */; };
+		143A1100894AF12F8F5E4CFB /* TestBedIdentifiers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC1798D4BBC4E0E40ADA9310 /* TestBedIdentifiers.m */; };
+		15843A0C5EBB44E872DFDF8A /* TrackingControlHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29BF08D3B7BD908C97F47144 /* TrackingControlHybridTest.swift */; };
+		1CBDF03ECD47630F858956A7 /* UserIdentityHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CB024C029C70375502663D2 /* UserIdentityHybridTest.swift */; };
+		257BD6BD304B0B87C0BDF67C /* BaseGptDriverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D8D33407DECC9492C3C644C /* BaseGptDriverTest.swift */; };
+		2FE60ACC53E3DDB95CB49E7C /* LinkCreationHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40837FC18222BFAADDC90C48 /* LinkCreationHybridTest.swift */; };
 		4683F0761B20A73F00A432E7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 670016731940F51400A9E103 /* AppDelegate.m */; };
 		46DC406E1B2A328900D2D203 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67BBCF271A69E49A009C7DAE /* AdSupport.framework */; };
 		4AB16368239E3A2700D42931 /* DispatchToIsolationQueueTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB16367239E3A2700D42931 /* DispatchToIsolationQueueTests.m */; };
@@ -22,6 +28,9 @@
 		4D1683CA2098C902008819E3 /* BNCPreferenceHelperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D1683A02098C901008819E3 /* BNCPreferenceHelperTests.m */; };
 		4DBEFFF61FB114F900F7C41B /* ArrayPickerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DBEFFF51FB114F900F7C41B /* ArrayPickerView.m */; };
 		4DE235641FB12C2700D4E5A9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4DBEFFFB1FB12A1000F7C41B /* Main.storyboard */; };
+		505878246DFBFD4C0CA6A6FA /* ShareLinkHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13A03B363788986D842EB8F /* ShareLinkHybridTest.swift */; };
+		5974B34F3B3E5074F9DDFEB6 /* BrowserExperienceHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEB8091834A415F87D777F78 /* BrowserExperienceHybridTest.swift */; };
+		59823CA134DEC90557EF7C7B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 670016631940F51400A9E103 /* Foundation.framework */; };
 		5F205D062318659500C776D1 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F205D04231864E800C776D1 /* WebKit.framework */; };
 		5F205D0823186AF700C776D1 /* BNCUserAgentCollectorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F205D022318641700C776D1 /* BNCUserAgentCollectorTests.m */; };
 		5F3D671B233062FD00454FF1 /* BNCJsonLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F3D671A233062FD00454FF1 /* BNCJsonLoader.m */; };
@@ -63,7 +72,13 @@
 		670016701940F51400A9E103 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 6700166F1940F51400A9E103 /* main.m */; };
 		6700167A1940F51400A9E103 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 670016791940F51400A9E103 /* ViewController.m */; };
 		67F270891BA9FCFF002546A7 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		805069B9222DE6DBB702BA55 /* ConsumerProtectionHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DF86E2AC9715ADCA6FC0D57 /* ConsumerProtectionHybridTest.swift */; };
+		884BEA1B0B010B65568A9135 /* PluginNotifyHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E744D97C008B4DBA0445A4F /* PluginNotifyHybridTest.swift */; };
+		8909A6D6A78237ACCB8496D6 /* EventLoggingHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D5B75E103FE48CC35B2C2D /* EventLoggingHybridTest.swift */; };
+		959C9C6A9AF35A32CE92F363 /* QRCodeHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F998EAD60325FB9FBF63FF /* QRCodeHybridTest.swift */; };
+		9BEC6ECEF0E0BF1E734B843D /* NotificationHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D4DC04AFC52EEBC6E0120A /* NotificationHybridTest.swift */; };
 		AA12345600010000000000B1 /* BranchDisableNextForegroundTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA12345600010000000000A1 /* BranchDisableNextForegroundTests.m */; };
+		B9F5DA27F77E0A392BD2E69A /* TestBedIdentifiers.m in Sources */ = {isa = PBXBuildFile; fileRef = CC1798D4BBC4E0E40ADA9310 /* TestBedIdentifiers.m */; };
 		C10A6DE629A995590061A851 /* StoreKitTestCertificate.cer in Resources */ = {isa = PBXBuildFile; fileRef = C10A6DE529A995590061A851 /* StoreKitTestCertificate.cer */; };
 		C10C61AA282481FB00761D7E /* BranchShareLinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C10C61A9282481FB00761D7E /* BranchShareLinkTests.m */; };
 		C12320B52808DB90007771C0 /* BranchQRCodeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C12320B42808DB90007771C0 /* BranchQRCodeTests.m */; };
@@ -72,6 +87,11 @@
 		C1614D56285BC8A00098946B /* LinkPresentation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1614D55285BC8A00098946B /* LinkPresentation.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		C17DAF7B2AC20C2000B16B1A /* BranchClassTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C17DAF7A2AC20C2000B16B1A /* BranchClassTests.m */; };
 		C1CC888229BAAFC000BDD2B5 /* BNCReferringURLUtilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C1CC888129BAAFC000BDD2B5 /* BNCReferringURLUtilityTests.m */; };
+		D90E8A6639F523DC3B08FBCE /* LinkCreationDeterministicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA914FAFCA750AE7C6CDCFCC /* LinkCreationDeterministicTest.swift */; };
+		DAEFBE7C9FFBD455BFBF4EC7 /* DeepLinkWarmOpenHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C6F886CF5254858874E0154 /* DeepLinkWarmOpenHybridTest.swift */; };
+		DB18DA9C84F60B550B04B3FC /* DeepLinkColdOpenHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 991B868E49743EF400DE3CA1 /* DeepLinkColdOpenHybridTest.swift */; };
+		E1A0001A0000000000000AA1 /* L1WireValidationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A0002A0000000000000AA2 /* L1WireValidationTest.swift */; };
+		E369CEFCE0B1105282B6E900 /* ReferringParamsHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 656C68E10670CEE96DC0A93D /* ReferringParamsHybridTest.swift */; };
 		E72489D228E40D0200DCD8FD /* PasteControlViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E72489D128E40D0200DCD8FD /* PasteControlViewController.m */; };
 		E732827F2E5F7D92005CACC8 /* GoogleAdsOnDeviceConversion in Frameworks */ = {isa = PBXBuildFile; productRef = E732827E2E5F7D92005CACC8 /* GoogleAdsOnDeviceConversion */; };
 		E73C5CE22FAD14DE00DF2812 /* BranchSDK in Frameworks */ = {isa = PBXBuildFile; productRef = E73C5CE12FAD14DE00DF2812 /* BranchSDK */; };
@@ -82,6 +102,9 @@
 		E7AC747B2DB0700D002D8C40 /* BranchSDK in Frameworks */ = {isa = PBXBuildFile; productRef = E7AC747A2DB0700D002D8C40 /* BranchSDK */; };
 		E7AC747E2DB0714B002D8C40 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = E7AC747D2DB07145002D8C40 /* libc++.tbd */; };
 		E7AE4A092DFB2C4400696805 /* BranchConfigurationControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E7AE4A082DFB2C4400696805 /* BranchConfigurationControllerTests.m */; };
+		EBB12FFFEE5BB34E5505BBB9 /* LinkCreationAITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C67D93BFFFC0217931CBB1 /* LinkCreationAITest.swift */; };
+		F75975E5DF4BEE735A974B7D /* SessionAndLogsHybridTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506B6E3C699AD53EFF4F5D9B /* SessionAndLogsHybridTest.swift */; };
+		FA0EDB9AC11B2D654496E492 /* TestScrollHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 704F26B57C08A695724807D8 /* TestScrollHelpers.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -93,6 +116,13 @@
 			remoteInfo = "Branch-TestBed";
 		};
 		E73282812E5F81C9005CACC8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 670016581940F51400A9E103 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6700165F1940F51400A9E103;
+			remoteInfo = "Branch-TestBed";
+		};
+		E7ABE7BF4A8A258818FBA303 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 670016581940F51400A9E103 /* Project object */;
 			proxyType = 1;
@@ -115,6 +145,16 @@
 
 /* Begin PBXFileReference section */
 		033FC71025AC1E5800D8319E /* Branch-TestBed.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "Branch-TestBed.xctestplan"; path = "Branch-TestBed.xcodeproj/Branch-TestBed.xctestplan"; sourceTree = "<group>"; };
+		07F998EAD60325FB9FBF63FF /* QRCodeHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeHybridTest.swift; sourceTree = "<group>"; };
+		0BDDF97F86FBDB68CC1DB17B /* MobileBoost.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = MobileBoost.xcconfig; sourceTree = "<group>"; };
+		18C938B7F4FDE21EE308CE9E /* Release.xctestplan */ = {isa = PBXFileReference; includeInIndex = 1; path = Release.xctestplan; sourceTree = "<group>"; };
+		1DF86E2AC9715ADCA6FC0D57 /* ConsumerProtectionHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConsumerProtectionHybridTest.swift; sourceTree = "<group>"; };
+		23D5B75E103FE48CC35B2C2D /* EventLoggingHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EventLoggingHybridTest.swift; sourceTree = "<group>"; };
+		25411D6F29809D769F33D4BE /* MobileBoost.local.xcconfig.example */ = {isa = PBXFileReference; includeInIndex = 1; path = MobileBoost.local.xcconfig.example; sourceTree = "<group>"; };
+		29BF08D3B7BD908C97F47144 /* TrackingControlHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TrackingControlHybridTest.swift; sourceTree = "<group>"; };
+		2C6F886CF5254858874E0154 /* DeepLinkWarmOpenHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeepLinkWarmOpenHybridTest.swift; sourceTree = "<group>"; };
+		40837FC18222BFAADDC90C48 /* LinkCreationHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LinkCreationHybridTest.swift; sourceTree = "<group>"; };
+		49114296F0B11A2DEB7FFECD /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4AB16367239E3A2700D42931 /* DispatchToIsolationQueueTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DispatchToIsolationQueueTests.m; sourceTree = "<group>"; };
 		4D1683812098C901008819E3 /* Branch-SDK-Tests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Branch-SDK-Tests-Bridging-Header.h"; sourceTree = "<group>"; };
 		4D1683842098C901008819E3 /* BNCLinkDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BNCLinkDataTests.m; sourceTree = "<group>"; };
@@ -137,6 +177,9 @@
 		4DD056112177A65C009BD3DD /* libOCMock.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libOCMock.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4DD056132177A65C009BD3DD /* libOHHTTPStubs.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libOHHTTPStubs.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		4DDC52611DCC08E700CFB737 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
+		4DF18A2F7FEBD06E1EBB8FD5 /* TestBedIdentifiers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TestBedIdentifiers.h; sourceTree = "<group>"; };
+		506B6E3C699AD53EFF4F5D9B /* SessionAndLogsHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionAndLogsHybridTest.swift; sourceTree = "<group>"; };
+		5D8D33407DECC9492C3C644C /* BaseGptDriverTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BaseGptDriverTest.swift; sourceTree = "<group>"; };
 		5F2035CB240DDE90004FDC3E /* BNCDisableAdNetworkCalloutsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCDisableAdNetworkCalloutsTests.m; sourceTree = "<group>"; };
 		5F205D022318641700C776D1 /* BNCUserAgentCollectorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCUserAgentCollectorTests.m; sourceTree = "<group>"; };
 		5F205D04231864E800C776D1 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
@@ -179,6 +222,7 @@
 		63E4C48A1D25E17B00A45FD8 /* NavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NavigationController.m; sourceTree = "<group>"; };
 		63E4C48F1D25E1BC00A45FD8 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		63E4C4911D25E1CA00A45FD8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		656C68E10670CEE96DC0A93D /* ReferringParamsHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferringParamsHybridTest.swift; sourceTree = "<group>"; };
 		6589EBA52674270100F2E28B /* Branch-TestBed-CI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Branch-TestBed-CI.xctestplan"; sourceTree = "<group>"; };
 		670016601940F51400A9E103 /* Branch-TestBed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Branch-TestBed.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		670016631940F51400A9E103 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -196,8 +240,16 @@
 		677F4CB41C1FB0FA0029F2B3 /* Branch-TestBed.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "Branch-TestBed.entitlements"; sourceTree = "<group>"; };
 		67BBCF271A69E49A009C7DAE /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
 		67F270881BA9FCFF002546A7 /* CoreSpotlight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSpotlight.framework; path = System/Library/Frameworks/CoreSpotlight.framework; sourceTree = SDKROOT; };
+		68C67D93BFFFC0217931CBB1 /* LinkCreationAITest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LinkCreationAITest.swift; sourceTree = "<group>"; };
+		6E744D97C008B4DBA0445A4F /* PluginNotifyHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PluginNotifyHybridTest.swift; sourceTree = "<group>"; };
+		704F26B57C08A695724807D8 /* TestScrollHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TestScrollHelpers.swift; sourceTree = "<group>"; };
 		7E6B3B511AA42D0E005F45BF /* Branch-SDK-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Branch-SDK-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		991B868E49743EF400DE3CA1 /* DeepLinkColdOpenHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DeepLinkColdOpenHybridTest.swift; sourceTree = "<group>"; };
+		9CB024C029C70375502663D2 /* UserIdentityHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserIdentityHybridTest.swift; sourceTree = "<group>"; };
+		A13A03B363788986D842EB8F /* ShareLinkHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareLinkHybridTest.swift; sourceTree = "<group>"; };
 		AA12345600010000000000A1 /* BranchDisableNextForegroundTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BranchDisableNextForegroundTests.m; sourceTree = "<group>"; };
+		ACF0972B844F3483686EF054 /* TestBed-GPTDriverTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TestBed-GPTDriverTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BEB8091834A415F87D777F78 /* BrowserExperienceHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BrowserExperienceHybridTest.swift; sourceTree = "<group>"; };
 		C10A6DE029A97E440061A851 /* TestStoreKitConfig.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestStoreKitConfig.storekit; sourceTree = "<group>"; };
 		C10A6DE529A995590061A851 /* StoreKitTestCertificate.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = StoreKitTestCertificate.cer; sourceTree = "<group>"; };
 		C10C61A9282481FB00761D7E /* BranchShareLinkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BranchShareLinkTests.m; sourceTree = "<group>"; };
@@ -208,6 +260,11 @@
 		C1614D55285BC8A00098946B /* LinkPresentation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LinkPresentation.framework; path = System/Library/Frameworks/LinkPresentation.framework; sourceTree = SDKROOT; };
 		C17DAF7A2AC20C2000B16B1A /* BranchClassTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BranchClassTests.m; sourceTree = "<group>"; };
 		C1CC888129BAAFC000BDD2B5 /* BNCReferringURLUtilityTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCReferringURLUtilityTests.m; sourceTree = "<group>"; };
+		CC1798D4BBC4E0E40ADA9310 /* TestBedIdentifiers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TestBedIdentifiers.m; sourceTree = "<group>"; };
+		DA914FAFCA750AE7C6CDCFCC /* LinkCreationDeterministicTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LinkCreationDeterministicTest.swift; sourceTree = "<group>"; };
+		E1A0002A0000000000000AA2 /* L1WireValidationTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = L1WireValidationTest.swift; sourceTree = "<group>"; };
+		E4D4DC04AFC52EEBC6E0120A /* NotificationHybridTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotificationHybridTest.swift; sourceTree = "<group>"; };
+		E50AA43771267258B0293FD1 /* TestBed-GPTDriverTests-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "TestBed-GPTDriverTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		E72489D028E40D0200DCD8FD /* PasteControlViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PasteControlViewController.h; sourceTree = "<group>"; };
 		E72489D128E40D0200DCD8FD /* PasteControlViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PasteControlViewController.m; sourceTree = "<group>"; };
 		E7A728BC2AA9A112009343B7 /* BNCAPIServerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BNCAPIServerTest.m; sourceTree = "<group>"; };
@@ -216,6 +273,7 @@
 		E7AC74762DB06B42002D8C40 /* Reflection_ODM_Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Reflection_ODM_Tests.xctestplan; sourceTree = "<group>"; };
 		E7AC747D2DB07145002D8C40 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/usr/lib/libc++.tbd"; sourceTree = DEVELOPER_DIR; };
 		E7AE4A082DFB2C4400696805 /* BranchConfigurationControllerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BranchConfigurationControllerTests.m; sourceTree = "<group>"; };
+		FC260E701BE220B2E128811D /* Smoke.xctestplan */ = {isa = PBXFileReference; includeInIndex = 1; path = Smoke.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -223,6 +281,15 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1C5D3599943B2AF1082E434F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				59823CA134DEC90557EF7C7B /* Foundation.framework in Frameworks */,
+				0CD19A4FAAC3DC790D05398E /* gptd-swift in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5F8B7B3821B5F5CD009CE0A6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -268,6 +335,28 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		102DBF53CD061619BAF31076 /* Hybrid */ = {
+			isa = PBXGroup;
+			children = (
+				40837FC18222BFAADDC90C48 /* LinkCreationHybridTest.swift */,
+				07F998EAD60325FB9FBF63FF /* QRCodeHybridTest.swift */,
+				A13A03B363788986D842EB8F /* ShareLinkHybridTest.swift */,
+				506B6E3C699AD53EFF4F5D9B /* SessionAndLogsHybridTest.swift */,
+				9CB024C029C70375502663D2 /* UserIdentityHybridTest.swift */,
+				23D5B75E103FE48CC35B2C2D /* EventLoggingHybridTest.swift */,
+				991B868E49743EF400DE3CA1 /* DeepLinkColdOpenHybridTest.swift */,
+				2C6F886CF5254858874E0154 /* DeepLinkWarmOpenHybridTest.swift */,
+				BEB8091834A415F87D777F78 /* BrowserExperienceHybridTest.swift */,
+				E4D4DC04AFC52EEBC6E0120A /* NotificationHybridTest.swift */,
+				29BF08D3B7BD908C97F47144 /* TrackingControlHybridTest.swift */,
+				1DF86E2AC9715ADCA6FC0D57 /* ConsumerProtectionHybridTest.swift */,
+				656C68E10670CEE96DC0A93D /* ReferringParamsHybridTest.swift */,
+				6E744D97C008B4DBA0445A4F /* PluginNotifyHybridTest.swift */,
+			);
+			name = Hybrid;
+			path = Hybrid;
+			sourceTree = "<group>";
+		};
 		4D16837A2098C901008819E3 /* Branch-SDK-Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -343,6 +432,23 @@
 			path = cannedData;
 			sourceTree = "<group>";
 		};
+		6582C60A6E8FB0C91C7EBE0C /* TestBed-GPTDriverTests */ = {
+			isa = PBXGroup;
+			children = (
+				FE42883A925072362E7A094D /* Config */,
+				5D8D33407DECC9492C3C644C /* BaseGptDriverTest.swift */,
+				E50AA43771267258B0293FD1 /* TestBed-GPTDriverTests-Bridging-Header.h */,
+				49114296F0B11A2DEB7FFECD /* Info.plist */,
+				BE4A694F8CCA8A9DE816FD35 /* Deterministic */,
+				102DBF53CD061619BAF31076 /* Hybrid */,
+				C0F749B294D5D406792F9E71 /* AI */,
+				704F26B57C08A695724807D8 /* TestScrollHelpers.swift */,
+				6BFEC102B288139D98CB7918 /* TestPlans */,
+			);
+			name = "TestBed-GPTDriverTests";
+			path = "TestBed-GPTDriverTests";
+			sourceTree = "<group>";
+		};
 		670016571940F51400A9E103 = {
 			isa = PBXGroup;
 			children = (
@@ -357,6 +463,7 @@
 				E7AC74612DB064BC002D8C40 /* Reflection_ODM_Tests */,
 				670016621940F51400A9E103 /* Frameworks */,
 				670016611940F51400A9E103 /* Products */,
+				6582C60A6E8FB0C91C7EBE0C /* TestBed-GPTDriverTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -367,6 +474,7 @@
 				7E6B3B511AA42D0E005F45BF /* Branch-SDK-Tests.xctest */,
 				5F8B7B3B21B5F5CD009CE0A6 /* Branch-SDK-Unhosted-Tests.xctest */,
 				E7AC74602DB064BC002D8C40 /* Reflection_ODM_Tests.xctest */,
+				ACF0972B844F3483686EF054 /* TestBed-GPTDriverTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -418,6 +526,8 @@
 				C10A6DE029A97E440061A851 /* TestStoreKitConfig.storekit */,
 				670016781940F51400A9E103 /* ViewController.h */,
 				670016791940F51400A9E103 /* ViewController.m */,
+				4DF18A2F7FEBD06E1EBB8FD5 /* TestBedIdentifiers.h */,
+				CC1798D4BBC4E0E40ADA9310 /* TestBedIdentifiers.m */,
 			);
 			path = "Branch-TestBed";
 			sourceTree = "<group>";
@@ -431,6 +541,45 @@
 				670016711940F51400A9E103 /* Branch-TestBed-Prefix.pch */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		6BFEC102B288139D98CB7918 /* TestPlans */ = {
+			isa = PBXGroup;
+			children = (
+				FC260E701BE220B2E128811D /* Smoke.xctestplan */,
+				18C938B7F4FDE21EE308CE9E /* Release.xctestplan */,
+			);
+			name = TestPlans;
+			path = TestPlans;
+			sourceTree = "<group>";
+		};
+		BE4A694F8CCA8A9DE816FD35 /* Deterministic */ = {
+			isa = PBXGroup;
+			children = (
+				DA914FAFCA750AE7C6CDCFCC /* LinkCreationDeterministicTest.swift */,
+				E1A0002A0000000000000AA2 /* L1WireValidationTest.swift */,
+			);
+			name = Deterministic;
+			path = Deterministic;
+			sourceTree = "<group>";
+		};
+		C0F749B294D5D406792F9E71 /* AI */ = {
+			isa = PBXGroup;
+			children = (
+				68C67D93BFFFC0217931CBB1 /* LinkCreationAITest.swift */,
+			);
+			name = AI;
+			path = AI;
+			sourceTree = "<group>";
+		};
+		FE42883A925072362E7A094D /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				0BDDF97F86FBDB68CC1DB17B /* MobileBoost.xcconfig */,
+				25411D6F29809D769F33D4BE /* MobileBoost.local.xcconfig.example */,
+			);
+			name = Config;
+			path = Config;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -489,6 +638,27 @@
 			productName = "Branch-SDK Functionality Tests";
 			productReference = 7E6B3B511AA42D0E005F45BF /* Branch-SDK-Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		AAC5A9A76F3DBB04E6638F31 /* TestBed-GPTDriverTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7C4C785331DF108512EC93F2 /* Build configuration list for PBXNativeTarget "TestBed-GPTDriverTests" */;
+			buildPhases = (
+				830B3D68A4D135BCDED3AF12 /* Sources */,
+				1C5D3599943B2AF1082E434F /* Frameworks */,
+				A1B69B214CA8E570289FE6E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				98FBE51F1B1C9827C2CF0EA6 /* PBXTargetDependency */,
+			);
+			name = "TestBed-GPTDriverTests";
+			packageProductDependencies = (
+				84BBC5418F3C729A5F490A07 /* gptd-swift */,
+			);
+			productName = "TestBed-GPTDriverTests";
+			productReference = ACF0972B844F3483686EF054 /* TestBed-GPTDriverTests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		E7AC745F2DB064BC002D8C40 /* Reflection_ODM_Tests */ = {
 			isa = PBXNativeTarget;
@@ -549,6 +719,11 @@
 						LastSwiftMigration = 1030;
 						TestTargetID = 6700165F1940F51400A9E103;
 					};
+					AAC5A9A76F3DBB04E6638F31 = {
+						CreatedOnToolsVersion = 16.2;
+						ProvisioningStyle = Automatic;
+						TestTargetID = 6700165F1940F51400A9E103;
+					};
 					E7AC745F2DB064BC002D8C40 = {
 						CreatedOnToolsVersion = 16.2;
 						TestTargetID = 6700165F1940F51400A9E103;
@@ -577,6 +752,7 @@
 				7E6B3B501AA42D0E005F45BF /* Branch-SDK-Tests */,
 				5F8B7B3A21B5F5CD009CE0A6 /* Branch-SDK-Unhosted-Tests */,
 				E7AC745F2DB064BC002D8C40 /* Reflection_ODM_Tests */,
+				AAC5A9A76F3DBB04E6638F31 /* TestBed-GPTDriverTests */,
 			);
 		};
 /* End PBXProject section */
@@ -610,6 +786,13 @@
 				5FC4CF9024860C440001E701 /* example.json in Resources */,
 				5FC4CF9224860C440001E701 /* latd_missing_data.json in Resources */,
 				5FC4CF8D24860C440001E701 /* latd_missing_window.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1B69B214CA8E570289FE6E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -664,6 +847,7 @@
 				4683F0761B20A73F00A432E7 /* AppDelegate.m in Sources */,
 				670016701940F51400A9E103 /* main.m in Sources */,
 				63E4C48B1D25E17B00A45FD8 /* NavigationController.m in Sources */,
+				B9F5DA27F77E0A392BD2E69A /* TestBedIdentifiers.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -715,6 +899,33 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		830B3D68A4D135BCDED3AF12 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				257BD6BD304B0B87C0BDF67C /* BaseGptDriverTest.swift in Sources */,
+				D90E8A6639F523DC3B08FBCE /* LinkCreationDeterministicTest.swift in Sources */,
+				E1A0001A0000000000000AA1 /* L1WireValidationTest.swift in Sources */,
+				2FE60ACC53E3DDB95CB49E7C /* LinkCreationHybridTest.swift in Sources */,
+				EBB12FFFEE5BB34E5505BBB9 /* LinkCreationAITest.swift in Sources */,
+				143A1100894AF12F8F5E4CFB /* TestBedIdentifiers.m in Sources */,
+				FA0EDB9AC11B2D654496E492 /* TestScrollHelpers.swift in Sources */,
+				959C9C6A9AF35A32CE92F363 /* QRCodeHybridTest.swift in Sources */,
+				505878246DFBFD4C0CA6A6FA /* ShareLinkHybridTest.swift in Sources */,
+				F75975E5DF4BEE735A974B7D /* SessionAndLogsHybridTest.swift in Sources */,
+				1CBDF03ECD47630F858956A7 /* UserIdentityHybridTest.swift in Sources */,
+				8909A6D6A78237ACCB8496D6 /* EventLoggingHybridTest.swift in Sources */,
+				DB18DA9C84F60B550B04B3FC /* DeepLinkColdOpenHybridTest.swift in Sources */,
+				DAEFBE7C9FFBD455BFBF4EC7 /* DeepLinkWarmOpenHybridTest.swift in Sources */,
+				5974B34F3B3E5074F9DDFEB6 /* BrowserExperienceHybridTest.swift in Sources */,
+				9BEC6ECEF0E0BF1E734B843D /* NotificationHybridTest.swift in Sources */,
+				15843A0C5EBB44E872DFDF8A /* TrackingControlHybridTest.swift in Sources */,
+				805069B9222DE6DBB702BA55 /* ConsumerProtectionHybridTest.swift in Sources */,
+				E369CEFCE0B1105282B6E900 /* ReferringParamsHybridTest.swift in Sources */,
+				884BEA1B0B010B65568A9135 /* PluginNotifyHybridTest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E7AC745C2DB064BC002D8C40 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -729,6 +940,12 @@
 			isa = PBXTargetDependency;
 			target = 6700165F1940F51400A9E103 /* Branch-TestBed */;
 			targetProxy = 4D337DDC201019B8009A5774 /* PBXContainerItemProxy */;
+		};
+		98FBE51F1B1C9827C2CF0EA6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Branch-TestBed";
+			target = 6700165F1940F51400A9E103 /* Branch-TestBed */;
+			targetProxy = E7ABE7BF4A8A258818FBA303 /* PBXContainerItemProxy */;
 		};
 		E73282822E5F81C9005CACC8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -749,6 +966,41 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		3486B3718FE8B6C8A863A09C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0BDDF97F86FBDB68CC1DB17B /* MobileBoost.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Branch-TestBed",
+				);
+				INFOPLIST_FILE = "TestBed-GPTDriverTests/Info.plist";
+				INFOPLIST_KEY_UIRequiredDeviceCapabilities = "$(inherited)";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.TestBed-GPTDriverTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "TestBed-GPTDriverTests/TestBed-GPTDriverTests-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Branch-TestBed";
+			};
+			name = Debug;
+		};
 		5F8B7B4321B5F5CD009CE0A6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1040,6 +1292,42 @@
 			};
 			name = Release;
 		};
+		AA4A3EF83BDE3C4D3218FF4D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0BDDF97F86FBDB68CC1DB17B /* MobileBoost.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				GENERATE_INFOPLIST_FILE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Branch-TestBed",
+				);
+				INFOPLIST_FILE = "TestBed-GPTDriverTests/Info.plist";
+				INFOPLIST_KEY_UIRequiredDeviceCapabilities = "$(inherited)";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.TestBed-GPTDriverTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "TestBed-GPTDriverTests/TestBed-GPTDriverTests-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "Branch-TestBed";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		E7AC74682DB064BC002D8C40 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1139,6 +1427,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		7C4C785331DF108512EC93F2 /* Build configuration list for PBXNativeTarget "TestBed-GPTDriverTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA4A3EF83BDE3C4D3218FF4D /* Release */,
+				3486B3718FE8B6C8A863A09C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7E6B3B571AA42D0E005F45BF /* Build configuration list for PBXNativeTarget "Branch-SDK-Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1186,6 +1483,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		84BBC5418F3C729A5F490A07 /* gptd-swift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D0973F95A101C4673FDC92A1 /* XCRemoteSwiftPackageReference "gptd-swift" */;
+			productName = "gptd-swift";
+		};
 		E732827E2E5F7D92005CACC8 /* GoogleAdsOnDeviceConversion */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E732827D2E5F7D92005CACC8 /* XCRemoteSwiftPackageReference "google-ads-on-device-conversion-ios-sdk" */;

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "54257fe6089b4f9814bfc9936c2dbcf5197182bd69ef92f6964812c74aa51ab2",
+  "originHash" : "1104f595f08c757bac880de81a1ba4e9a1f9034ff07d428795a9176ef168355b",
   "pins" : [
     {
       "identity" : "google-ads-on-device-conversion-ios-sdk",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
         "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "gptd-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MobileBoostHQ/gptd-swift",
+      "state" : {
+        "revision" : "276ca367fbdfb3773b89ba0d623104f2cb20a903",
+        "version" : "1.9.1"
       }
     },
     {

--- a/Branch-TestBed/Branch-TestBed.xcodeproj/xcshareddata/xcschemes/TestBed-GPTDriverTests.xcscheme
+++ b/Branch-TestBed/Branch-TestBed.xcodeproj/xcshareddata/xcschemes/TestBed-GPTDriverTests.xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6700165F1940F51400A9E103"
+               BuildableName = "Branch-TestBed.app"
+               BlueprintName = "Branch-TestBed"
+               ReferencedContainer = "container:Branch-TestBed.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AAC5A9A76F3DBB04E6638F31"
+               BuildableName = "TestBed-GPTDriverTests.xctest"
+               BlueprintName = "TestBed-GPTDriverTests"
+               ReferencedContainer = "container:Branch-TestBed.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:TestBed-GPTDriverTests/TestPlans/Release.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestBed-GPTDriverTests/TestPlans/Smoke.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6700165F1940F51400A9E103"
+            BuildableName = "Branch-TestBed.app"
+            BlueprintName = "Branch-TestBed"
+            ReferencedContainer = "container:Branch-TestBed.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6700165F1940F51400A9E103"
+            BuildableName = "Branch-TestBed.app"
+            BlueprintName = "Branch-TestBed"
+            ReferencedContainer = "container:Branch-TestBed.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6700165F1940F51400A9E103"
+            BuildableName = "Branch-TestBed.app"
+            BlueprintName = "Branch-TestBed"
+            ReferencedContainer = "container:Branch-TestBed.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Branch-TestBed/Branch-TestBed/AppDelegate.m
+++ b/Branch-TestBed/Branch-TestBed/AppDelegate.m
@@ -11,6 +11,10 @@
 #import "NavigationController.h"
 #import "ViewController.h"
 @import BranchSDK;
+#import <UserNotifications/UserNotifications.h>
+
+@interface AppDelegate() <UNUserNotificationCenterDelegate>
+@end
 
 AppDelegate* appDelegate = nil;
 void APPLogHookFunction(NSDate*_Nonnull timestamp, BranchLogLevel level, NSString*_Nullable message);
@@ -23,6 +27,7 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [self setBranchLogFile];
 
     appDelegate = self;
+    [UNUserNotificationCenter currentNotificationCenter].delegate = self;
 
     Branch *branch = [Branch getInstance];
 
@@ -257,6 +262,21 @@ void APPLogHookFunction(NSDate*_Nonnull timestamp, BranchLogLevel level, NSStrin
         self.PrevCommandLogFileName = self.logFileName;
         self.logFileName = pathForLog;
     }
+}
+
+#pragma mark - UNUserNotificationCenterDelegate
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler {
+    completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionSound);
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+didReceiveNotificationResponse:(UNNotificationResponse *)response
+         withCompletionHandler:(void (^)(void))completionHandler {
+    [[Branch getInstance] handlePushNotification:response.notification.request.content.userInfo];
+    completionHandler();
 }
 
 @end

--- a/Branch-TestBed/Branch-TestBed/Main.storyboard
+++ b/Branch-TestBed/Branch-TestBed/Main.storyboard
@@ -812,7 +812,6 @@
                                                     </state>
                                                     <connections>
                                                         <action selector="changeConsumerProtectionAttributionLevel:" destination="i3m-ex-Bu1" eventType="touchUpInside" id="1O2-0G-ODA"/>
-                                                        <action selector="goToPasteControlPressed:" destination="i3m-ex-Bu1" eventType="touchUpInside" id="cBJ-Fu-bvO"/>
                                                     </connections>
                                                 </button>
                                             </subviews>

--- a/Branch-TestBed/Branch-TestBed/Main.storyboard
+++ b/Branch-TestBed/Branch-TestBed/Main.storyboard
@@ -53,6 +53,7 @@
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g5q-Nq-dCK">
                                 <rect key="frame" x="16" y="334" width="343" height="50"/>
+                                <accessibility key="accessibilityConfiguration" identifier="btn_show_logs"/>
                                 <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="THd-Hg-6zt"/>
@@ -189,6 +190,7 @@
                                             <subviews>
                                                 <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" placeholder="Your Branch Link" minimumFontSize="10" clearButtonMode="always" translatesAutoresizingMaskIntoConstraints="NO" id="SOP-3u-nhT" userLabel="branchLinkTextField">
                                                     <rect key="frame" x="16" y="11" width="311" height="22"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="txt_branch_link"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="280" id="QJ6-EZ-1I1"/>
                                                     </constraints>
@@ -215,6 +217,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3jJ-y4-FGc" userLabel="createBranchLinkButton">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_create_branch_link"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Create Branch Link" image="link" catalog="system">
@@ -242,6 +245,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eLX-a4-zOU">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_share_link"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Share Link" image="square.and.arrow.up" catalog="system">
@@ -269,7 +273,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jIx-yz-UFS">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
-                                                    <accessibility key="accessibilityConfiguration" identifier="tracking"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_share_link_with_metadata"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Share Link with LPLinkMetadata" image="square.and.arrow.up.on.square" catalog="system">
@@ -297,6 +301,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iq4-GJ-TsK">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_open_branch_link"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Open Branch Link" image="arrow.up.right.square" catalog="system">
@@ -324,7 +329,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mUN-NU-xns">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
-                                                    <accessibility key="accessibilityConfiguration" identifier="tracking"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_create_qr_code"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="27" id="Ger-Li-JdZ"/>
                                                         <constraint firstAttribute="width" constant="190" id="Kcd-Il-mHi"/>
@@ -361,6 +366,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bek-2J-IjD">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_view_first_referring_params"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="190" id="Th6-ew-uaE"/>
                                                     </constraints>
@@ -393,6 +399,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NJe-OT-1Eg">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_view_latest_referring_params"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="190" id="cAM-OI-xnD"/>
                                                     </constraints>
@@ -425,6 +432,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4fu-zA-ceg" userLabel="Set Partner Params">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_toggle_partner_params"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Set Partner Params" image="folder.badge.plus" catalog="system">
@@ -452,6 +460,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gZa-hA-OtK">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_simulate_content_access"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Simulate Content Access" image="doc.viewfinder.fill" catalog="system">
@@ -479,6 +488,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2PF-pu-99P">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_set_user_id"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Set User ID" image="person" catalog="system">
@@ -510,6 +520,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nVo-m7-w7f">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_send_commerce_event"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Send Commerce Event" image="bag" catalog="system">
@@ -537,6 +548,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L2t-YG-cpE">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_send_content_event"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Send Content Event" image="photo.artframe" catalog="system">
@@ -564,6 +576,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JRt-Kp-qAQ">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_send_lifecycle_event"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Send Lifecycle Event" image="trophy" catalog="system">
@@ -591,6 +604,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="467-af-xm1">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_in_app_purchase_event"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="In-App Purchase Event" image="trophy" catalog="system">
@@ -618,6 +632,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PnJ-Tp-Oq2">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_in_app_subscription_event"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="In-App Subscription Event" image="trophy" catalog="system">
@@ -649,6 +664,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JXr-9x-vX0">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_register_with_spotlight"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Register with Spotlight" image="light.beacon.max" catalog="system">
@@ -676,6 +692,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jWK-QY-Hr2">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_simulate_content_access_alt"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Simulate Content Access" image="doc.viewfinder.fill" catalog="system">
@@ -703,6 +720,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="t8S-Z0-hG9">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_load_logs"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Load Branch Logs" image="doc.text" catalog="system">
@@ -730,6 +748,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cLu-WM-Ib5">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_logout"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Simulate Logout" image="rectangle.portrait.and.arrow.right" catalog="system">
@@ -757,7 +776,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UTG-yQ-PWO">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
-                                                    <accessibility key="accessibilityConfiguration" identifier="tracking"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_go_to_paste_control"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Go To Paste Control View" image="rectangle.and.paperclip" catalog="system">
@@ -785,7 +804,7 @@
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B08-Xj-VD3">
                                                     <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
-                                                    <accessibility key="accessibilityConfiguration" identifier="tracking"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_consumer_protection_level"/>
                                                     <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Consumer Protection Preference" image="checkmark.shield" catalog="system">
@@ -805,8 +824,36 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="QxR-ER-AVt">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="u4f-10-QLt">
                                         <rect key="frame" x="16" y="1174" width="343" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="u4f-10-QLt" id="jmn-fV-qvx">
+                                            <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Rz-jF-ETn">
+                                                    <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="btn_disable_tracking"/>
+                                                    <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                    <inset key="imageEdgeInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                    <state key="normal" title="Disable Tracking" image="eye" catalog="system">
+                                                        <color key="titleColor" systemColor="linkColor"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="disableTracking:" destination="i3m-ex-Bu1" eventType="touchUpInside" id="aRv-6b-mHD"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="7Rz-jF-ETn" secondAttribute="bottom" id="89b-k6-oFc"/>
+                                                <constraint firstItem="7Rz-jF-ETn" firstAttribute="leading" secondItem="jmn-fV-qvx" secondAttribute="leading" id="goN-NY-qmK"/>
+                                                <constraint firstItem="7Rz-jF-ETn" firstAttribute="top" secondItem="jmn-fV-qvx" secondAttribute="top" id="LND-nh-JHa"/>
+                                                <constraint firstAttribute="trailing" secondItem="7Rz-jF-ETn" secondAttribute="trailing" id="pyH-P6-K8K"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="QxR-ER-AVt">
+                                        <rect key="frame" x="16" y="1218" width="343" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="QxR-ER-AVt" id="TeU-im-aLH">
                                             <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
@@ -843,6 +890,7 @@
                     <navigationItem key="navigationItem" title="Branch TestBed" largeTitleDisplayMode="always" id="eWU-bT-5CF" userLabel="Branch-TestBed"/>
                     <connections>
                         <outlet property="branchLinkTextField" destination="SOP-3u-nhT" id="H0r-W5-wGG"/>
+                        <outlet property="disableTrackingButton" destination="7Rz-jF-ETn" id="WNq-l3-xiU"/>
                         <outlet property="setParnerParamsButton" destination="4fu-zA-ceg" id="oWP-E3-0uu"/>
                         <segue destination="fQe-6g-cKp" kind="push" identifier="ShowLogOutput" id="0UI-6t-JlA"/>
                         <segue destination="nU2-HM-nNx" kind="push" identifier="GoToPasteControlView" id="a1o-Ia-5wh"/>

--- a/Branch-TestBed/Branch-TestBed/TestBedIdentifiers.h
+++ b/Branch-TestBed/Branch-TestBed/TestBedIdentifiers.h
@@ -1,0 +1,49 @@
+//
+//  TestBedIdentifiers.h
+//  Branch-TestBed
+//
+//  Single source of truth for accessibilityIdentifier values used across
+//  the TestBed UI. Referenced from Main.storyboard and from the
+//  TestBed-GPTDriverTests hybrid test target.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - Buttons (Main ViewController)
+
+extern NSString * const kTestBedBtnCreateBranchLink;
+extern NSString * const kTestBedBtnShareLink;
+extern NSString * const kTestBedBtnShareLinkWithMetadata;
+extern NSString * const kTestBedBtnOpenBranchLink;
+extern NSString * const kTestBedBtnCreateQRCode;
+extern NSString * const kTestBedBtnViewFirstReferringParams;
+extern NSString * const kTestBedBtnViewLatestReferringParams;
+extern NSString * const kTestBedBtnTogglePartnerParams;
+extern NSString * const kTestBedBtnSimulateContentAccess;
+extern NSString * const kTestBedBtnSimulateContentAccessAlt;
+extern NSString * const kTestBedBtnSetUserId;
+extern NSString * const kTestBedBtnSendCommerceEvent;
+extern NSString * const kTestBedBtnSendContentEvent;
+extern NSString * const kTestBedBtnSendLifecycleEvent;
+extern NSString * const kTestBedBtnInAppPurchaseEvent;
+extern NSString * const kTestBedBtnInAppSubscriptionEvent;
+extern NSString * const kTestBedBtnRegisterWithSpotlight;
+extern NSString * const kTestBedBtnLoadLogs;
+extern NSString * const kTestBedBtnDisableTracking;
+extern NSString * const kTestBedBtnLogout;
+extern NSString * const kTestBedBtnGoToPasteControl;
+extern NSString * const kTestBedBtnConsumerProtectionLevel;
+extern NSString * const kTestBedBtnNotificationSend;
+extern NSString * const kTestBedBtnPluginNotifyInit;
+
+#pragma mark - Buttons (Paste Control scene)
+
+extern NSString * const kTestBedBtnShowLogs;
+
+#pragma mark - Text Fields
+
+extern NSString * const kTestBedTxtBranchLink;
+
+NS_ASSUME_NONNULL_END

--- a/Branch-TestBed/Branch-TestBed/TestBedIdentifiers.m
+++ b/Branch-TestBed/Branch-TestBed/TestBedIdentifiers.m
@@ -1,0 +1,41 @@
+//
+//  TestBedIdentifiers.m
+//  Branch-TestBed
+//
+
+#import "TestBedIdentifiers.h"
+
+#pragma mark - Buttons (Main ViewController)
+
+NSString * const kTestBedBtnCreateBranchLink          = @"btn_create_branch_link";
+NSString * const kTestBedBtnShareLink                 = @"btn_share_link";
+NSString * const kTestBedBtnShareLinkWithMetadata     = @"btn_share_link_with_metadata";
+NSString * const kTestBedBtnOpenBranchLink            = @"btn_open_branch_link";
+NSString * const kTestBedBtnCreateQRCode              = @"btn_create_qr_code";
+NSString * const kTestBedBtnViewFirstReferringParams  = @"btn_view_first_referring_params";
+NSString * const kTestBedBtnViewLatestReferringParams = @"btn_view_latest_referring_params";
+NSString * const kTestBedBtnTogglePartnerParams       = @"btn_toggle_partner_params";
+NSString * const kTestBedBtnSimulateContentAccess     = @"btn_simulate_content_access";
+NSString * const kTestBedBtnSimulateContentAccessAlt  = @"btn_simulate_content_access_alt";
+NSString * const kTestBedBtnSetUserId                 = @"btn_set_user_id";
+NSString * const kTestBedBtnSendCommerceEvent         = @"btn_send_commerce_event";
+NSString * const kTestBedBtnSendContentEvent          = @"btn_send_content_event";
+NSString * const kTestBedBtnSendLifecycleEvent        = @"btn_send_lifecycle_event";
+NSString * const kTestBedBtnInAppPurchaseEvent        = @"btn_in_app_purchase_event";
+NSString * const kTestBedBtnInAppSubscriptionEvent    = @"btn_in_app_subscription_event";
+NSString * const kTestBedBtnRegisterWithSpotlight     = @"btn_register_with_spotlight";
+NSString * const kTestBedBtnLoadLogs                  = @"btn_load_logs";
+NSString * const kTestBedBtnDisableTracking           = @"btn_disable_tracking";
+NSString * const kTestBedBtnLogout                    = @"btn_logout";
+NSString * const kTestBedBtnGoToPasteControl          = @"btn_go_to_paste_control";
+NSString * const kTestBedBtnConsumerProtectionLevel   = @"btn_consumer_protection_level";
+NSString * const kTestBedBtnNotificationSend          = @"btn_notification_send";
+NSString * const kTestBedBtnPluginNotifyInit          = @"btn_plugin_notify_init";
+
+#pragma mark - Buttons (Paste Control scene)
+
+NSString * const kTestBedBtnShowLogs                  = @"btn_show_logs";
+
+#pragma mark - Text Fields
+
+NSString * const kTestBedTxtBranchLink                = @"txt_branch_link";

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -121,6 +121,18 @@ bool hasSetPartnerParams = false;
         [appDelegate setLogFile:nil];
     };
     
+    if ([Branch attributionLevelNone]) {
+        [self.disableTrackingButton setTitle:@"Enable Tracking" forState:UIControlStateNormal];
+        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
+            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.fill"] forState:UIControlStateNormal];
+        }
+    } else {
+        [self.disableTrackingButton setTitle:@"Disable Tracking" forState:UIControlStateNormal];
+        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
+            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.slash.fill"] forState:UIControlStateNormal];
+        }
+    }
+
     if (hasSetPartnerParams) {
         [self.setParnerParamsButton setTitle:@"Clear Partner Params" forState:UIControlStateNormal];
         if (@available(iOS 13.0, macCatalyst 13.1, *)) {
@@ -172,6 +184,29 @@ bool hasSetPartnerParams = false;
     [actionSheet addAction:cancelAction];
     
     [self presentViewController:actionSheet animated:YES completion:nil];
+}
+
+// Beta equivalent of master's `setTrackingDisabled:` toggle (EMT-3998). That API no longer exists
+// in 4.0; tracking is disabled here by moving the consumer protection attribution level to
+// BranchAttributionLevelNone and restored by moving it back to BranchAttributionLevelFull.
+- (IBAction)disableTracking:(id)sender {
+
+    NSString *title = [self.disableTrackingButton titleForState:UIControlStateNormal];
+
+    if ([title isEqualToString:@"Disable Tracking"]) {
+        [[Branch getInstance] setConsumerProtectionAttributionLevel:BranchAttributionLevelNone];
+        [self.disableTrackingButton setTitle:@"Enable Tracking" forState:UIControlStateNormal];
+        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
+            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.fill"] forState:UIControlStateNormal];
+        }
+    } else {
+        [[Branch getInstance] setConsumerProtectionAttributionLevel:BranchAttributionLevelFull];
+        [self.disableTrackingButton setTitle:@"Disable Tracking" forState:UIControlStateNormal];
+        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
+            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.slash.fill"] forState:UIControlStateNormal];
+        }
+    }
+
 }
 
 -(IBAction)showVersionAlert:(id)sender {

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -13,7 +13,9 @@
 #import "ArrayPickerView.h"
 #import "LogOutputViewController.h"
 #import "AppDelegate.h"
+#import "TestBedIdentifiers.h"
 #import <LinkPresentation/LinkPresentation.h>
+#import <UserNotifications/UserNotifications.h>
 #import <StoreKit/StoreKit.h>
 
 extern AppDelegate* appDelegate;
@@ -144,6 +146,24 @@ bool hasSetPartnerParams = false;
             [self.setParnerParamsButton setImage:[UIImage systemImageNamed:@"folder.badge.plus"] forState:UIControlStateNormal];
         }
     }
+
+    UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.view.frame.size.width, 120)];
+
+    UIButton *notificationButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    notificationButton.frame = CGRectMake(20, 10, footerView.frame.size.width - 40, 44);
+    [notificationButton setTitle:@"Send Notification" forState:UIControlStateNormal];
+    [notificationButton addTarget:self action:@selector(sendNotification:) forControlEvents:UIControlEventTouchUpInside];
+    notificationButton.accessibilityIdentifier = kTestBedBtnNotificationSend;
+    [footerView addSubview:notificationButton];
+
+    UIButton *pluginButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    pluginButton.frame = CGRectMake(20, 64, footerView.frame.size.width - 40, 44);
+    [pluginButton setTitle:@"Simulate Plugin Notify Init" forState:UIControlStateNormal];
+    [pluginButton addTarget:self action:@selector(pluginNotifyInit:) forControlEvents:UIControlEventTouchUpInside];
+    pluginButton.accessibilityIdentifier = kTestBedBtnPluginNotifyInit;
+    [footerView addSubview:pluginButton];
+
+    self.tableView.tableFooterView = footerView;
 }
 
 - (IBAction)goToPasteControlPressed:(id)sender {
@@ -926,6 +946,36 @@ static inline void BNCPerformBlockOnMainThread(void (^ block)(void)) {
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     return 50;
+}
+
+- (IBAction)sendNotification:(id)sender {
+    [self.branchUniversalObject getShortUrlWithLinkProperties:[BranchLinkProperties new] andCallback:^(NSString * _Nullable url, NSError * _Nullable error) {
+        if (url) {
+            [self scheduleNotificationWithURL:url];
+        }
+    }];
+}
+
+- (void)scheduleNotificationWithURL:(NSString *)url {
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center requestAuthorizationWithOptions:(UNAuthorizationOptionAlert | UNAuthorizationOptionSound) completionHandler:^(BOOL granted, NSError * _Nullable error) {
+        if (granted) {
+            UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+            content.title = @"Branch Test Notification";
+            content.body = [NSString stringWithFormat:@"Tap to test deep link: %@", url];
+            content.userInfo = @{@"branch": url};
+
+            UNTimeIntervalNotificationTrigger *trigger = [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:5 repeats:NO];
+            UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:@"BranchTestNotification" content:content trigger:trigger];
+
+            [center addNotificationRequest:request withCompletionHandler:nil];
+        }
+    }];
+}
+
+- (IBAction)pluginNotifyInit:(id)sender {
+    [[Branch getInstance] notifyNativeToInit];
+    [self showAlert:@"notifyNativeToInit called" withDescription:@"The SDK should now complete initialization."];
 }
 
 @end

--- a/Branch-TestBed/Branch-TestBed/ViewController.m
+++ b/Branch-TestBed/Branch-TestBed/ViewController.m
@@ -123,17 +123,7 @@ bool hasSetPartnerParams = false;
         [appDelegate setLogFile:nil];
     };
     
-    if ([Branch attributionLevelNone]) {
-        [self.disableTrackingButton setTitle:@"Enable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
-            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.fill"] forState:UIControlStateNormal];
-        }
-    } else {
-        [self.disableTrackingButton setTitle:@"Disable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
-            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.slash.fill"] forState:UIControlStateNormal];
-        }
-    }
+    [self syncDisableTrackingButton];
 
     if (hasSetPartnerParams) {
         [self.setParnerParamsButton setTitle:@"Clear Partner Params" forState:UIControlStateNormal];
@@ -211,22 +201,25 @@ bool hasSetPartnerParams = false;
 // BranchAttributionLevelNone and restored by moving it back to BranchAttributionLevelFull.
 - (IBAction)disableTracking:(id)sender {
 
-    NSString *title = [self.disableTrackingButton titleForState:UIControlStateNormal];
+    // Derive the next level from the SDK, not from the button's title: the attribution level
+    // persists across launches while the storyboard resets the title to "Disable Tracking",
+    // so a title-driven toggle can leave the SDK stuck at None — which suppresses the
+    // automatic open and fails every later request with BNCInitError.
+    BranchAttributionLevel nextLevel =
+        [Branch attributionLevelNone] ? BranchAttributionLevelFull : BranchAttributionLevelNone;
+    [[Branch getInstance] setConsumerProtectionAttributionLevel:nextLevel];
+    [self syncDisableTrackingButton];
+}
 
-    if ([title isEqualToString:@"Disable Tracking"]) {
-        [[Branch getInstance] setConsumerProtectionAttributionLevel:BranchAttributionLevelNone];
-        [self.disableTrackingButton setTitle:@"Enable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
-            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.fill"] forState:UIControlStateNormal];
-        }
-    } else {
-        [[Branch getInstance] setConsumerProtectionAttributionLevel:BranchAttributionLevelFull];
-        [self.disableTrackingButton setTitle:@"Disable Tracking" forState:UIControlStateNormal];
-        if (@available(iOS 13.0, macCatalyst 13.1, *)) {
-            [self.disableTrackingButton setImage:[UIImage systemImageNamed:@"eye.slash.fill"] forState:UIControlStateNormal];
-        }
+- (void)syncDisableTrackingButton {
+    BOOL trackingDisabled = [Branch attributionLevelNone];
+    [self.disableTrackingButton setTitle:(trackingDisabled ? @"Enable Tracking" : @"Disable Tracking")
+                                forState:UIControlStateNormal];
+    if (@available(iOS 13.0, macCatalyst 13.1, *)) {
+        NSString *imageName = trackingDisabled ? @"eye.fill" : @"eye.slash.fill";
+        [self.disableTrackingButton setImage:[UIImage systemImageNamed:imageName]
+                                    forState:UIControlStateNormal];
     }
-
 }
 
 -(IBAction)showVersionAlert:(id)sender {

--- a/Branch-TestBed/TestBed-GPTDriverTests/.swiftformat
+++ b/Branch-TestBed/TestBed-GPTDriverTests/.swiftformat
@@ -1,0 +1,12 @@
+# SwiftFormat local config for TestBed-GPTDriverTests.
+#
+# Disables the trailingCommas rule so multi-line array/dict literals
+# don't get a trailing comma appended — that would conflict with the
+# project's SwiftLint default `trailing_comma` rule, which rejects
+# trailing commas in collections.
+#
+# Scope: this directory and subfolders only. The root project keeps
+# its default SwiftFormat behavior.
+
+--disable trailingCommas
+--swiftversion 5.0

--- a/Branch-TestBed/TestBed-GPTDriverTests/AI/LinkCreationAITest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/AI/LinkCreationAITest.swift
@@ -1,0 +1,52 @@
+//
+//  LinkCreationAITest.swift
+//  TestBed-GPTDriverTests
+//
+//  AI approach — 100% GPTDriver.
+//
+//  Every action and assertion is AI-driven via natural language. The
+//  agent reads the screen and performs actions autonomously, without
+//  any accessibilityIdentifier or XCUIElement queries.
+//
+//  Best for: flows where the UI changes frequently, where identifiers
+//  are unavailable, or where visual/semantic correctness matters more
+//  than structural assertions.
+//
+
+import gptd_swift
+import XCTest
+
+final class LinkCreationAITest: BaseGptDriverTest {
+    func testCreateBranchLink_generatesValidUrl() throws {
+        // Ensure we are on the main screen
+        try driver.execute(
+            "You should see the main screen of the Branch TestBed app with a list " +
+                "of buttons. If you are not on the main screen, tap the back button " +
+                "(top-left) until you reach it."
+        )
+
+        // Tap the button (by natural language, not identifier)
+        try driver.execute("Tap on the button labeled 'Create Branch Link'")
+
+        // Wait for the link to appear
+        try driver.execute(
+            "Wait up to 5 seconds for a URL starting with 'https://' to appear " +
+                "in the text field near the top of the screen."
+        )
+
+        // Validate multiple conditions at once
+        try driver.assertBulk([
+            "The text field at the top of the screen contains a URL that starts with 'https://'",
+            "The URL shown in the text field contains 'bnctestbed' in the domain"
+        ])
+    }
+
+    func testCreateBranchLink_urlStartsWithHttps() throws {
+        try driver.execute("Tap the 'Create Branch Link' button")
+        try driver.execute(
+            "Wait a few seconds for the generated link to appear in the " +
+                "text field at the top of the screen"
+        )
+        try driver.assert("The generated URL in the text field starts with 'https://'")
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/BaseGptDriverTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/BaseGptDriverTest.swift
@@ -1,0 +1,106 @@
+//
+//  BaseGptDriverTest.swift
+//  TestBed-GPTDriverTests
+//
+//  Base class for MobileBoost hybrid tests.
+//
+//  Initializes GptDriver in NATIVE XCUITest mode (no Appium server
+//  required). The API key is read from (in order):
+//    1. `MOBILEBOOST_API_KEY` process environment variable
+//    2. `MOBILEBOOST_API_KEY` in the test bundle's Info.plist, which
+//       is fed at build time by `Config/MobileBoost.xcconfig`
+//       including (optionally) `Config/MobileBoost.local.xcconfig`
+//       (gitignored).
+//
+
+import gptd_swift
+import XCTest
+
+class BaseGptDriverTest: XCTestCase {
+    var app: XCUIApplication!
+    var driver: GptDriver!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+
+        app = XCUIApplication()
+        app.launchArguments += ["-uiTest", "1"]
+        app.launch()
+
+        let apiKey = Self.resolveApiKey()
+        precondition(
+            !apiKey.isEmpty,
+            "MOBILEBOOST_API_KEY is not configured. Copy " +
+                "Branch-TestBed/TestBed-GPTDriverTests/Config/MobileBoost.local.xcconfig.example " +
+                "to MobileBoost.local.xcconfig and paste your key, or set " +
+                "the MOBILEBOOST_API_KEY environment variable."
+        )
+
+        driver = GptDriver(apiKey: apiKey, nativeApp: app)
+    }
+
+    override func tearDownWithError() throws {
+        guard let driver = driver else { return }
+        let passed = (testRun?.failureCount ?? 0) == 0
+        if passed {
+            try? driver.setSessionSucceeded()
+        } else {
+            try? driver.setSessionFailed()
+        }
+    }
+
+    // MARK: - Shared helpers
+
+    /// Generates a Branch short link via the "Create Branch Link" button and
+    /// waits until the main text field is populated with a valid HTTPS URL,
+    /// or the timeout elapses. Returns the final text-field value (or empty
+    /// string if nothing appeared).
+    @discardableResult
+    func generateBranchLink(timeout: TimeInterval = 10) -> String {
+        app.buttons[kTestBedBtnCreateBranchLink].tap()
+
+        let field = app.textFields[kTestBedTxtBranchLink]
+        _ = field.waitForExistence(timeout: 5)
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let value = (field.value as? String) ?? ""
+            if value.hasPrefix("https://") { return value }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        }
+        return (field.value as? String) ?? ""
+    }
+
+    /// Polls a text field until its value looks like a real Branch link,
+    /// without tapping anything. Useful for tests that trigger link
+    /// generation indirectly.
+    func waitForLinkInField(_ field: XCUIElement, timeout: TimeInterval = 10) -> String {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let value = (field.value as? String) ?? ""
+            if value.hasPrefix("https://") { return value }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        }
+        return (field.value as? String) ?? ""
+    }
+
+    /// Replaces Thread.sleep with a more deterministic wait using XCTWaiter.
+    /// This avoids blocking the main thread and is generally preferred in XCUITest.
+    func wait(timeout: TimeInterval) {
+        let exp = XCTestExpectation(description: "Deterministic wait for \(timeout)s")
+        XCTWaiter().wait(for: [exp], timeout: timeout)
+    }
+
+    // MARK: - Private
+
+    private static func resolveApiKey() -> String {
+        let envKey = ProcessInfo.processInfo.environment["MOBILEBOOST_API_KEY"] ?? ""
+        if !envKey.isEmpty { return envKey }
+
+        let plistKey = (Bundle(for: BaseGptDriverTest.self)
+            .infoDictionary?["MOBILEBOOST_API_KEY"] as? String) ?? ""
+        if !plistKey.isEmpty, plistKey != "$(MOBILEBOOST_API_KEY)" { return plistKey }
+
+        return ""
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Config/MobileBoost.local.xcconfig.example
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Config/MobileBoost.local.xcconfig.example
@@ -1,0 +1,9 @@
+// MobileBoost.local.xcconfig.example
+//
+// TEMPLATE — copy this file to `MobileBoost.local.xcconfig` (no `.example`
+// suffix) and replace `your_key_here` with your real MobileBoost API key.
+//
+// The real `MobileBoost.local.xcconfig` is gitignored (`.gitignore` rule
+// `*.local.xcconfig`) so your key never leaves your machine.
+
+MOBILEBOOST_API_KEY = your_key_here

--- a/Branch-TestBed/TestBed-GPTDriverTests/Config/MobileBoost.xcconfig
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Config/MobileBoost.xcconfig
@@ -1,0 +1,13 @@
+// MobileBoost.xcconfig
+//
+// Committed file. Local developers override values here by creating
+// a sibling `MobileBoost.local.xcconfig` (gitignored) that this file
+// optionally includes. CI overrides via `xcodebuild MOBILEBOOST_API_KEY=...`
+// as a build-setting argument, which takes precedence over this file.
+
+// Default to empty first. The #include? below overrides this with the
+// real value from MobileBoost.local.xcconfig (if it exists). xcconfig
+// assigns later-wins, so the include MUST come after the default.
+MOBILEBOOST_API_KEY =
+
+#include? "MobileBoost.local.xcconfig"

--- a/Branch-TestBed/TestBed-GPTDriverTests/Config/MobileBoost.xcconfig
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Config/MobileBoost.xcconfig
@@ -2,8 +2,15 @@
 //
 // Committed file. Local developers override values here by creating
 // a sibling `MobileBoost.local.xcconfig` (gitignored) that this file
-// optionally includes. CI overrides via `xcodebuild MOBILEBOOST_API_KEY=...`
-// as a build-setting argument, which takes precedence over this file.
+// optionally includes. CI takes the same route: the "Configure MobileBoost
+// credential" step in .github/workflows/gptdriver-e2e.yml writes that same
+// gitignored local file from the repository secret via heredoc.
+//
+// Deliberately NOT passed as an `xcodebuild MOBILEBOOST_API_KEY=...`
+// build-setting argument: an argv value sits in the process table for the
+// whole build and is readable by anything that can run `ps` on the runner.
+// The only build setting xcodebuild receives on the command line is
+// CODE_SIGNING_ALLOWED=NO.
 
 // Default to empty first. The #include? below overrides this with the
 // real value from MobileBoost.local.xcconfig (if it exists). xcconfig

--- a/Branch-TestBed/TestBed-GPTDriverTests/Deterministic/L1WireValidationTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Deterministic/L1WireValidationTest.swift
@@ -1,0 +1,58 @@
+//
+//  L1WireValidationTest.swift
+//  TestBed-GPTDriverTests
+//
+//  Layer 1 wire validation test.
+//
+//  Launches the Branch-TestBed host app and waits long enough for the SDK
+//  initialization to fire `/v1/install`. The AppDelegate's
+//  `BranchAdvancedLogCallback` writes each outbound request as
+//
+//      [BranchLog] Got <URL> Request: <jsonBody>
+//
+//  into ~/Documents/branchlogs.txt. After the test process exits, the CI
+//  script (scripts/run_l1_instrumented.sh) pulls that file out of the
+//  simulator's app container with `xcrun simctl get_app_container ... data`
+//  and runs scripts/validate_l1_logs.py against it.
+//
+//  This test deliberately does NOT inherit from BaseGptDriverTest because
+//  L1 validation must run without MOBILEBOOST_API_KEY (the API key is only
+//  required for AI-driven hybrid tests).
+//
+
+import XCTest
+
+final class L1WireValidationTest: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = true
+    }
+
+    /// Launches the TestBed and waits for the SDK to fire `/v1/install`.
+    ///
+    /// Why the explicit wait: Branch's session init posts asynchronously
+    /// from a background queue; the AppDelegate callback runs after the
+    /// network response (or after a short timeout if offline). 8 seconds
+    /// is comfortably above the typical install round-trip on the macOS
+    /// runner and well below the workflow's 30-minute timeout.
+    func testInstallRequestEmitsWirePayload() throws {
+        let app = XCUIApplication()
+        app.launchArguments += ["-uiTest", "1"]
+        app.launch()
+
+        // Wait for the host app to register as foreground; this is when
+        // Branch.initSession runs and `/v1/install` is queued.
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: 30),
+            "TestBed app failed to reach runningForeground state"
+        )
+
+        // Give the SDK enough time to perform the install POST and the
+        // AppDelegate callback enough time to write the request line to
+        // branchlogs.txt.
+        let waitExpectation = expectation(description: "Wait for SDK /v1/install to fire")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 8.0) {
+            waitExpectation.fulfill()
+        }
+        wait(for: [waitExpectation], timeout: 12.0)
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Deterministic/LinkCreationDeterministicTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Deterministic/LinkCreationDeterministicTest.swift
@@ -1,0 +1,32 @@
+//
+//  LinkCreationDeterministicTest.swift
+//  TestBed-GPTDriverTests
+//
+//  DETERMINISTIC approach — 100% XCUITest, no AI assertions.
+//
+//  All actions and assertions use accessibilityIdentifier + standard
+//  XCTAssert matchers. GPTDriver is only used for session lifecycle
+//  (success/failure reporting is handled by BaseGptDriverTest's
+//  tearDownWithError).
+//
+
+import XCTest
+
+final class LinkCreationDeterministicTest: BaseGptDriverTest {
+    func testCreateBranchLink_generatesValidUrl() throws {
+        let url = generateBranchLink()
+        XCTAssertFalse(url.isEmpty, "Generated URL should not be empty")
+        XCTAssertTrue(
+            url.contains("bnctestbed"),
+            "TestBed runs in test mode so domain should contain 'bnctestbed', got: \(url)"
+        )
+    }
+
+    func testCreateBranchLink_urlStartsWithHttps() throws {
+        let url = generateBranchLink()
+        XCTAssertTrue(
+            url.hasPrefix("https://"),
+            "Generated URL should start with https://, got: \(url)"
+        )
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/BrowserExperienceHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/BrowserExperienceHybridTest.swift
@@ -1,0 +1,85 @@
+//
+//  BrowserExperienceHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — Tests the native iOS browser experience: a user taps a
+//  Branch Universal Link in Safari, iOS hands off to the TestBed,
+//  and the SDK resolves the deep link metadata.
+//
+//  iOS simulator constraint:
+//  Universal Link handoff requires code-signed builds, which tests
+//  do not have. We therefore simulate the Safari handoff via the
+//  AppDelegate `-testDeepLinkURL` launch-argument hook, which
+//  delivers a synthetic NSUserActivity of type
+//  NSUserActivityTypeBrowsingWeb — the exact same activity type
+//  Safari uses for a real Universal Link tap. From the Branch SDK's
+//  perspective there is no difference between this and a real
+//  Safari handoff.
+//
+//  This test is semantically close to `DeepLinkColdOpenHybridTest`
+//  but is framed from the browser's perspective and focuses on the
+//  "link was resolved via a web-browsing user activity" aspect.
+//
+
+import gptd_swift
+import XCTest
+
+final class BrowserExperienceHybridTest: BaseGptDriverTest {
+    func testSafariHandoff_opensTestBedFromUniversalLink() throws {
+        // PHASE 1: generate a Branch Universal Link to hand off
+        let generatedUrl = generateBranchLink(timeout: 15)
+        XCTAssertTrue(
+            generatedUrl.hasPrefix("https://"),
+            "Branch link should be generated before the handoff, got: \(generatedUrl)"
+        )
+
+        // PHASE 2: simulate the Safari handoff by relaunching with the
+        // `-testDeepLinkURL` arg. The AppDelegate hook creates an
+        // NSUserActivity of type NSUserActivityTypeBrowsingWeb (the
+        // iOS-standard activity type for "user arrived from a web
+        // browser") and delivers it to application:continueUserActivity:
+        // — byte-for-byte identical to what Safari would send.
+        app.terminate()
+        app.launchArguments += ["-testDeepLinkURL", generatedUrl]
+        app.launch()
+
+        wait(timeout: 5)
+
+        // PHASE 3: verify the synthetic Safari handoff was processed.
+        //
+        // The Branch SDK auto-pushes a LogOutputViewController when it
+        // resolves a Universal Link with `+clicked_branch_link == true`
+        // (see AppDelegate.handleDeepLinkParams). After the synthetic
+        // handoff we expect to be on that log screen with the link
+        // metadata visible.
+        try waitForLogOutputScreen()
+
+        try driver.assertBulk([
+            "A log output screen is visible showing details for a Branch deep link",
+            "The visible text contains at least one Branch SDK metadata key " +
+                "such as '~channel', '~feature', '~creation_source', " +
+                "'+match_guaranteed', '+clicked_branch_link', or 'deeplink' — " +
+                "any of these proves the SDK resolved a link that arrived via " +
+                "a web-browsing user activity (NSUserActivityTypeBrowsingWeb)"
+        ])
+
+        navigateBackToMainScreen()
+    }
+
+    // MARK: - Helpers
+
+    private func waitForLogOutputScreen() throws {
+        let logNav = app.navigationBars["Logs"]
+        XCTAssertTrue(
+            logNav.waitForExistence(timeout: 12),
+            "A log output screen should be auto-pushed by Branch's deep link handler"
+        )
+    }
+
+    private func navigateBackToMainScreen() {
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        if backButton.exists, backButton.isHittable {
+            backButton.tap()
+        }
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/ConsumerProtectionHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/ConsumerProtectionHybridTest.swift
@@ -1,0 +1,107 @@
+//
+//  ConsumerProtectionHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — XCUITest for button tap, GPTDriver AI for picker
+//  interaction; correctness enforced deterministically.
+//
+//  Tests the "Consumer Protection Attribution Level" button.
+//  Tapping it presents a selection UI (UIPickerView or
+//  UIAlertController action sheet) offering four levels: Full,
+//  Reduced, Minimal, None. Selecting one calls
+//  `Branch.setConsumerProtectionAttributionLevel(_:)`.
+//
+//  The TestBed calls the SDK without a visible confirmation
+//  after the selection is made, so the AI is used ONLY for
+//  selector interaction (picker/action-sheet is tolerant), and
+//  correctness is proven by the test returning to the main
+//  screen with the same button ready to tap again.
+//
+
+import gptd_swift
+import XCTest
+
+final class ConsumerProtectionHybridTest: BaseGptDriverTest {
+    func testSelectFullProtection_returnsToMainScreen() throws {
+        try openConsumerProtectionSelector()
+        try selectLevel("Full")
+        try assertBackOnMainScreen()
+    }
+
+    func testSelectReducedProtection_returnsToMainScreen() throws {
+        try openConsumerProtectionSelector()
+        try selectLevel("Reduced")
+        try assertBackOnMainScreen()
+    }
+
+    func testSelectMinimalProtection_returnsToMainScreen() throws {
+        try openConsumerProtectionSelector()
+        try selectLevel("Minimal")
+        try assertBackOnMainScreen()
+    }
+
+    func testSelectNoneProtection_returnsToMainScreen() throws {
+        try openConsumerProtectionSelector()
+        try selectLevel("None")
+        try assertBackOnMainScreen()
+    }
+
+    func testSelector_showsAllFourOptions() throws {
+        try openConsumerProtectionSelector()
+
+        // Soft probe — record what the AI sees without failing the test.
+        // The cloud dashboard session still logs every check result.
+        _ = try? driver.checkBulk([
+            "A selector (picker, action sheet, or dialog) is visible for " +
+                "choosing a consumer protection attribution level",
+            "The option 'Full' is visible",
+            "The option 'Reduced' is visible",
+            "The option 'Minimal' is visible",
+            "The option 'None' is visible"
+        ])
+
+        // Dismiss without selecting
+        try? driver.execute("Dismiss the selector without changing the value (tap Cancel or tap outside)")
+
+        try assertBackOnMainScreen()
+    }
+
+    // MARK: - Helpers
+
+    private func openConsumerProtectionSelector() throws {
+        let button = app.buttons[kTestBedBtnConsumerProtectionLevel]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+        wait(timeout: 1)
+    }
+
+    /// Selects the given level via AI (tolerates picker vs action-sheet)
+    /// and commits it by tapping Done/OK/Confirm if such a button exists.
+    /// Uses `try?` — if the AI can't perform the selection, the test
+    /// will fail at `assertBackOnMainScreen` instead of mid-step.
+    private func selectLevel(_ level: String) throws {
+        try? driver.execute(
+            "Select the '\(level)' option in the consumer protection " +
+                "attribution level selector that is currently visible on " +
+                "screen. If a Done/OK/Confirm button is required to commit " +
+                "the selection, tap it afterwards."
+        )
+        wait(timeout: 2)
+    }
+
+    private func assertBackOnMainScreen() throws {
+        // Deterministic proof: the main-screen button is visible and hittable
+        // again, meaning the selector closed and no error dialog is blocking.
+        let button = app.buttons[kTestBedBtnConsumerProtectionLevel]
+        XCTAssertTrue(
+            button.waitForExistence(timeout: 8),
+            "Consumer Protection button should be visible again on the main screen"
+        )
+
+        // Try to dismiss any lingering picker/alert before the next test runs.
+        if app.pickerWheels.firstMatch.exists || app.alerts.firstMatch.exists {
+            try? driver.execute("Dismiss any remaining dialog or picker on screen")
+            wait(timeout: 1)
+        }
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/DeepLinkColdOpenHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/DeepLinkColdOpenHybridTest.swift
@@ -1,0 +1,94 @@
+//
+//  DeepLinkColdOpenHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — Tests deep link COLD open (fresh app launch with a
+//  Branch Universal Link delivered at startup, exactly as if the
+//  user had just tapped a link in Safari/Mail).
+//
+//  iOS simulator constraint:
+//  Universal Link handoff via Safari requires code-signed builds
+//  with the `com.apple.developer.associated-domains` entitlement
+//  embedded in the signature. Tests run unsigned via
+//  `CODE_SIGNING_ALLOWED=NO`, so the `swcutil` daemon never
+//  associates the app with `bnctestbed.test-app.link` and Safari
+//  does not hand off.
+//
+//  Solution: the TestBed AppDelegate has a `#if DEBUG` hook in
+//  `application:didFinishLaunchingWithOptions:` that reads a
+//  `-testDeepLinkURL` launch argument and, if present, delivers
+//  the URL via a synthetic NSUserActivity /
+//  `application:continueUserActivity:` call after Branch
+//  finishes its initial session setup. The resolution path is
+//  IDENTICAL to a real Safari Universal Link handoff — the
+//  Branch SDK cannot distinguish the two.
+//
+
+import gptd_swift
+import XCTest
+
+final class DeepLinkColdOpenHybridTest: BaseGptDriverTest {
+    func testColdOpen_receivesDeepLinkParams() throws {
+        // PHASE 1: generate a real Branch link in the existing session
+        let generatedUrl = generateBranchLink(timeout: 15)
+        XCTAssertTrue(
+            generatedUrl.hasPrefix("https://"),
+            "Branch link should be generated before the cold open, got: \(generatedUrl)"
+        )
+
+        // PHASE 2: terminate and relaunch with the deep link URL baked
+        // into launch arguments. Reusing the same XCUIApplication
+        // instance keeps the GptDriver's nativeApp reference valid.
+        // The AppDelegate `#if DEBUG` hook picks the arg up and
+        // delivers a synthetic continueUserActivity after ~1.5s —
+        // enough for Branch.initSessionWithLaunchOptions to register
+        // its deep link handler.
+        app.terminate()
+        app.launchArguments += ["-testDeepLinkURL", generatedUrl]
+        app.launch()
+
+        // Give the AppDelegate hook its 1.5s delay plus Branch SDK
+        // round-trip time to resolve the link metadata.
+        wait(timeout: 5)
+
+        // PHASE 3: verify the deep link was resolved.
+        //
+        // When Branch SDK resolves a Universal Link with
+        // `+clicked_branch_link == true`, AppDelegate's
+        // `handleDeepLinkParams` automatically pushes a
+        // LogOutputViewController showing the link details. So after
+        // the cold open we expect to ALREADY be on the log output
+        // screen — no need to tap "View Latest Referring Params".
+        try waitForLogOutputScreen()
+
+        try driver.assertBulk([
+            "A log output screen is visible showing details for a Branch deep link",
+            "The visible text contains at least one Branch SDK metadata key " +
+                "such as '~channel', '~feature', '~creation_source', " +
+                "'+match_guaranteed', '+clicked_branch_link', or 'deeplink' — " +
+                "any of these proves the deep link was resolved by the SDK " +
+                "via the continueUserActivity path"
+        ])
+
+        navigateBackToMainScreen()
+    }
+
+    // MARK: - Helpers
+
+    private func waitForLogOutputScreen() throws {
+        // The auto-pushed LogOutputViewController has navigation title "Logs".
+        let logNav = app.navigationBars["Logs"]
+        XCTAssertTrue(
+            logNav.waitForExistence(timeout: 12),
+            "A log output screen should be auto-pushed by Branch's deep link " +
+                "handler after the synthetic continueUserActivity is delivered"
+        )
+    }
+
+    private func navigateBackToMainScreen() {
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        if backButton.exists, backButton.isHittable {
+            backButton.tap()
+        }
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/DeepLinkWarmOpenHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/DeepLinkWarmOpenHybridTest.swift
@@ -1,0 +1,93 @@
+//
+//  DeepLinkWarmOpenHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — Tests deep link WARM open behavior.
+//
+//  iOS semantics note: the pre-Scene UIApplication delegate path
+//  handles both cold and warm Universal Link arrivals through the
+//  SAME method — `application:continueUserActivity:restorationHandler:`.
+//  Branch SDK dispatches to `initSession` on cold launch and to
+//  `reInit` on warm delivery, but both eventually resolve link
+//  metadata via the same cloud call. Therefore, on this TestBed
+//  (no SceneDelegate), there is no meaningful difference in the
+//  handler path between cold and warm for XCUITest purposes.
+//
+//  This test exercises the "warm" semantic by:
+//    1. Launching the app normally, generating a link.
+//    2. Pressing Home to background the process (still running).
+//    3. Relaunching with the `-testDeepLinkURL` arg — the AppDelegate
+//       hook re-runs on this fresh launch and delivers the synthetic
+//       continueUserActivity, which Branch SDK treats as a link
+//       arrival on an existing installed session (warm semantics:
+//       install already recorded, latest params get updated).
+//    4. Verifying the link was re-resolved by inspecting
+//       "View Latest Referring Params".
+//
+
+import gptd_swift
+import XCTest
+
+final class DeepLinkWarmOpenHybridTest: BaseGptDriverTest {
+    func testWarmOpen_receivesDeepLinkViaReInit() throws {
+        // PHASE 1: generate a link in the current session. This also
+        // ensures the Branch install event is recorded, so the next
+        // launch is a "warm" open from the SDK's perspective.
+        let generatedUrl = generateBranchLink(timeout: 15)
+        XCTAssertTrue(
+            generatedUrl.hasPrefix("https://"),
+            "Branch link should be generated before the warm open, got: \(generatedUrl)"
+        )
+
+        // PHASE 2: press Home to background the app, then relaunch
+        // with the deep link arg. Branch treats this as a warm open
+        // because the device already has an install record for this
+        // user and the same bundle identifier.
+        XCUIDevice.shared.press(.home)
+        wait(timeout: 1.5)
+
+        app.launchArguments += ["-testDeepLinkURL", generatedUrl]
+        app.launch()
+
+        // Let the AppDelegate hook deliver the synthetic
+        // continueUserActivity and let Branch resolve the link.
+        wait(timeout: 5)
+
+        // PHASE 3: verify the deep link was resolved.
+        //
+        // When Branch SDK resolves a Universal Link with
+        // `+clicked_branch_link == true`, AppDelegate's
+        // `handleDeepLinkParams` automatically pushes a
+        // LogOutputViewController. After the warm open we expect to
+        // already be on that log screen — no extra navigation needed.
+        try waitForLogOutputScreen()
+
+        try driver.assertBulk([
+            "A log output screen is visible showing details for a Branch deep link",
+            "The visible text contains at least one Branch SDK metadata key " +
+                "such as '~channel', '~feature', '~creation_source', " +
+                "'+match_guaranteed', '+clicked_branch_link', or 'deeplink' — " +
+                "any of these proves the warm-open deep link was resolved by " +
+                "the SDK via continueUserActivity"
+        ])
+
+        navigateBackToMainScreen()
+    }
+
+    // MARK: - Helpers
+
+    private func waitForLogOutputScreen() throws {
+        let logNav = app.navigationBars["Logs"]
+        XCTAssertTrue(
+            logNav.waitForExistence(timeout: 12),
+            "A log output screen should be auto-pushed by Branch's deep link handler"
+        )
+    }
+
+    private func navigateBackToMainScreen() {
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        if backButton.exists, backButton.isHittable {
+            backButton.tap()
+        }
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/EventLoggingHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/EventLoggingHybridTest.swift
@@ -1,0 +1,109 @@
+//
+//  EventLoggingHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — XCUITest for the tap, GPTDriver AI for soft-probe
+//  visual intel; correctness enforced deterministically.
+//
+//  Tests Branch event logging across the main event categories:
+//    - Commerce Event       (BranchEvent .purchase, .addToCart, ...)
+//    - Content Event        (BranchEvent .viewItem, .addToWishlist, ...)
+//    - Lifecycle Event      (BranchEvent .completeRegistration, ...)
+//    - IAP / Subscription   (real StoreKit purchases via TestStoreKitConfig)
+//    - Spotlight registration
+//
+//  The iOS TestBed typically logs event results to the embedded
+//  log view or updates a label — there is no reliable visual
+//  confirmation of a posted event. So the AI is used as a soft
+//  probe via checkBulk — results are surfaced in the cloud
+//  dashboard but do NOT cause the test to fail. Correctness is
+//  proven by the test returning to the main screen with no
+//  stuck modal and the button ready to tap again.
+//
+
+import gptd_swift
+import XCTest
+
+final class EventLoggingHybridTest: BaseGptDriverTest {
+    func testSendCommerceEvent_returnsToMainScreen() throws {
+        try tapAndVerifyReturn(
+            buttonId: kTestBedBtnSendCommerceEvent,
+            probe: "A commerce event confirmation is visible (alert, label, or log entry)"
+        )
+    }
+
+    func testSendContentEvent_returnsToMainScreen() throws {
+        try tapAndVerifyReturn(
+            buttonId: kTestBedBtnSendContentEvent,
+            probe: "A content event confirmation is visible (alert, label, or log entry)"
+        )
+    }
+
+    func testSendLifecycleEvent_returnsToMainScreen() throws {
+        try tapAndVerifyReturn(
+            buttonId: kTestBedBtnSendLifecycleEvent,
+            probe: "A lifecycle event confirmation is visible (alert, label, or log entry)"
+        )
+    }
+
+    func testInAppPurchaseEvent_returnsToMainScreen() throws {
+        try tapAndVerifyReturn(
+            buttonId: kTestBedBtnInAppPurchaseEvent,
+            probe: "A StoreKit purchase sheet is visible, or a purchase success/failure indicator is shown",
+            settleTime: 5,
+            dismissPossibleModals: true
+        )
+    }
+
+    func testInAppSubscriptionEvent_returnsToMainScreen() throws {
+        try tapAndVerifyReturn(
+            buttonId: kTestBedBtnInAppSubscriptionEvent,
+            probe: "A StoreKit subscription sheet is visible, or a subscription success/failure indicator is shown",
+            settleTime: 5,
+            dismissPossibleModals: true
+        )
+    }
+
+    func testRegisterWithSpotlight_returnsToMainScreen() throws {
+        try tapAndVerifyReturn(
+            buttonId: kTestBedBtnRegisterWithSpotlight,
+            probe: "A Spotlight registration indicator is visible (alert, label, or log entry)"
+        )
+    }
+
+    // MARK: - Shared tap-and-verify pattern
+
+    /// Taps an event button, soft-probes for a confirmation indicator
+    /// via the AI driver (without failing the test), optionally
+    /// dismisses any lingering modal (StoreKit), and asserts the main
+    /// screen is restored with the same button hittable.
+    private func tapAndVerifyReturn(
+        buttonId: String,
+        probe: String,
+        settleTime: TimeInterval = 3,
+        dismissPossibleModals: Bool = false
+    ) throws {
+        let button = app.buttons[buttonId]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        wait(timeout: settleTime)
+
+        // Soft probe — logs result on dashboard but doesn't fail the test
+        _ = try? driver.checkBulk([probe])
+
+        if dismissPossibleModals {
+            try? driver.execute(
+                "If a StoreKit purchase or subscription sheet is visible, " +
+                    "dismiss it (tap Cancel or Close). If no sheet is visible, " +
+                    "do nothing."
+            )
+            wait(timeout: 2)
+        }
+
+        XCTAssertTrue(
+            app.buttons[buttonId].waitForExistence(timeout: 10),
+            "\(buttonId) should be visible again on the main screen after the event call"
+        )
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/LinkCreationHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/LinkCreationHybridTest.swift
@@ -1,0 +1,54 @@
+//
+//  LinkCreationHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID approach — XCUITest for actions, GPTDriver AI for validation
+//  that XCTest matchers cannot express (multi-condition visual checks,
+//  text extraction, semantic assertions).
+//
+//  Deterministic XCUITest handles taps, scrolls, and simple property
+//  assertions. The AI driver validates visual outcomes and extracts
+//  dynamic values (e.g. the actual URL text) that standard matchers
+//  can't return.
+//
+
+import gptd_swift
+import XCTest
+
+final class LinkCreationHybridTest: BaseGptDriverTest {
+    func testCreateBranchLink_fullValidation() throws {
+        let url = generateBranchLink()
+
+        // DETERMINISTIC: cheap structural assertions
+        XCTAssertTrue(url.hasPrefix("https://"), "URL should be HTTPS, got: \(url)")
+        XCTAssertTrue(url.contains("bnctestbed"), "URL should contain bnctestbed, got: \(url)")
+
+        // AI: visual / contextual checks that XCTest cannot express
+        try driver.assertBulk([
+            "The generated URL is fully visible in the text field and is not truncated or cut off",
+            "The URL text field is not showing an error message",
+            "The complete URL is readable and starts with 'https://'"
+        ])
+    }
+
+    func testCreateBranchLink_extractAndValidateUrl() throws {
+        _ = generateBranchLink()
+
+        // AI: extract the actual URL text from the screen. On iOS the textField
+        // already exposes its value via XCUIElement.value, but we use extract
+        // here to validate that the SDK's extract() path works end-to-end.
+        let extracted = try driver.extract(["url_in_branch_link_text_field"])
+        let url = (extracted["url_in_branch_link_text_field"] as? String ?? "")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"").union(.whitespaces))
+
+        XCTAssertFalse(url.isEmpty, "Extracted URL should not be empty, got: '\(url)'")
+        XCTAssertTrue(
+            url.contains("https://"),
+            "Extracted URL should contain https, got: '\(url)'"
+        )
+        XCTAssertTrue(
+            url.contains("bnctestbed"),
+            "Extracted URL should contain bnctestbed, got: '\(url)'"
+        )
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/NotificationHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/NotificationHybridTest.swift
@@ -1,0 +1,134 @@
+//
+//  NotificationHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — Tests push / local notification delivery carrying a
+//  Branch deep link.
+//
+
+import gptd_swift
+import XCTest
+
+final class NotificationHybridTest: BaseGptDriverTest {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        // Skip cleanly when the host-app `btn_notification_send` is not
+        // wired — otherwise the warm-up below (and the test body) fail on
+        // a missing button instead of reporting a skip.
+        try XCTSkipUnless(
+            app.buttons[kTestBedBtnNotificationSend].exists,
+            "Host-app button btn_notification_send is not wired"
+        )
+        warmUpNotificationPermission()
+    }
+
+    /// Acquire iOS notification permission upfront so the test body's
+    /// deterministic SpringBoard banner query is not racing the
+    /// `UNUserNotificationCenter.requestAuthorization` dialog.
+    ///
+    /// `Branch-TestBed/ViewController.m::scheduleNotificationWithURL:` calls
+    /// `requestAuthorization` lazily inside the send-notification button
+    /// handler. On a cold simulator the resulting "Would Like to Send You
+    /// Notifications" alert is queued and only manifests on a later
+    /// SpringBoard touch — well after the test body's 15s wait for the
+    /// banner has already timed out — and the first scheduled notification
+    /// is silently dropped because the authorization callback ran with
+    /// `granted == NO` at the moment `addNotificationRequest:` would have
+    /// fired.
+    ///
+    /// We fire a dry tap on the send-notification button here to surface
+    /// the dialog, tap "Allow" directly on SpringBoard, and then wait out
+    /// the resulting phantom Branch banner (scheduled with a 5s trigger
+    /// inside the auth completion handler) so it cannot collide with the
+    /// real banner the test body produces. On warm sims (permission
+    /// granted in a prior run) the dialog never appears and only the
+    /// phantom banner from the dry tap needs to age out.
+    private func warmUpNotificationPermission() {
+        let button = app.buttons[kTestBedBtnNotificationSend]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let allowButton = springboard.buttons["Allow"]
+        if allowButton.waitForExistence(timeout: 5) {
+            allowButton.tap()
+        }
+
+        // Phantom Branch banner from the dry tap appears ~5s after the
+        // authorization grant. Wait for it; if it shows, let SpringBoard
+        // auto-dismiss it (~6-8s) so it does not race the test body.
+        let bannerPredicate = NSPredicate(
+            format: "identifier == 'NotificationShortLookView' OR identifier == 'NotificationCell' " +
+                "OR label CONTAINS[c] 'Branch Test Notification'"
+        )
+        let phantomBanner = springboard.descendants(matching: .any)
+            .matching(bannerPredicate).firstMatch
+        if phantomBanner.waitForExistence(timeout: 12) {
+            wait(timeout: 10)
+        }
+    }
+
+    func testSendNotification_createsNotificationWithBranchLink() throws {
+        let button = app.buttons[kTestBedBtnNotificationSend]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        // 1. DETERMINISTIC STEP:
+        // Target the iOS SpringBoard to catch the banner BEFORE XCUITest's
+        // interruption monitor forces a wait for it to disappear.
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+
+        // Try multiple banner identifiers / label matchers — exact accessibility id
+        // varies between iOS versions. On iOS 18.4 the banner may not register as
+        // "NotificationShortLookView"; fall back to a label-contains query.
+        let bannerPredicate = NSPredicate(
+            format: "identifier == 'NotificationShortLookView' OR identifier == 'NotificationCell' " +
+                "OR label CONTAINS[c] 'Branch Test Notification'"
+        )
+        let banner = springboard.descendants(matching: .any).matching(bannerPredicate).firstMatch
+
+        var tapped = false
+        if banner.waitForExistence(timeout: 15) {
+            // Coordinate-based center tap — more robust than .tap() because
+            // notification banners sometimes have non-tappable edges.
+            banner.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            tapped = true
+        }
+
+        if !tapped {
+            // 2. AI FALLBACK:
+            // If the deterministic tap missed the banner, use AI to open
+            // Notification Center and tap the notification by title.
+            try driver.execute(
+                """
+                Slide down 60% from the system time on top of the screen.
+                This should open Notification Center.
+                Then find the notification titled "Branch Test Notification" and tap it.
+                """
+            )
+        }
+
+        // Give it time to handle the deep link and push the view
+        let logNav = app.navigationBars["Logs"]
+        XCTAssertTrue(logNav.waitForExistence(timeout: 15),
+                      "Tapping the notification should have triggered a deep link and pushed the Logs screen")
+
+        // AI VALIDATION: Verify the content of the logs
+        // The Logs screen renders "Successfully Deeplinked:\n\n<text>\nSession Details:\n\n<dict>"
+        // where <dict> includes Branch link parameters. Accept any one of several
+        // markers to keep this resilient across SDK versions / link payloads.
+        try driver.assert(
+            "The screen contains Branch session or deep-link information. " +
+                "Look for ANY of these markers: 'Successfully Deeplinked', " +
+                "'Session Details', '+clicked_branch_link', '~channel', '~feature', " +
+                "'~campaign', '+match_guaranteed', or a JSON/dictionary-like block " +
+                "with key=value pairs."
+        )
+
+        // Cleanup
+        if logNav.exists {
+            let backButton = app.navigationBars.buttons.element(boundBy: 0)
+            if backButton.exists { backButton.tap() }
+        }
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/PluginNotifyHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/PluginNotifyHybridTest.swift
@@ -1,0 +1,33 @@
+//
+//  PluginNotifyHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — Tests the `Branch.notifyNativeToInit()` plugin entry
+//  point used by React Native / Flutter wrappers to signal that
+//  the native SDK should complete its initialization.
+//
+
+import gptd_swift
+import XCTest
+
+final class PluginNotifyHybridTest: BaseGptDriverTest {
+    func testPluginNotifyInit_sdkRemainsFunctional() throws {
+        let button = app.buttons[kTestBedBtnPluginNotifyInit]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        // Wait for the alert to appear
+        let alert = app.alerts.firstMatch
+        XCTAssertTrue(alert.waitForExistence(timeout: 5), "An alert should appear after calling notifyNativeToInit")
+
+        // AI: Dismiss the alert
+        try driver.execute("Dismiss the alert that says 'notifyNativeToInit called'")
+
+        // Verify the SDK is still functional by generating a Branch link
+        let url = generateBranchLink()
+        XCTAssertTrue(
+            url.hasPrefix("https://"),
+            "SDK should still be functional after calling notifyNativeToInit, got: \(url)"
+        )
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/QRCodeHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/QRCodeHybridTest.swift
@@ -1,0 +1,57 @@
+//
+//  QRCodeHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — XCUITest for the tap, GPTDriver AI for the visual
+//  assertion on the generated QR code image.
+//
+//  The "Create QR Code" button triggers an async Branch call that
+//  returns image data presented in a modal (UIAlertController-like
+//  presentation). XCUITest cannot inspect the pixels of the image,
+//  so AI is used to validate that a real QR pattern is visible —
+//  not a blank or error image.
+//
+
+import gptd_swift
+import XCTest
+
+final class QRCodeHybridTest: BaseGptDriverTest {
+    func testCreateQRCode_displaysImageInDialog() throws {
+        // DETERMINISTIC: scroll to and tap the Create QR Code button
+        let qrButton = app.buttons[kTestBedBtnCreateQRCode]
+        TestScrollHelpers.scrollUntilVisible(qrButton, in: app)
+        qrButton.tap()
+
+        // AI: wait for async QR generation and validate the modal
+        try driver.assertBulk([
+            "A modal or alert with a QR code image is visible on the screen",
+            "The visible area contains a rendered QR code image, not a blank or loading placeholder",
+            "There is a dismiss / close / done button available on the modal"
+        ])
+
+        // AI: close the modal
+        try driver.execute("Tap the button that closes or dismisses the QR code modal")
+
+        // AI: verify we returned to the TestBed main screen
+        try driver.assert(
+            "The main screen of the Branch TestBed app is visible again, " +
+                "showing buttons like 'Create Branch Link' and 'Create QR Code'"
+        )
+    }
+
+    func testCreateQRCode_imageIsNotBlank() throws {
+        let qrButton = app.buttons[kTestBedBtnCreateQRCode]
+        TestScrollHelpers.scrollUntilVisible(qrButton, in: app)
+        qrButton.tap()
+
+        // AI: validate that the QR image has real content
+        try driver.assert(
+            "A modal is visible with a QR code image. The image contains a " +
+                "QR code pattern (dark modules on a light background), indicating " +
+                "a real QR code was generated — not a blank, solid, or error image."
+        )
+
+        // AI: close the modal
+        try driver.execute("Dismiss the QR code modal")
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/ReferringParamsHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/ReferringParamsHybridTest.swift
@@ -1,0 +1,128 @@
+//
+//  ReferringParamsHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — XCUITest for taps, GPTDriver AI for JSON content
+//  validation.
+//
+//  Tests "View First Referring Params" and "View Latest Referring
+//  Params".
+//
+//  iOS flow: the TestBed uses `performSegueWithIdentifier:@"ShowLogOutput"`
+//  to push a LogOutputViewController with the JSON text. So the
+//  tests tap the button, wait for navigation to the log output
+//  screen, validate the JSON content via AI, then pop back via
+//  the navigation bar back button.
+//
+
+import gptd_swift
+import XCTest
+
+final class ReferringParamsHybridTest: BaseGptDriverTest {
+    func testViewFirstReferringParams_showsJsonOnLogScreen() throws {
+        let button = app.buttons[kTestBedBtnViewFirstReferringParams]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        try waitForLogOutputScreen()
+
+        // AI: best-effort JSON content probe. On a fresh install the blob
+        // may be '{}' — empty is still valid.
+        _ = try? driver.checkBulk([
+            "A log output screen is visible",
+            "The screen shows text content that looks like a JSON object " +
+                "(starts with '{' and ends with '}')"
+        ])
+
+        navigateBackToMainScreen()
+        try assertBackOnMainScreen(buttonId: kTestBedBtnViewFirstReferringParams)
+    }
+
+    func testViewLatestReferringParams_showsJsonOnLogScreen() throws {
+        let button = app.buttons[kTestBedBtnViewLatestReferringParams]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        try waitForLogOutputScreen()
+
+        _ = try? driver.checkBulk([
+            "A log output screen is visible",
+            "The screen shows text content that looks like a JSON object"
+        ])
+
+        navigateBackToMainScreen()
+        try assertBackOnMainScreen(buttonId: kTestBedBtnViewLatestReferringParams)
+    }
+
+    func testViewLatestReferringParams_extractAndValidateJson() throws {
+        let button = app.buttons[kTestBedBtnViewLatestReferringParams]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        try waitForLogOutputScreen()
+
+        // AI: extract the JSON blob visible on the log output screen
+        let extracted = (try? driver.extract(["json_content_on_log_screen"])) ?? [:]
+        let raw = (extracted["json_content_on_log_screen"] as? String) ?? ""
+
+        // Soft assertion — log the extracted value for debugging but do not
+        // fail the test if extract returns empty. The test's job is to prove
+        // the navigation and round-trip works, not to enforce non-empty JSON
+        // (which may legitimately be '{}' on a fresh install).
+        let cleaned = normalizeJson(raw)
+        if !cleaned.isEmpty {
+            XCTAssertTrue(
+                cleaned.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("{"),
+                "Extracted text should look like JSON, got: \(cleaned)"
+            )
+        }
+
+        navigateBackToMainScreen()
+        try assertBackOnMainScreen(buttonId: kTestBedBtnViewLatestReferringParams)
+    }
+
+    // MARK: - Helpers
+
+    private func waitForLogOutputScreen() throws {
+        // The LogOutputViewController has its own navigation title "Logs"
+        // (see Main.storyboard navigationItem id=xBm-ZR-KfE). Wait for a
+        // navigation bar with that title to appear.
+        let logNav = app.navigationBars["Logs"]
+        if logNav.waitForExistence(timeout: 8) {
+            return
+        }
+        // Fallback: any new nav bar that isn't the main TestBed nav bar
+        let anyNav = app.navigationBars.firstMatch
+        XCTAssertTrue(
+            anyNav.waitForExistence(timeout: 5),
+            "A log output screen should be pushed after tapping the referring-params button"
+        )
+    }
+
+    private func navigateBackToMainScreen() {
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        if backButton.exists, backButton.isHittable {
+            backButton.tap()
+        } else {
+            // Fallback: swipe from the left edge to trigger the iOS back gesture
+            app.swipeRight()
+        }
+    }
+
+    private func assertBackOnMainScreen(buttonId: String) throws {
+        XCTAssertTrue(
+            app.buttons[buttonId].waitForExistence(timeout: 5),
+            "Should be back on the main screen with \(buttonId) visible"
+        )
+    }
+
+    private func normalizeJson(_ raw: String) -> String {
+        var cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.hasPrefix("\""), cleaned.hasSuffix("\""), cleaned.count >= 2 {
+            cleaned = String(cleaned.dropFirst().dropLast())
+            cleaned = cleaned.replacingOccurrences(of: "\\\"", with: "\"")
+            cleaned = cleaned.replacingOccurrences(of: "\\\\", with: "\\")
+        }
+        return cleaned
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/SessionAndLogsHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/SessionAndLogsHybridTest.swift
@@ -1,0 +1,82 @@
+//
+//  SessionAndLogsHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — XCUITest for actions, GPTDriver AI for result validation.
+//
+//  Tests session initialization, log viewing, and logout.
+//
+//  The iOS TestBed does not expose a user-facing "Init Session"
+//  button — the Branch SDK auto-initializes in AppDelegate's
+//  didFinishLaunchingWithOptions. We verify the session is alive
+//  at app launch by creating a Branch link immediately — if the
+//  session failed, link creation would return an error.
+//
+
+import gptd_swift
+import XCTest
+
+final class SessionAndLogsHybridTest: BaseGptDriverTest {
+    func testSessionAlive_generatesLinkAfterLaunch() throws {
+        // Branch SDK auto-initializes at app launch. A successful link
+        // generation within a few seconds of launch is proof that the
+        // session is alive and the SDK is responsive.
+        let url = generateBranchLink()
+
+        XCTAssertTrue(
+            url.hasPrefix("https://"),
+            "Session should be alive enough to generate a link, got: \(url)"
+        )
+        XCTAssertTrue(
+            url.contains("bnctestbed"),
+            "Link should be on the TestBed domain, got: \(url)"
+        )
+    }
+
+    func testLoadLogs_showsLogContent() throws {
+        // DETERMINISTIC: navigate to the log output screen
+        let loadLogsButton = app.buttons[kTestBedBtnLoadLogs]
+        TestScrollHelpers.scrollUntilVisible(loadLogsButton, in: app)
+        loadLogsButton.tap()
+
+        // Soft probe — best-effort log content check
+        _ = try? driver.checkBulk([
+            "A log output screen is visible",
+            "The log screen contains SDK log text entries (timestamps, " +
+                "level markers, or SDK message content)"
+        ])
+
+        // DETERMINISTIC: navigate back to the main screen
+        let backButton = app.navigationBars.buttons.element(boundBy: 0)
+        if backButton.exists, backButton.isHittable {
+            backButton.tap()
+        }
+
+        // DETERMINISTIC: confirm we're back on the main screen
+        XCTAssertTrue(
+            app.buttons[kTestBedBtnLoadLogs].waitForExistence(timeout: 5),
+            "Should be back on the main screen with the Load Logs button visible"
+        )
+    }
+
+    func testLogout_staysOnMainScreen() throws {
+        // DETERMINISTIC: scroll to and tap the logout button
+        let logoutButton = app.buttons[kTestBedBtnLogout]
+        TestScrollHelpers.scrollUntilVisible(logoutButton, in: app)
+        logoutButton.tap()
+
+        // Give the SDK a moment to complete the logout callback
+        wait(timeout: 2)
+
+        // Soft probe — best-effort confirmation check, does not fail the test
+        _ = try? driver.checkBulk([
+            "A confirmation indicator is visible showing that the user was logged out"
+        ])
+
+        // DETERMINISTIC: verify main screen is still displayed
+        XCTAssertTrue(
+            app.buttons[kTestBedBtnLogout].waitForExistence(timeout: 3),
+            "Main screen should still be visible after logout"
+        )
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/ShareLinkHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/ShareLinkHybridTest.swift
@@ -1,0 +1,89 @@
+//
+//  ShareLinkHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — XCUITest for the tap, GPTDriver AI for validating the
+//  native iOS share sheet (UIActivityViewController), which
+//  XCUITest cannot easily introspect in detail.
+//
+//  The TestBed has TWO share buttons:
+//    - "Share Branch Link" (kTestBedBtnShareLink) — basic
+//      UIActivityViewController with the Branch link.
+//    - "Share Link with LPLinkMetadata" (kTestBedBtnShareLinkWithMetadata)
+//      — same, decorated with rich LinkPresentation metadata.
+//  Both present a native iOS share sheet; the differences are
+//  only visible in the rich preview card at the top of the sheet.
+//
+
+import gptd_swift
+import XCTest
+
+final class ShareLinkHybridTest: BaseGptDriverTest {
+    func testShareBranchLink_opensShareSheet() throws {
+        // DETERMINISTIC: first generate a link so there's something to share
+        _ = generateBranchLink()
+
+        // DETERMINISTIC: tap "Share Link"
+        let shareButton = app.buttons[kTestBedBtnShareLink]
+        TestScrollHelpers.scrollUntilVisible(shareButton, in: app)
+        shareButton.tap()
+
+        // AI: validate the iOS share sheet appeared
+        try driver.assertBulk([
+            "A native iOS share sheet is visible on screen",
+            "The share sheet shows a list of sharing destinations (AirDrop, Messages, Mail, etc.) or app icons"
+        ])
+
+        // AI: dismiss the share sheet and return to the main screen
+        try driver.execute(
+            "Dismiss the share sheet (swipe down from the top of the sheet or tap Cancel) " +
+                "so the TestBed main screen is visible again"
+        )
+
+        // DETERMINISTIC: verify we're back on the main screen
+        XCTAssertTrue(
+            app.buttons[kTestBedBtnShareLink].waitForExistence(timeout: 5),
+            "Share button should be visible again on the main screen"
+        )
+    }
+
+    func testShareLinkWithMetadata_opensShareSheetWithRichPreview() throws {
+        _ = generateBranchLink()
+
+        // DETERMINISTIC: tap "Share Link with LPLinkMetadata"
+        let shareMetaButton = app.buttons[kTestBedBtnShareLinkWithMetadata]
+        TestScrollHelpers.scrollUntilVisible(shareMetaButton, in: app)
+        shareMetaButton.tap()
+
+        // AI: validate the share sheet with rich preview card
+        try driver.assert(
+            "A native iOS share sheet is visible, showing a rich preview card " +
+                "at the top of the sheet (with title, image, or subtitle text) " +
+                "from the LinkPresentation metadata, followed by a list of " +
+                "sharing destinations."
+        )
+
+        // AI: dismiss
+        try driver.execute("Dismiss the share sheet and return to the TestBed main screen")
+    }
+
+    func testShareBranchLink_containsShareContent() throws {
+        _ = generateBranchLink()
+
+        let shareButton = app.buttons[kTestBedBtnShareLink]
+        TestScrollHelpers.scrollUntilVisible(shareButton, in: app)
+        shareButton.tap()
+
+        // AI: best-effort extraction of what the share sheet exposes
+        _ = try? driver.extract(["share_subject_or_title", "share_url_or_message"])
+
+        // AI: verify at minimum that something shareable is on screen
+        try driver.assert(
+            "The share sheet is visible and contains the Branch link to share — " +
+                "either visible in a preview or implied by the destinations shown"
+        )
+
+        // AI: dismiss
+        try driver.execute("Dismiss the share sheet")
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/TrackingControlHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/TrackingControlHybridTest.swift
@@ -1,0 +1,77 @@
+//
+//  TrackingControlHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — XCUITest for button taps, GPTDriver AI for soft-probe
+//  intel only; correctness enforced deterministically.
+//
+//  Tests the "Disable Tracking" toggle. The TestBed wires the flow
+//  to a regular UIButton (kTestBedBtnDisableTracking) that calls
+//  `Branch.getInstance().setTrackingDisabled(BOOL)` — there may
+//  or may not be a visible label change depending on TestBed
+//  implementation, so the AI is used in soft-probe mode.
+//
+//  Correctness is proven by:
+//    (a) the button remains tappable after each toggle,
+//    (b) the SDK is still functional (can still generate links)
+//        after an even number of toggles.
+//
+
+import gptd_swift
+import XCTest
+
+final class TrackingControlHybridTest: BaseGptDriverTest {
+    func testToggleTracking_disablesThenEnables() throws {
+        let toggle = app.buttons[kTestBedBtnDisableTracking]
+        TestScrollHelpers.scrollUntilVisible(toggle, in: app)
+
+        // PHASE 1: tap once — tracking should flip
+        toggle.tap()
+        wait(timeout: 2)
+
+        _ = try? driver.checkBulk([
+            "The Disable Tracking button has flipped to a new state (label or " +
+                "visual style changed) or an indicator shows tracking is disabled"
+        ])
+
+        XCTAssertTrue(
+            app.buttons[kTestBedBtnDisableTracking].waitForExistence(timeout: 5),
+            "Tracking button should still be visible after first tap"
+        )
+
+        // PHASE 2: tap again — tracking should flip back
+        let toggleAgain = app.buttons[kTestBedBtnDisableTracking]
+        TestScrollHelpers.scrollUntilVisible(toggleAgain, in: app)
+        toggleAgain.tap()
+        wait(timeout: 2)
+
+        _ = try? driver.checkBulk([
+            "The Disable Tracking button has flipped back to its original state " +
+                "or an indicator shows tracking is enabled again"
+        ])
+
+        XCTAssertTrue(
+            app.buttons[kTestBedBtnDisableTracking].waitForExistence(timeout: 5),
+            "Tracking button should still be visible after second tap"
+        )
+    }
+
+    func testToggleTracking_twoTapsLeaveSDKFunctional() throws {
+        let toggle = app.buttons[kTestBedBtnDisableTracking]
+        TestScrollHelpers.scrollUntilVisible(toggle, in: app)
+
+        for _ in 0 ..< 2 {
+            toggle.tap()
+            wait(timeout: 1)
+        }
+
+        // The SDK should remain functional: generating a link should still work.
+        // Tracking OFF → link creation still works (it just doesn't report to server).
+        // After two toggles we're back to ON, so behavior should be the same as baseline.
+        let url = generateBranchLink()
+        XCTAssertTrue(
+            url.hasPrefix("https://"),
+            "SDK should still be functional after toggling tracking twice, got: \(url)"
+        )
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/UserIdentityHybridTest.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Hybrid/UserIdentityHybridTest.swift
@@ -1,0 +1,159 @@
+//
+//  UserIdentityHybridTest.swift
+//  TestBed-GPTDriverTests
+//
+//  HYBRID — XCUITest for taps, GPTDriver AI for soft probes;
+//  correctness enforced deterministically.
+//
+//  The iOS TestBed does NOT prompt for input — the
+//  setUserIDButtonTouchUpInside IBAction calls `Branch.setIdentity:`
+//  with a hardcoded `user_id2` value and, on success, pushes
+//  LogOutputViewController via
+//  `performSegueWithIdentifier:@"ShowLogOutput"`. On failure it
+//  presents a UIAlertController with the error description.
+//
+//  These tests therefore exercise the happy path (tap → log view)
+//  and the logout round-trip (tap → staysOnMain). There is no
+//  text-entry path to test until the TestBed is updated to prompt
+//  for a user ID.
+//
+
+import gptd_swift
+import XCTest
+
+final class UserIdentityHybridTest: BaseGptDriverTest {
+    func testSetUserIdentity_pushesLogOutputScreen() throws {
+        let button = app.buttons[kTestBedBtnSetUserId]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        // setIdentity is async — the callback may take a moment before
+        // performSegueWithIdentifier fires.
+        try waitForLogOutputOrAlertSettled()
+
+        // Soft probe — record what the AI sees about the identity set
+        _ = try? driver.checkBulk([
+            "A log output screen is visible showing text that mentions " +
+                "the identity was set (e.g. 'Identity set to:') or shows " +
+                "the new user ID in the content"
+        ])
+
+        navigateBackToMainScreen()
+
+        XCTAssertTrue(
+            app.buttons[kTestBedBtnSetUserId].waitForExistence(timeout: 5),
+            "Should be back on the main screen after setting identity"
+        )
+    }
+
+    func testSetUserIdentity_extractIdentityConfirmation() throws {
+        let button = app.buttons[kTestBedBtnSetUserId]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        try waitForLogOutputOrAlertSettled()
+
+        // AI: best-effort extraction of the identity value visible on
+        // the log output screen
+        _ = try? driver.extract(["identity_value", "user_id_in_log"])
+
+        navigateBackToMainScreen()
+
+        XCTAssertTrue(
+            app.buttons[kTestBedBtnSetUserId].waitForExistence(timeout: 5)
+        )
+    }
+
+    func testLogoutClearsIdentity_staysOnMainScreen() throws {
+        let logoutButton = app.buttons[kTestBedBtnLogout]
+        TestScrollHelpers.scrollUntilVisible(logoutButton, in: app)
+        logoutButton.tap()
+
+        // Branch.logoutWithCallback is async; the success alert (if any)
+        // takes a moment to present. We then dismiss it and verify the
+        // main screen is still visible.
+        wait(timeout: 3)
+
+        // iOS presents "Logout succeeded" via showAlert on success. If
+        // visible, dismiss it.
+        let alert = app.alerts.firstMatch
+        if alert.waitForExistence(timeout: 3) {
+            let okButton = alert.buttons.matching(
+                NSPredicate(format: "label IN %@", ["OK", "Done", "Dismiss"])
+            ).firstMatch
+            if okButton.exists {
+                okButton.tap()
+            } else {
+                alert.buttons.firstMatch.tap()
+            }
+        }
+
+        XCTAssertTrue(
+            app.buttons[kTestBedBtnLogout].waitForExistence(timeout: 5),
+            "Main screen should still be visible after logout"
+        )
+    }
+
+    func testSetUserIdentity_noCrashOnRapidTaps() throws {
+        // Stress smoke test: rapidly tapping Set User ID should not crash.
+        // iOS TestBed hardcodes the user_id2 value and segues to log view
+        // on each success callback — tapping twice in a row should either
+        // segue twice (second no-op) or surface an error dialog. Either
+        // way, the SDK should remain functional.
+        let button = app.buttons[kTestBedBtnSetUserId]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        try waitForLogOutputOrAlertSettled()
+        navigateBackToMainScreen()
+
+        // Second tap
+        let secondTap = app.buttons[kTestBedBtnSetUserId]
+        if secondTap.waitForExistence(timeout: 5), secondTap.isHittable {
+            secondTap.tap()
+            try waitForLogOutputOrAlertSettled()
+            navigateBackToMainScreen()
+        }
+
+        // Verify the SDK is still alive by generating a Branch link
+        let url = generateBranchLink()
+        XCTAssertTrue(
+            url.hasPrefix("https://"),
+            "SDK should still be functional after two setIdentity taps, got: \(url)"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// The iOS TestBed either pushes the log output VC on success or
+    /// shows a UIAlertController on failure. This helper waits until
+    /// one of those two states is reached, or a short timeout elapses
+    /// (in which case the test lets XCTAssert fail on the next step).
+    private func waitForLogOutputOrAlertSettled() throws {
+        let deadline = Date().addingTimeInterval(10)
+        while Date() < deadline {
+            if app.navigationBars["Logs"].exists { return }
+            if app.alerts.firstMatch.exists { return }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        }
+    }
+
+    private func navigateBackToMainScreen() {
+        // If we're on a log screen, tap the back button.
+        if app.navigationBars["Logs"].exists {
+            let backButton = app.navigationBars.buttons.element(boundBy: 0)
+            if backButton.exists, backButton.isHittable {
+                backButton.tap()
+                return
+            }
+        }
+        // If an alert is visible, dismiss it.
+        let alert = app.alerts.firstMatch
+        if alert.exists {
+            let firstButton = alert.buttons.firstMatch
+            if firstButton.exists {
+                firstButton.tap()
+            }
+        }
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/Info.plist
+++ b/Branch-TestBed/TestBed-GPTDriverTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>MOBILEBOOST_API_KEY</key>
+	<string>$(MOBILEBOOST_API_KEY)</string>
+</dict>
+</plist>

--- a/Branch-TestBed/TestBed-GPTDriverTests/README.md
+++ b/Branch-TestBed/TestBed-GPTDriverTests/README.md
@@ -1,0 +1,137 @@
+# TestBed-GPTDriverTests
+
+MobileBoost / GPTDriver hybrid test target for the Branch iOS SDK TestBed.
+
+The target follows a hybrid philosophy: **deterministic XCUITest first, AI-assisted validation only when XCTest matchers cannot express the intent**.
+
+## What is this?
+
+A UI Testing Bundle (`TestBed-GPTDriverTests.xctest`) that drives the Branch TestBed app through end-to-end scenarios and reports results to the MobileBoost cloud dashboard. Each test case:
+
+1. Performs deterministic steps via `XCUIApplication` — taps buttons by `accessibilityIdentifier`, reads text fields, asserts with `XCTAssert*`.
+2. When the assertion is visual, semantic, or multi-conditional, hands off to the [`gptd-swift`](https://github.com/MobileBoostHQ/gptd-swift) SDK — `driver.execute`, `driver.assert`, `driver.assertBulk`, `driver.extract`, `driver.checkBulk`.
+3. Reports `setSessionSucceeded` / `setSessionFailed` to the MobileBoost dashboard automatically via `BaseGptDriverTest.tearDownWithError`.
+
+## Quick start
+
+```bash
+# 1. Copy the secret template
+cd Branch-TestBed/TestBed-GPTDriverTests/Config
+cp MobileBoost.local.xcconfig.example MobileBoost.local.xcconfig
+
+# 2. Paste your MobileBoost API key into the new file
+#    (the file is gitignored — your key never leaves your machine)
+
+# 3. Run the full suite
+cd ../../..
+xcodebuild test \
+  -project Branch-TestBed/Branch-TestBed.xcodeproj \
+  -scheme TestBed-GPTDriverTests \
+  -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+To run a single class:
+
+```bash
+xcodebuild test \
+  -project Branch-TestBed/Branch-TestBed.xcodeproj \
+  -scheme TestBed-GPTDriverTests \
+  -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
+  -only-testing:TestBed-GPTDriverTests/LinkCreationHybridTest \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Each run opens a session on the MobileBoost dashboard with the `sessionURL` available via `driver.sessionURL` inside the test.
+
+## Layout
+
+```
+TestBed-GPTDriverTests/
+├── BaseGptDriverTest.swift         — base class, driver init, link helpers
+├── TestScrollHelpers.swift         — scroll-until-visible helper for below-the-fold buttons
+├── TestBed-GPTDriverTests-Bridging-Header.h
+│                                   — imports TestBedIdentifiers.h so Swift tests see the
+│                                     same accessibilityIdentifier string constants as the
+│                                     Obj-C storyboard
+├── Info.plist                      — declares MOBILEBOOST_API_KEY = $(MOBILEBOOST_API_KEY)
+├── Config/
+│   ├── MobileBoost.xcconfig        — committed, #include? of MobileBoost.local.xcconfig
+│   ├── MobileBoost.local.xcconfig  — GITIGNORED, your real key
+│   └── MobileBoost.local.xcconfig.example
+├── Deterministic/                  — 100% XCUITest, no AI
+│   └── LinkCreationDeterministicTest.swift
+├── Hybrid/                         — XCUITest actions + AI validation
+│   ├── LinkCreationHybridTest.swift
+│   ├── QRCodeHybridTest.swift
+│   ├── ShareLinkHybridTest.swift
+│   ├── SessionAndLogsHybridTest.swift
+│   ├── UserIdentityHybridTest.swift
+│   ├── EventLoggingHybridTest.swift
+│   ├── DeepLinkColdOpenHybridTest.swift
+│   ├── DeepLinkWarmOpenHybridTest.swift
+│   ├── BrowserExperienceHybridTest.swift
+│   ├── NotificationHybridTest.swift         ← XCTSkip until iOS TestBed adds button
+│   ├── TrackingControlHybridTest.swift
+│   ├── ConsumerProtectionHybridTest.swift
+│   ├── ReferringParamsHybridTest.swift
+│   └── PluginNotifyHybridTest.swift         ← XCTSkip until iOS TestBed adds button
+├── AI/                             — 100% AI-driven, no identifiers
+│   └── LinkCreationAITest.swift
+├── TestPlans/
+│   ├── Smoke.xctestplan            — fast dev-loop subset (~37s)
+│   └── Release.xctestplan          — full suite (~15m), default in scheme
+└── scripts/
+    └── format-test-results.sh      — parse xcodebuild log into markdown row
+```
+
+## Dependencies
+
+- Swift Package: `gptd-swift` (≥ 1.9.1, up to next major). Declared in the parent `Branch-TestBed.xcodeproj`.
+- iOS 14.0+ (the minimum platform declared by `gptd-swift`). The host app `Branch-TestBed` still targets iOS 12, so running these tests requires a simulator with iOS ≥ 14.
+- Runs on simulator only (code signing disabled).
+
+## Secret management
+
+The API key is resolved in this order inside `BaseGptDriverTest.resolveApiKey()`:
+
+1. Process environment variable `MOBILEBOOST_API_KEY` (set by `xcodebuild MOBILEBOOST_API_KEY=xxx`)
+2. `MOBILEBOOST_API_KEY` in the test bundle's `Info.plist`, which Xcode substitutes at build time from `Config/MobileBoost.xcconfig` (which optionally `#include?`s `MobileBoost.local.xcconfig`)
+3. Empty → `precondition` failure with a clear message pointing at the example file
+
+Copy [`Config/MobileBoost.local.xcconfig.example`](./Config/MobileBoost.local.xcconfig.example) to `Config/MobileBoost.local.xcconfig` and paste your key. The example file is committed; the real file is gitignored by the `*.local.xcconfig` rule in the repo root `.gitignore`.
+
+## Test Plans
+
+Two Xcode Test Plans live in `TestPlans/` and are wired into the `TestBed-GPTDriverTests` scheme:
+
+| Plan | Tests | Wall time | When to run |
+|---|---|---|---|
+| `Smoke.xctestplan` | 5 cherry-picked fast tests | ~37s | Every PR, tight dev loop |
+| `Release.xctestplan` | Full suite (all 16 classes) | ~15m | Before merging to release branch; default plan in the scheme |
+
+To run a specific plan from the command line:
+
+```bash
+xcodebuild test \
+  -project Branch-TestBed/Branch-TestBed.xcodeproj \
+  -scheme TestBed-GPTDriverTests \
+  -testPlan Smoke \
+  -destination "platform=iOS Simulator,name=iPhone 16,OS=latest" \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+## Pending TestBed features
+
+2 of the 16 tests are placeholders (`XCTSkip`) pending TestBed feature additions:
+
+| Test | Required TestBed feature |
+|---|---|
+| `NotificationHybridTest` | A "Send Notification" button + IBAction that schedules a local `UNNotificationRequest` carrying a Branch link |
+| `PluginNotifyHybridTest` | A "Simulate Plugin Notify Init" button + IBAction that calls `[[Branch getInstance] notifyNativeToInit]` |
+
+Both files contain header comments with the exact changes required to enable them.
+
+## See also
+
+- [`TESTING_GUIDE.md`](./TESTING_GUIDE.md) — writing new tests, philosophy, troubleshooting.

--- a/Branch-TestBed/TestBed-GPTDriverTests/TESTING_GUIDE.md
+++ b/Branch-TestBed/TestBed-GPTDriverTests/TESTING_GUIDE.md
@@ -1,0 +1,164 @@
+# Testing Guide — TestBed-GPTDriverTests
+
+A practical manual for working on the MobileBoost hybrid test suite for the iOS Branch SDK TestBed. Read this before writing a new test.
+
+## Philosophy: deterministic first, AI second
+
+Every test in this target falls into one of three modes. Pick the mode that matches the flow; do not reach for AI when plain XCUITest would do.
+
+| Use XCUITest when… | Use GPTDriver AI when… |
+|---|---|
+| An element has an `accessibilityIdentifier` in `TestBedIdentifiers.h` | Validating visual output (QR code image, chart, share sheet preview) |
+| The action is a simple tap / type / swipe | Extracting data from a modal (`driver.extract`) |
+| The assertion is exact text or state | Navigating across apps (Safari ↔ TestBed, Settings ↔ TestBed) |
+| The flow is stable | Asserting semantic correctness (`driver.assert`) |
+| Speed & determinism matter (sub-second feedback loops) | A step is flaky or the UI is undergoing change |
+
+**Rule of thumb:** if you can write the test in 5 lines of XCUITest, do that. Every call to the AI driver costs cloud round-trip time and incurs MobileBoost usage.
+
+## The three modes in this repo
+
+- **Deterministic** (`Deterministic/`) — 100% XCUITest. No `driver.*` calls except session lifecycle (handled by `BaseGptDriverTest.tearDownWithError`).
+- **Hybrid** (`Hybrid/`) — XCUITest for the actions the storyboard identifiers can express, AI for validations XCTest cannot.
+- **AI** (`AI/`) — 100% GPTDriver. No `accessibilityIdentifier` or `XCUIElement` queries. The agent reads the screen and acts autonomously.
+
+The same flow should typically live in all three modes as separate test classes, giving you structural coverage (Deterministic), UX coverage (Hybrid), and resilience coverage (AI).
+
+## Writing a new test
+
+1. **Subclass `BaseGptDriverTest`.**
+2. **Prefer identifiers from `TestBedIdentifiers.h`.** They are exposed to Swift through the bridging header. If the control you need has no identifier, add one in `TestBedIdentifiers.h/.m` and `Main.storyboard` — those changes ship in a separate PR under `Branch-TestBed`, not in the test target.
+3. **Reuse the base helpers:**
+   - `generateBranchLink(timeout:)` — taps Create Branch Link and polls the text field until a real HTTPS URL appears.
+   - `waitForLinkInField(_:timeout:)` — raw polling helper.
+   - `TestScrollHelpers.scrollUntilVisible(_:in:)` — scrolls a container until a below-the-fold element is hittable.
+4. **Use `try driver.*` for AI calls.** All GPTDriver methods throw. In tearDown we use `try?` on `setSessionSucceeded` / `setSessionFailed` because those shouldn't hide real test failures.
+5. **Do NOT call `driver.setSessionSucceeded()` inside your test methods.** Session status is set automatically by `tearDownWithError` based on `testRun.failureCount`. Calling it manually in a passing branch can create false positives on failed runs.
+6. **Check lint before committing:** `swiftformat TestBed-GPTDriverTests/` and `swiftlint lint --quiet TestBed-GPTDriverTests/` should both report zero warnings.
+
+## Minimal test skeleton
+
+```swift
+import XCTest
+
+final class MyFeatureHybridTest: BaseGptDriverTest {
+    func testFeature_behavesAsExpected() throws {
+        // DETERMINISTIC: drive the UI with identifiers
+        let button = app.buttons[kTestBedBtnMyFeature]
+        TestScrollHelpers.scrollUntilVisible(button, in: app)
+        button.tap()
+
+        // DETERMINISTIC: cheap structural assertion
+        XCTAssertTrue(app.staticTexts["Success"].waitForExistence(timeout: 5))
+
+        // AI: semantic / multi-condition validation
+        try driver.assertBulk([
+            "A confirmation message is visible to the user",
+            "The message does not contain the word 'Error'"
+        ])
+    }
+}
+```
+
+## Deep link tests — launch argument hook
+
+`DeepLinkColdOpenHybridTest`, `DeepLinkWarmOpenHybridTest`, and `BrowserExperienceHybridTest` simulate Safari → app Universal Link handoff via a test-only hook in `Branch-TestBed/Branch-TestBed/AppDelegate.m`:
+
+```objc
+#if DEBUG
+NSString *testDeepLinkURL = [[NSUserDefaults standardUserDefaults] stringForKey:@"testDeepLinkURL"];
+if (testDeepLinkURL.length > 0) {
+    NSURL *url = [NSURL URLWithString:testDeepLinkURL];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        NSUserActivity *activity = [[NSUserActivity alloc]
+            initWithActivityType:NSUserActivityTypeBrowsingWeb];
+        activity.webpageURL = url;
+        [self application:application
+             continueUserActivity:activity
+               restorationHandler:^(NSArray * _Nullable r) {}];
+    });
+}
+#endif
+```
+
+The hook reads a `-testDeepLinkURL <url>` launch argument and, if present, constructs an `NSUserActivity` of type `NSUserActivityTypeBrowsingWeb` and calls `application:continueUserActivity:` after a 1.5s delay (enough for `Branch.initSessionWithLaunchOptions` to register its handler). The Branch SDK resolution path is **byte-for-byte identical** to a real Safari Universal Link handoff — the SDK has no way to tell the synthetic delivery apart from the real thing.
+
+**Why this is necessary on simulator:** Universal Link handoff via Safari requires the app to be code-signed with the `com.apple.developer.associated-domains` entitlement embedded in the signature. Tests run unsigned via `CODE_SIGNING_ALLOWED=NO`, so the `swcutil` daemon never associates the app with `bnctestbed.test-app.link` and Safari does not hand off. The hook bypasses Safari entirely while still exercising the full SDK code path.
+
+**Safety:** the hook is wrapped in `#if DEBUG` so it never ships in Release builds, and it requires an explicit launch argument — no production code path can accidentally trigger it.
+
+**Test flow** (all 3 tests follow this pattern):
+
+1. Generate a real Branch link via the existing TestBed UI and extract the URL via `driver.extract`.
+2. `app.terminate()` (cold) or `XCUIDevice.shared.press(.home)` (warm).
+3. Set `app.launchArguments += ["-testDeepLinkURL", generatedUrl]` and call `app.launch()` again.
+4. Wait ~5 seconds for the AppDelegate hook to fire and Branch SDK to resolve the link.
+5. Verify Branch's `handleDeepLinkParams` auto-pushed `LogOutputViewController` (signaled by the navigation bar titled "Logs") and that the visible JSON contains expected metadata keys (`~channel`, `~feature`, `+match_guaranteed`, `+clicked_branch_link`, etc.).
+
+## StoreKit / IAP tests
+
+`EventLoggingHybridTest` covers both real IAP purchases and subscriptions. These flows present a StoreKit sheet driven by `TestStoreKitConfig.storekit` (already in the TestBed bundle). The scheme must be configured to load the storekit config when the test target launches — this is set in `TestBed-GPTDriverTests.xcscheme` by default.
+
+Each event test gives the AI a chance to dismiss the StoreKit sheet via `try? driver.execute("Dismiss any StoreKit dialog if one is visible")` before re-asserting that the main screen is visible.
+
+## API key resolution
+
+`BaseGptDriverTest.resolveApiKey()` tries, in order:
+
+1. `MOBILEBOOST_API_KEY` process environment variable (set by `xcodebuild MOBILEBOOST_API_KEY=xxx`).
+2. `MOBILEBOOST_API_KEY` in the test bundle's Info.plist, which Xcode substitutes at build time from `Config/MobileBoost.xcconfig` (which optionally `#include?`s `MobileBoost.local.xcconfig`).
+3. Empty string → `precondition` failure with a clear message pointing at the example file.
+
+The real `MobileBoost.local.xcconfig` is gitignored by the `*.local.xcconfig` rule in the repo root `.gitignore`.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `precondition failed: MOBILEBOOST_API_KEY not configured` | No `MobileBoost.local.xcconfig` and no env var | Copy the template and fill in your key, or `export MOBILEBOOST_API_KEY=…` before `xcodebuild` |
+| Linker error `_kTestBedBtn…` undefined | `TestBedIdentifiers.m` not linked into the test target | Verify it's listed in Compile Sources of `TestBed-GPTDriverTests`; the xcodeproj gem script adds it automatically |
+| `module map file 'ObjCExceptionCatcher.modulemap' not found` | Building with `-target` instead of `-scheme` | Always use `-scheme TestBed-GPTDriverTests` for builds; SPM dependency resolution requires a scheme |
+| Deep link test never sees the LogOutput screen | The AppDelegate `#if DEBUG` hook is missing or the launch argument is misspelled | Verify `Branch-TestBed/AppDelegate.m` still has the `testDeepLinkURL` block, and check that the test passes `["-testDeepLinkURL", url]` (exactly that key, dash-prefixed) |
+| SwiftFormat and SwiftLint disagree on trailing commas | Default-config mismatch between the two tools | This directory has a local `.swiftformat` that disables `trailingCommas` — if you see the conflict, that file is the fix |
+| Tests run but session shows `failed` on dashboard even though `XCTAssert` passed | Forgot that session status is auto-set in tearDown | Remove any manual `driver.setSessionSucceeded()` calls from test bodies — they're redundant and fragile |
+
+## Pre-merge checklist for new tests
+
+Before declaring a new test ready for review:
+
+- [ ] Consistent test class name (`XxxHybridTest` / `XxxDeterministicTest` / `XxxAITest`).
+- [ ] Each `func test…()` method covers a distinct scenario with a descriptive name.
+- [ ] Tagged `Release` or `Smoke` via the appropriate test plan in `TestBed-GPTDriverTests.xcscheme`.
+- [ ] A single Branch SDK API is exercised per class where possible (Link creation, Event, ReferringParams, …).
+- [ ] Platform-specific quirks are documented in the test class header comment.
+- [ ] New identifiers (if any) added to `TestBedIdentifiers.h/.m` AND `Main.storyboard`.
+- [ ] `swiftformat` + `swiftlint` are green.
+- [ ] `xcodebuild build-for-testing -scheme TestBed-GPTDriverTests` succeeds.
+- [ ] Flaky steps are flagged with code comments noting the known limitation.
+
+## Scope of what this target does NOT cover
+
+- **Unit tests for the SDK itself.** Those live in `Branch-SDK-Tests` and `Branch-SDK-Unhosted-Tests` under the same Xcode project. This target is strictly E2E on the TestBed app.
+- **The legacy `Branch-TestBed-UITests` suite.** That bundle ships with Obj-C XCUITests that predate GPTDriver and remain as fast local smoke tests. Do not migrate them here — this target is the dedicated AI-assisted hybrid test layer and should not absorb the legacy smoke suite.
+- **Device testing.** Everything here assumes simulator. Physical-device runs require code signing + provisioning work that is out of scope.
+- **CI integration.** The existing `.github/workflows/gptdriverautomation.yml` workflow handles the Path-A AI-only JSON suites under `gptdriver/` on `Release-*` branches. A future PR will add a `build-for-testing` job to run this target as well.
+
+## AI-only JSON suites ↔ hybrid class mapping
+
+The repo already ships 27 AI-only JSON suites under `gptdriver/` that exercise the TestBed via Appium + MobileBoost cloud. Each hybrid class in this target has a rough counterpart among those JSONs — the JSON describes the same scenario in narrative form for the AI-only runner. A non-exhaustive mapping:
+
+| Hybrid test class | AI-only JSON suite(s) |
+|---|---|
+| `LinkCreationHybridTest` | `create-branch-link.json`, `create-deep-link.json` |
+| `QRCodeHybridTest` | `qr-code-generation.json`, `qr-code-test.json` |
+| `EventLoggingHybridTest` | `event-commerce.json`, `event-content.json`, `event-lifecycle.json` |
+| `ReferringParamsHybridTest` | `first-referring-params.json`, `latest-referring-params.json` |
+| `DeepLinkColdOpenHybridTest` | `cold-open-universal-link.json`, `universal-link-cold-open-*.json`, `uri-scheme-cold-start-*.json` |
+| `DeepLinkWarmOpenHybridTest` | `warm-open-via-universal-link.json`, `uri-scheme-warm-open-*.json` |
+| `UserIdentityHybridTest` | `set-user-id.json`, `simulate-logout.json` |
+| `ShareLinkHybridTest` | `share-sheet-test.json` |
+| `TrackingControlHybridTest` | `tracking-toggle.json` |
+| `ConsumerProtectionHybridTest` | `set-dma-params.json` |
+
+The two paths coexist: the AI-only suites run on MobileBoost cloud via Appium; the hybrid tests run locally or in CI via `xcodebuild test`. Both report to the same MobileBoost dashboard.

--- a/Branch-TestBed/TestBed-GPTDriverTests/TestBed-GPTDriverTests-Bridging-Header.h
+++ b/Branch-TestBed/TestBed-GPTDriverTests/TestBed-GPTDriverTests-Bridging-Header.h
@@ -1,0 +1,10 @@
+//
+//  TestBed-GPTDriverTests-Bridging-Header.h
+//  TestBed-GPTDriverTests
+//
+//  Exposes the Objective-C TestBedIdentifiers.h constants to Swift
+//  test code, so tests can query controls using the exact same
+//  identifier strings used by Main.storyboard.
+//
+
+#import "TestBedIdentifiers.h"

--- a/Branch-TestBed/TestBed-GPTDriverTests/TestPlans/L1Validation.xctestplan
+++ b/Branch-TestBed/TestBed-GPTDriverTests/TestPlans/L1Validation.xctestplan
@@ -1,0 +1,32 @@
+{
+  "configurations" : [
+    {
+      "id" : "B4F1A7D1-3E7E-4F92-9E55-9C5D6E5F22A1",
+      "name" : "L1Validation",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Branch-TestBed.xcodeproj",
+      "identifier" : "AAC5A9A76F3DBB04E6638F31",
+      "name" : "TestBed-GPTDriverTests"
+    }
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "L1WireValidationTest\/testInstallRequestEmitsWirePayload()"
+      ],
+      "target" : {
+        "containerPath" : "container:Branch-TestBed.xcodeproj",
+        "identifier" : "AAC5A9A76F3DBB04E6638F31",
+        "name" : "TestBed-GPTDriverTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/TestPlans/Release.xctestplan
+++ b/Branch-TestBed/TestBed-GPTDriverTests/TestPlans/Release.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "23F687DE-A2EF-4FC1-8244-4E061C07018A",
+      "name" : "Release",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Branch-TestBed.xcodeproj",
+      "identifier" : "AAC5A9A76F3DBB04E6638F31",
+      "name" : "TestBed-GPTDriverTests"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Branch-TestBed.xcodeproj",
+        "identifier" : "AAC5A9A76F3DBB04E6638F31",
+        "name" : "TestBed-GPTDriverTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/TestPlans/Smoke.xctestplan
+++ b/Branch-TestBed/TestBed-GPTDriverTests/TestPlans/Smoke.xctestplan
@@ -1,0 +1,35 @@
+{
+  "configurations" : [
+    {
+      "id" : "0567288E-8382-469B-BD18-6D37C3B9CC6E",
+      "name" : "Smoke",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Branch-TestBed.xcodeproj",
+      "identifier" : "AAC5A9A76F3DBB04E6638F31",
+      "name" : "TestBed-GPTDriverTests"
+    }
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "LinkCreationDeterministicTest",
+        "LinkCreationHybridTest\/testCreateBranchLink_fullValidation()",
+        "SessionAndLogsHybridTest\/testSessionAlive_generatesLinkAfterLaunch()",
+        "TrackingControlHybridTest\/testToggleTracking_twoTapsLeaveSDKFunctional()"
+      ],
+      "target" : {
+        "containerPath" : "container:Branch-TestBed.xcodeproj",
+        "identifier" : "AAC5A9A76F3DBB04E6638F31",
+        "name" : "TestBed-GPTDriverTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/TestScrollHelpers.swift
+++ b/Branch-TestBed/TestBed-GPTDriverTests/TestScrollHelpers.swift
@@ -1,0 +1,52 @@
+//
+//  TestScrollHelpers.swift
+//  TestBed-GPTDriverTests
+//
+//  Small XCUITest helpers shared across hybrid tests. XCUITest has
+//  no built-in "scroll until visible" primitive — elements below
+//  the fold must be scrolled into view before they become hittable.
+//  These helpers do that by swiping up on the first table (or
+//  scrollView) until the element is visible, with a bounded number
+//  of retries.
+//
+
+import XCTest
+
+enum TestScrollHelpers {
+    /// Polls the given element and swipes up on the main scrolling
+    /// container until the element becomes hittable or the maxSwipes
+    /// budget is exhausted. Silently succeeds if the element is
+    /// already visible.
+    static func scrollUntilVisible(
+        _ element: XCUIElement,
+        in app: XCUIApplication,
+        maxSwipes: Int = 8
+    ) {
+        if element.exists, element.isHittable { return }
+
+        let scrollContainer = firstScrollingContainer(in: app)
+        var swipes = 0
+        while swipes < maxSwipes {
+            if element.exists, element.isHittable { return }
+            scrollContainer.swipeUp()
+            swipes += 1
+        }
+
+        // Last-resort existence wait so the caller's subsequent tap
+        // fails with a clear message rather than a silent no-op.
+        _ = element.waitForExistence(timeout: 2)
+    }
+
+    private static func firstScrollingContainer(in app: XCUIApplication) -> XCUIElement {
+        let table = app.tables.firstMatch
+        if table.exists { return table }
+
+        let collection = app.collectionViews.firstMatch
+        if collection.exists { return collection }
+
+        let scrollView = app.scrollViews.firstMatch
+        if scrollView.exists { return scrollView }
+
+        return app
+    }
+}

--- a/Branch-TestBed/TestBed-GPTDriverTests/scripts/format-test-results.sh
+++ b/Branch-TestBed/TestBed-GPTDriverTests/scripts/format-test-results.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# format-test-results.sh
+#
+# Parses an `xcodebuild test` log file and emits a single markdown table row
+# summarizing the run, useful for pasting into review notes or PR
+# descriptions after a local run of the TestBed-GPTDriverTests target.
+#
+# Usage:
+#   ./format-test-results.sh <path-to-xcodebuild-log>
+#
+# Optional environment overrides (auto-detected from the log when possible):
+#   SDK_VERSION   — version string to print in the row (default: <unknown>)
+#   DESTINATION   — destination string to print in the row (default: parsed
+#                   from the log or <unknown>)
+#   PLAN_NAME     — test plan name to print as a small note (default: parsed)
+#
+# Output: one markdown table row, e.g.
+#   | 2026-04-15 | 3.14.0 | iPhone 16 / iOS 18.4 | ✅ pass | 37 | 0 | 2 | 15m 24s |
+#
+# Exit code: 0 always (so the helper never breaks a CI pipeline). The row's
+# Result column reflects the underlying xcodebuild exit when present in the
+# log via "xcodebuild exit=N".
+
+set -uo pipefail
+
+LOG_FILE="${1:-}"
+
+if [[ -z "$LOG_FILE" ]]; then
+  echo "usage: $0 <path-to-xcodebuild-log>" >&2
+  exit 0
+fi
+
+if [[ ! -f "$LOG_FILE" ]]; then
+  echo "error: log file not found: $LOG_FILE" >&2
+  exit 0
+fi
+
+# ---- counts ----
+# `grep -c` always outputs a number on its own; the `|| true` swallows the
+# non-zero exit code that grep returns when there are zero matches, so this
+# never triggers `set -e` style behaviour from a calling script.
+PASSED=$(grep -cE "^Test Case .* passed " "$LOG_FILE" 2>/dev/null || true)
+FAILED=$(grep -cE "^Test Case .* failed " "$LOG_FILE" 2>/dev/null || true)
+SKIPPED=$(grep -cE "^Test Case .* skipped " "$LOG_FILE" 2>/dev/null || true)
+PASSED=${PASSED:-0}
+FAILED=${FAILED:-0}
+SKIPPED=${SKIPPED:-0}
+
+# ---- runtime ----
+# xcodebuild prints lines like:
+#   Executed 39 tests, with 2 tests skipped and 0 failures (0 unexpected) in 924.059 (924.106) seconds
+RUNTIME_SECONDS=$(grep -E "^[[:space:]]*Executed [0-9]+ tests, with " "$LOG_FILE" \
+  | tail -1 \
+  | sed -E 's/.*in ([0-9.]+).*/\1/' \
+  || echo "0")
+
+# Format runtime as Mm SSs (round seconds)
+if [[ "$RUNTIME_SECONDS" =~ ^[0-9.]+$ ]]; then
+  RUNTIME_INT=$(printf "%.0f" "$RUNTIME_SECONDS")
+  MINUTES=$((RUNTIME_INT / 60))
+  SECONDS=$((RUNTIME_INT % 60))
+  if [[ $MINUTES -gt 0 ]]; then
+    RUNTIME_STR="${MINUTES}m ${SECONDS}s"
+  else
+    RUNTIME_STR="${SECONDS}s"
+  fi
+else
+  RUNTIME_STR="<unknown>"
+fi
+
+# ---- result emoji ----
+EXIT_LINE=$(grep -E "^xcodebuild exit=" "$LOG_FILE" 2>/dev/null | tail -1)
+if [[ -n "$EXIT_LINE" ]]; then
+  EXIT_CODE=$(echo "$EXIT_LINE" | sed -E 's/^xcodebuild exit=([0-9]+).*/\1/')
+else
+  EXIT_CODE=""
+fi
+
+if [[ "$FAILED" -eq 0 ]] && [[ "$EXIT_CODE" == "0" || -z "$EXIT_CODE" ]]; then
+  RESULT="✅ pass"
+elif [[ "$FAILED" -gt 0 ]]; then
+  RESULT="❌ fail"
+else
+  RESULT="⚠️ unknown"
+fi
+
+# ---- destination (parse from log if not provided) ----
+if [[ -z "${DESTINATION:-}" ]]; then
+  # xcodebuild echoes the chosen destination in lines like:
+  #   { platform:iOS Simulator, ... OS:18.4, name:iPhone 16 }
+  DEST_LINE=$(grep -E "^\s*\{ platform:iOS Simulator.*name:[A-Za-z]" "$LOG_FILE" 2>/dev/null | head -1 || true)
+  if [[ -n "$DEST_LINE" ]]; then
+    DEVICE_NAME=$(echo "$DEST_LINE" | sed -E 's/.*name:([^,}]+).*/\1/' | xargs)
+    OS_VERSION=$(echo "$DEST_LINE" | sed -E 's/.*OS:([0-9.]+).*/\1/' | xargs)
+    DESTINATION="${DEVICE_NAME} / iOS ${OS_VERSION}"
+  else
+    DESTINATION="<unknown>"
+  fi
+fi
+
+# ---- plan name (parse from log if not provided) ----
+if [[ -z "${PLAN_NAME:-}" ]]; then
+  PLAN_LINE=$(grep -E "Test Plan: " "$LOG_FILE" 2>/dev/null | head -1 || true)
+  if [[ -n "$PLAN_LINE" ]]; then
+    PLAN_NAME=$(echo "$PLAN_LINE" | sed -E 's/.*Test Plan: ([A-Za-z0-9_-]+).*/\1/')
+  else
+    PLAN_NAME=""
+  fi
+fi
+
+# ---- date (today, ISO) ----
+RUN_DATE=$(date -u +%Y-%m-%d)
+
+# ---- SDK version ----
+SDK_VERSION="${SDK_VERSION:-<unknown>}"
+
+# ---- emit row ----
+printf "| %s | %s | %s | %s | %s | %s | %s | %s |\n" \
+  "$RUN_DATE" \
+  "$SDK_VERSION" \
+  "$DESTINATION" \
+  "$RESULT" \
+  "$PASSED" \
+  "$FAILED" \
+  "$SKIPPED" \
+  "$RUNTIME_STR"
+
+# ---- helpful stderr summary so the user knows which table to paste into ----
+{
+  echo ""
+  echo "Run date:    $RUN_DATE"
+  echo "Plan:        ${PLAN_NAME:-<not parsed>}"
+  echo "Destination: $DESTINATION"
+  echo "Pass / Fail / Skip: $PASSED / $FAILED / $SKIPPED"
+  echo "Runtime:     $RUNTIME_STR"
+  echo "Result:      $RESULT"
+  if [[ -n "${PLAN_NAME:-}" ]]; then
+    echo ""
+    echo "→ Test plan: ${PLAN_NAME}"
+  fi
+} >&2


### PR DESCRIPTION
Ports the GPTDriver hybrid E2E suite from `master` to `4.0.0-beta.0`. Beta had zero files under `Branch-TestBed/TestBed-GPTDriverTests/` and no `TestBed-GPTDriverTests` scheme, so the branch had no E2E coverage at all. Android closed the equivalent gap on its beta in #1382.

Four layers, all required for the suite to run: the suite files, the `gptd-swift` package, the Xcode target graft, and the TestBed app instrumentation.

## Commits

| commit | what |
| --- | --- |
| `038d2e0a` | `gptd-swift` package reference, nothing consuming it yet |
| `3f3d89c5` | the 30 suite files, inert — no target wiring |
| `c2555b54` | the target, the scheme, `TestBedIdentifiers.h/.m` |
| `7ff3f2b9` | 24 accessibility identifiers, plus the tracking toggle |
| `40e7bc0d` | the notification / plugin-notify host controls |

## Verification

| check | result |
| --- | --- |
| `project.pbxproj` graft | +302 / **-0** — purely additive, no existing line disturbed |
| beta's `HEADER_SEARCH_PATHS` | 8 before, 8 after |
| corruption markers | zero `(null)` build files, zero orphan `PBXBuildFile` |
| `TestBed-GPTDriverTests` | TEST BUILD SUCCEEDED |
| `Branch-TestBed`, `BranchSDKTests` | BUILD SUCCEEDED |
| `L1WireValidationTest` on beta | passed, 11.8s |
| storyboard identifier uniqueness | zero duplicates |
| `BranchSDKTests` regression | 483 executed / 475 passed / 8 failed, identical failing set to the branch base |

The pbxproj was grafted by hand rather than through a project-editing tool, because scripted edits to this file produced `(null)` build files, a dropped `DevelopmentTeam` and stripped group names on #1607 and had to be reverted. The zero-deletion diff is the receipt that nothing existing moved.

The regression bar is the failing-test **set**, not a count: base `c0475277` and HEAD both fail exactly `BNCKeyChainTests` x7 plus `BNCApplicationTests.testAppDates`, measured in the same session on the same simulator. The absolute number drifts with the runtime, since the keychain failures are `errSecMissingEntitlement` under `CODE_SIGNING_ALLOWED=NO`.

## Premises that did not survive contact

Four things stated when this was scoped turned out to be wrong, all verified by measurement:

- **`setTrackingDisabled` no longer exists on beta** — zero hits in `Sources/BranchSDK/Public/*.h` and in `Branch.m`, not even a deprecated shim. The new Disable Tracking button drives `-[Branch setConsumerProtectionAttributionLevel:]`, toggling `BranchAttributionLevelNone` against `Full`. Same intent, different API, and the code says so.
- **Beta's storyboard was not identifier-free.** It carried 5 `accessibilityConfiguration` entries, 4 of them sharing the identifier `tracking` — including the Consumer Protection Preference button. A repeated identifier makes `app.buttons["tracking"]` ambiguous under XCUI, so those four were resolved to their real identifiers rather than merely added to.
- **The 2 code-set identifiers had no host control on beta.** `notificationButton` and `pluginButton` originate in `eb264885`, not `46c5a7bf`; without them the constants wire to nothing. `40e7bc0d` ports the TestBed side of that commit.
- **The 483 / 6 baseline does not reproduce.** The base commit itself fails 8 on current runtimes, and the two `BranchConfigurationControllerTests` failures previously flagged for triage now pass.

## Worth a reviewer's attention

`40e7bc0d` touches `AppDelegate.m` — 20 added lines, nothing removed, Branch init untouched. That file overlaps #1614 and #1625. The commit is deliberately self-contained so it can be reverted alone if either lands first.

The `UNUserNotificationCenter` delegate lives in `AppDelegate` rather than `ViewController` because it must be assigned before the app finishes launching, and `viewDidLoad` runs after `didFinishLaunchingWithOptions:` returns. Moving it to dodge the overlap would break a documented contract.

## Out of scope

- **`layer1-logger-tests.yml` and its scripts.** The L1 log-parsing pipeline needs `run_l1_instrumented.sh`, `validate_l1_logs.py` and `test_validate_l1_logs.py`, none of which exist on beta, so a literal port lands a gate that fails on every run. It gets its own ticket. `L1WireValidationTest.swift` — the XCUI test that is this ticket's deterministic gate — came with the suite and passes.
- **`gptdriver-release.yml`.** Two runs ever, both failed, and #1608 removes it on master.
- Triaging the pre-existing `BNCKeyChain` and `BNCApplication` failures, which are environmental under unsigned builds.

## Noticed in passing, not touched

`TrackingControlHybridTest` sits on the consumer-protection surface that EMT-3699 and the attribution-level work are still moving. It passes queries against the new control, but it may want revisiting once that surface settles.

## CI gate

`3c7540e3` adds `.github/workflows/gptdriver-e2e.yml`, written for this branch rather than ported. Two jobs, because the suite has two halves with very different costs:

- **`deterministic`** — runs `L1WireValidationTest` only. References no secret at all, and runs on pushes to the beta line and on pull requests targeting `4.0.0-beta.0`.
- **`full-suite`** — runs `Release.xctestplan`. Gated on `workflow_dispatch` or a push to `Release-*`, and `needs: deterministic`, so the device-farm minutes are never spent on a build that does not link.

`MOBILEBOOST_API_KEY` reaches the build by writing the gitignored `Config/MobileBoost.local.xcconfig`, never as an `xcodebuild MOBILEBOOST_API_KEY=…` argument — that form puts the key in argv where `ps` can read it for the length of the run, which is the exposure master's own workflow comments warn about.

`gptdriver-release.yml` is deliberately not the basis for this. It never runs `xcodebuild test` and never touches the XCUI suite — it builds the app, zips it, and shells out to a `mobileboost run` CLI. It is a different execution model, not an older version of this one, and #1608 removes it on master.

## What the deterministic gate does and does not prove

`L1WireValidationTest` is worth reading before trusting its name. It asserts that the TestBed reaches `runningForeground`, then waits 8 seconds unconditionally. It does not read or validate any wire payload — that was the job of `validate_l1_logs.py`, which parses `branchlogs.txt` and is not on this branch.

So the gate proves: the TestBed builds against beta's SDK, the test target compiles and links, `gptd-swift` resolves, and the app launches and stays up. That is a real gate and worth running on every PR. It is not wire validation, and the ticket's "deterministic subset passes" criterion should be read with that in mind.

The full suite has still never been run on beta. Its first run is a measurement, not a target — master's 39/39 in 15m10s is a reference point from a different branch.

## First full-suite run on beta, the recorded result

**40 tests, 36 passed, 4 failed**, iPhone 16e / iOS 26.3.1. Master's reference of 39/39 was measured on a different branch and on iOS 18.4, so it is a reference point rather than a target.

The four failures are all one root cause, and it is not in the ported suite. `DeepLinkColdOpenHybridTest`, `DeepLinkWarmOpenHybridTest`, `BrowserExperienceHybridTest` and `NotificationHybridTest` each assert that Branch's deep-link handler pushes a Logs screen. On this branch `requestDeepLinkData:` delivers `{}` to every caller: `BranchRequestDeepLink.m` fires the callback before `attemptToSendOpen:`, and the resolved link data from `/v3/deeplink` is never persisted to `sessionParams`, which is written only from the open response. Across the run, all 47 `Deep linked with params:` lines are `{ }` and the render branch is never taken. Tracked as EMT-4023; no app-side change can render data the SDK discards, and the TestBed-side rendering is prepared on `wip/emt-3998-deeplink-render` to land once that is fixed.

An earlier run of the same suite returned 31/40. The five additional passes come from `ea08c742`, and one `QRCodeHybridTest` case failed in that run on an AI step and passed in this one.

## Two defects fixed here that predate this port

**The Consumer Protection button fired two actions.** `Main.storyboard` bound both `changeConsumerProtectionAttributionLevel:` and a stray `goToPasteControlPressed:` to the same control, so one tap opened the action sheet and also pushed the Paste Controls screen underneath it, and five `ConsumerProtectionHybridTest` cases then looked for the button on the wrong screen. The wiring is identical on `master`, including at `8ef0f4b7`, the commit of the 39/39 baseline. It stayed invisible because iOS 18.4 drops that second push while iOS 26.3.1 performs it, confirmed with a standalone two-action repro run on both runtimes. `master` needs the same one-line deletion before its CI moves to iOS 26.

**The tracking toggle read its own state from a button title.** Introduced by `7ff3f2b9` in this PR. The title resets from the storyboard on every launch while the attribution level it toggles persists to defaults, so after a relaunch following an odd number of taps the button read "Disable Tracking" while the SDK was already at `None`. That matters beyond cosmetics: `Branch.m:1969` gates the automatic open on `![Branch attributionLevelNone]`, so an app left at `None` never initialises and every later request fails with `BNCInitError`. In a suite where every test relaunches rather than reinstalls, one leaked `None` would poison every test after it. `34144cff` derives the state from `+[Branch attributionLevelNone]` instead.


## Reproduced on a second run, and the blockers are now open

Dispatched the full suite again on this branch: [run 31827759729](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/actions/runs/31827759729). Same result as the recorded run — **40 tests, 36 passed, 4 failed** — on iPhone 16 Plus / iOS 26.2 rather than iPhone 16e / iOS 26.3.1. The same four cases fail on a different device and OS, which rules out a simulator-specific flake and confirms the cause is the SDK path described above.

The SDK work those four depend on is now open, stacked in this order: EMT-4028: teach the request queue to recognise the 4.0 open and deep-link classes (#1632) → EMT-4023: persist the resolved deep link payload where it arrives (#1633) → EMT-4029: consult the URL filters before resolving a deep link (#1634) → EMT-4027: detect a first launch on the 4.0 open path (#1635). The TestBed-side rendering prepared on `wip/emt-3998-deeplink-render` lands under EMT-4040, not here.

The four stay in the suite. `full-suite` runs only on `workflow_dispatch` or a push to `Release-*`, so they are not part of this PR's checks and block nothing today. Leaving them in keeps the signal for the one moment it matters, which is cutting a release.
