### PR TITLE
EMT-4026: make the deprecated device-token fallback reachable when the modern key is absent

### DIFF
--- a/BranchSDKTests/BranchOpenResponseDeviceTokenTests.m
+++ b/BranchSDKTests/BranchOpenResponseDeviceTokenTests.m
@@ -12,7 +12,7 @@
 #import "BranchOpenRequest.h"
 #import "BranchRequestOpen.h"
 
-static NSString * const kDeprecatedDeviceTokenKey = @"device_fingerprint_id";
+static NSString * const deprecatedDeviceTokenKey = @"device_fingerprint_id";
 
 @interface BranchOpenResponseDeviceTokenTests : XCTestCase
 @property (nonatomic, copy) NSString *savedDeviceToken;
@@ -51,7 +51,7 @@ static NSString * const kDeprecatedDeviceTokenKey = @"device_fingerprint_id";
 // The regression: a response carrying only the deprecated key stored no device token,
 // because the fallback was nested inside a guard requiring the modern key.
 - (void)testRequestOpenStoresDeviceTokenFromDeprecatedKeyOnly {
-    [self processOpenResponseData:@{ kDeprecatedDeviceTokenKey: @"legacy_device_token" }];
+    [self processOpenResponseData:@{ deprecatedDeviceTokenKey: @"legacy_device_token" }];
 
     XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"legacy_device_token");
 }
@@ -65,7 +65,7 @@ static NSString * const kDeprecatedDeviceTokenKey = @"device_fingerprint_id";
 - (void)testRequestOpenPrefersModernKeyOverDeprecatedKey {
     [self processOpenResponseData:@{
         BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN: @"modern_device_token",
-        kDeprecatedDeviceTokenKey: @"legacy_device_token"
+        deprecatedDeviceTokenKey: @"legacy_device_token"
     }];
 
     XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"modern_device_token");
@@ -82,7 +82,7 @@ static NSString * const kDeprecatedDeviceTokenKey = @"device_fingerprint_id";
 
 // The wire may deliver these identifiers as numbers, but the property is an NSString.
 - (void)testRequestOpenNormalizesNumericDeviceToken {
-    [self processOpenResponseData:@{ kDeprecatedDeviceTokenKey: @1234567890 }];
+    [self processOpenResponseData:@{ deprecatedDeviceTokenKey: @1234567890 }];
 
     NSString *token = [BNCPreferenceHelper sharedInstance].randomizedDeviceToken;
     XCTAssertTrue([token isKindOfClass:[NSString class]]);
@@ -92,7 +92,7 @@ static NSString * const kDeprecatedDeviceTokenKey = @"device_fingerprint_id";
 #pragma mark - BranchOpenRequest
 
 - (void)testOpenRequestStoresDeviceTokenFromDeprecatedKeyOnly {
-    [self processLegacyOpenResponseData:@{ kDeprecatedDeviceTokenKey: @"legacy_device_token" }];
+    [self processLegacyOpenResponseData:@{ deprecatedDeviceTokenKey: @"legacy_device_token" }];
 
     XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"legacy_device_token");
 }
@@ -112,7 +112,7 @@ static NSString * const kDeprecatedDeviceTokenKey = @"device_fingerprint_id";
 }
 
 - (void)testOpenRequestNormalizesNumericDeviceToken {
-    [self processLegacyOpenResponseData:@{ kDeprecatedDeviceTokenKey: @1234567890 }];
+    [self processLegacyOpenResponseData:@{ deprecatedDeviceTokenKey: @1234567890 }];
 
     NSString *token = [BNCPreferenceHelper sharedInstance].randomizedDeviceToken;
     XCTAssertTrue([token isKindOfClass:[NSString class]]);

--- a/BranchSDKTests/BranchOpenResponseDeviceTokenTests.m
+++ b/BranchSDKTests/BranchOpenResponseDeviceTokenTests.m
@@ -1,0 +1,122 @@
+//
+//  BranchOpenResponseDeviceTokenTests.m
+//  BranchSDKTests
+//
+//  Copyright © 2026 Branch, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BranchConstants.h"
+#import "BNCPreferenceHelper.h"
+#import "BNCServerResponse.h"
+#import "BranchOpenRequest.h"
+#import "BranchRequestOpen.h"
+
+static NSString * const kDeprecatedDeviceTokenKey = @"device_fingerprint_id";
+
+@interface BranchOpenResponseDeviceTokenTests : XCTestCase
+@property (nonatomic, copy) NSString *savedDeviceToken;
+@end
+
+@implementation BranchOpenResponseDeviceTokenTests
+
+- (void)setUp {
+    self.savedDeviceToken = [BNCPreferenceHelper sharedInstance].randomizedDeviceToken;
+    [BNCPreferenceHelper sharedInstance].randomizedDeviceToken = nil;
+}
+
+- (void)tearDown {
+    [BNCPreferenceHelper sharedInstance].randomizedDeviceToken = self.savedDeviceToken;
+}
+
+- (BNCServerResponse *)responseWithData:(NSDictionary *)data {
+    BNCServerResponse *response = [[BNCServerResponse alloc] init];
+    response.statusCode = @200;
+    response.data = data;
+    return response;
+}
+
+- (void)processOpenResponseData:(NSDictionary *)data {
+    BranchRequestOpen *request = [[BranchRequestOpen alloc] initWithCallback:nil isInstall:NO];
+    [request processResponse:[self responseWithData:data] error:nil];
+}
+
+- (void)processLegacyOpenResponseData:(NSDictionary *)data {
+    BranchOpenRequest *request = [[BranchOpenRequest alloc] initWithCallback:nil isInstall:NO];
+    [request processResponse:[self responseWithData:data] error:nil];
+}
+
+#pragma mark - BranchRequestOpen
+
+// The regression: a response carrying only the deprecated key stored no device token,
+// because the fallback was nested inside a guard requiring the modern key.
+- (void)testRequestOpenStoresDeviceTokenFromDeprecatedKeyOnly {
+    [self processOpenResponseData:@{ kDeprecatedDeviceTokenKey: @"legacy_device_token" }];
+
+    XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"legacy_device_token");
+}
+
+- (void)testRequestOpenStoresDeviceTokenFromModernKey {
+    [self processOpenResponseData:@{ BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN: @"modern_device_token" }];
+
+    XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"modern_device_token");
+}
+
+- (void)testRequestOpenPrefersModernKeyOverDeprecatedKey {
+    [self processOpenResponseData:@{
+        BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN: @"modern_device_token",
+        kDeprecatedDeviceTokenKey: @"legacy_device_token"
+    }];
+
+    XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"modern_device_token");
+}
+
+// A response carrying neither key must not clobber a token from an earlier session.
+- (void)testRequestOpenKeepsExistingDeviceTokenWhenResponseHasNeitherKey {
+    [BNCPreferenceHelper sharedInstance].randomizedDeviceToken = @"previously_stored_token";
+
+    [self processOpenResponseData:@{ BRANCH_RESPONSE_KEY_SESSION_ID: @"session_id" }];
+
+    XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"previously_stored_token");
+}
+
+// The wire may deliver these identifiers as numbers, but the property is an NSString.
+- (void)testRequestOpenNormalizesNumericDeviceToken {
+    [self processOpenResponseData:@{ kDeprecatedDeviceTokenKey: @1234567890 }];
+
+    NSString *token = [BNCPreferenceHelper sharedInstance].randomizedDeviceToken;
+    XCTAssertTrue([token isKindOfClass:[NSString class]]);
+    XCTAssertEqualObjects(token, @"1234567890");
+}
+
+#pragma mark - BranchOpenRequest
+
+- (void)testOpenRequestStoresDeviceTokenFromDeprecatedKeyOnly {
+    [self processLegacyOpenResponseData:@{ kDeprecatedDeviceTokenKey: @"legacy_device_token" }];
+
+    XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"legacy_device_token");
+}
+
+- (void)testOpenRequestStoresDeviceTokenFromModernKey {
+    [self processLegacyOpenResponseData:@{ BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN: @"modern_device_token" }];
+
+    XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"modern_device_token");
+}
+
+- (void)testOpenRequestKeepsExistingDeviceTokenWhenResponseHasNeitherKey {
+    [BNCPreferenceHelper sharedInstance].randomizedDeviceToken = @"previously_stored_token";
+
+    [self processLegacyOpenResponseData:@{ BRANCH_RESPONSE_KEY_SESSION_ID: @"session_id" }];
+
+    XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].randomizedDeviceToken, @"previously_stored_token");
+}
+
+- (void)testOpenRequestNormalizesNumericDeviceToken {
+    [self processLegacyOpenResponseData:@{ kDeprecatedDeviceTokenKey: @1234567890 }];
+
+    NSString *token = [BNCPreferenceHelper sharedInstance].randomizedDeviceToken;
+    XCTAssertTrue([token isKindOfClass:[NSString class]]);
+    XCTAssertEqualObjects(token, @"1234567890");
+}
+
+@end

--- a/Sources/BranchSDK/BranchOpenRequest.m
+++ b/Sources/BranchSDK/BranchOpenRequest.m
@@ -167,13 +167,10 @@
 }
 
 - (NSString *)randomizedDeviceTokenFromResponseData:(NSDictionary *)data {
-    if (![data objectForKey:BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN]) {
-        return nil;
-    }
-    NSString *token = data[BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN];
+    NSString *token = BNCStringFromWireFormat(data[BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN]);
     if (!token) {
         // fallback to deprecated name. Fingerprinting was removed long ago, hence the name change.
-        token = data[@"device_fingerprint_id"];
+        token = BNCStringFromWireFormat(data[@"device_fingerprint_id"]);
     }
     return token;
 }

--- a/Sources/BranchSDK/BranchRequestOpen.m
+++ b/Sources/BranchSDK/BranchRequestOpen.m
@@ -107,12 +107,14 @@
         userIdentity = [userIdentity stringValue];
     }
     
-    if ([data objectForKey:BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN]) {
-        preferenceHelper.randomizedDeviceToken = data[BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN];
-        if (!preferenceHelper.randomizedDeviceToken) {
-            // fallback to deprecated name. Fingerprinting was removed long ago, hence the name change.
-            preferenceHelper.randomizedDeviceToken = data[@"device_fingerprint_id"];
-        }
+    NSString *deviceToken = BNCStringFromWireFormat(data[BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN]);
+    if (!deviceToken) {
+        // fallback to deprecated name. Fingerprinting was removed long ago, hence the name change.
+        deviceToken = BNCStringFromWireFormat(data[@"device_fingerprint_id"]);
+    }
+
+    if (deviceToken) {
+        preferenceHelper.randomizedDeviceToken = deviceToken;
     }
    
     if (data[BRANCH_RESPONSE_KEY_USER_URL]) {


### PR DESCRIPTION
## Reference
[EMT-4026](https://branch.atlassian.net/browse/EMT-4026) -- make the deprecated device-token fallback reachable when the modern key is absent.

## Summary
`BranchRequestOpen.m` guarded the `device_fingerprint_id` fallback behind the presence of the modern `randomized_device_token` key, so the fallback was unreachable in exactly the case it exists for and no device token was stored. `BranchOpenRequest.m` carried the same defect as an early `return nil`. Both now follow the pattern the bundle token already uses in these files: read the modern key, fall back when empty, no outer guard, assign only when a value was obtained. `BNCStringFromWireFormat` is applied to both reads, so a numeric `device_fingerprint_id` cannot reach the `NSString` property and crash the setter on the next open.

## Motivation
A fresh install completes its open and then drops every request behind it -- `BNCServerRequestOperation` drops any non-open request when the device token is missing. `/v3/events/open` answers a fresh install with the legacy identity shape (`device_fingerprint_id`, `identity_id`, `session_id`), so this line hits the guard; `master` never does, because `/v1/open` always returns the modern key. Latent pre-existing defect exposed by the endpoint change, not a regression introduced here. A warm launch never reaches it, which is why it went unseen: every capture until now had been a warm open.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
New test class, 9 cases across both request classes: deprecated key only, modern key only, both, neither, numeric values. Before the change, 6 assertion failures in 4 cases. After, 9/9 pass; full suite `492 tests, 0 failures` -- [run 31654961566](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/actions/runs/31654961566).

Runtime, fresh install of Branch-TestBed with four requests issued behind the open, identical driver in both runs:

| | before | after |
| --- | --- | --- |
| requests on the wire | 1 | 5 |
| `Missing session items` | 4 | 0 |

The response carried `device_fingerprint_id` and zero occurrences of the modern key; after the change that value comes back out under the modern name on subsequent requests, so store-and-reuse is confirmed rather than storage alone. Reproducing the runtime capture needs the TestBed log hook from #1627; the unit tests are self-contained.

cc @BranchMetrics/saas-sdk-devs for visibility.


[EMT-4026]: https://branch.atlassian.net/browse/EMT-4026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ