### PR TITLE
EMT-4024: remove the stray paste-control action from the Consumer Protection button

### DIFF
--- a/Branch-TestBed/Branch-TestBed/Main.storyboard
+++ b/Branch-TestBed/Branch-TestBed/Main.storyboard
@@ -840,7 +840,6 @@
                                                     </state>
                                                     <connections>
                                                         <action selector="changeConsumerProtectionAttributionLevel:" destination="i3m-ex-Bu1" eventType="touchUpInside" id="eif-fe-3JM"/>
-                                                        <action selector="goToPasteControlPressed:" destination="i3m-ex-Bu1" eventType="touchUpInside" id="oct-dQ-HLq"/>
                                                     </connections>
                                                 </button>
                                             </subviews>


### PR DESCRIPTION
### The defect

In `Branch-TestBed/Branch-TestBed/Main.storyboard`, the "Consumer Protection Preference" button (`btn_consumer_protection_level`) carried **two** `touchUpInside` actions:

- `changeConsumerProtectionAttributionLevel:` — its own, correct action
- `goToPasteControlPressed:` — stray, belongs to the "Go To Paste Control View" button

`goToPasteControlPressed:` runs `performSegueWithIdentifier:@"GoToPasteControlView"`, so a single tap on Consumer Protection both presented the attribution-level action sheet **and** pushed the Paste Controls screen underneath it. Dismissing the sheet left the user on Paste Controls instead of the main TestBed screen.

This PR deletes that one stray action. The legitimate binding on "Go To Paste Control View" is untouched — `goToPasteControlPressed` goes from 2 occurrences in the file to 1.

### Why the E2E baseline never caught it

The runtime decides whether the second action fires. iOS 18.4 drops the push; iOS 26.3.1 performs it. The 39/39 E2E baseline on `master` ran on the runtime that masks the bug. Once the runtime performs the push, five `ConsumerProtectionHybridTest` cases fail, because the assertions run against the Paste Controls screen rather than the main screen.

The equivalent fix landed on the `4.0.0-beta.0` line in `ea08c742`.

### Functional verification

A temporary keyless `XCTestCase` (no MobileBoost API key, importing only `XCTest`) launched the app on **iPhone 16e / iOS 26.3.1**, scrolled to the Consumer Protection button, tapped it, dismissed the action sheet, and asserted the navigation bar was still the main screen. Same test, same simulator, only the storyboard line differing:

| Working tree | Result |
| --- | --- |
| Stray action present (before) | **FAILED** — `XCTAssertFalse failed - Tapping Consumer Protection navigated to Paste Controls`, plus `Main TestBed screen is no longer on top` |
| Stray action removed (after) | **PASSED** — action sheet still presents, `"Paste Controls"` navigation bar absent, main screen still on top |

The probe confirmed the correct action is unaffected: the "Select Consumer Protection Attribution Level" sheet was presented in both runs. The temporary test was removed before committing; this PR is one deleted line.

### Structural checks

- Consumer Protection button: 1 action (`changeConsumerProtectionAttributionLevel:`)
- Paste Control button: 1 action (`goToPasteControlPressed:`), unchanged
- `goToPasteControlPressed` occurrences: 2 before, 1 after
- `xmllint --noout Main.storyboard` passes
- `git diff --numstat`: `0	1	Branch-TestBed/Branch-TestBed/Main.storyboard`, no other file

EMT-4024
