### PR TITLE
EMT-4027: detect a first launch on the 4.0 open path

### DIFF
--- a/BranchSDKTests/BranchRequestOpenInstallTests.m
+++ b/BranchSDKTests/BranchRequestOpenInstallTests.m
@@ -1,0 +1,257 @@
+//
+//  BranchRequestOpenInstallTests.m
+//  BranchSDKTests
+//
+//  Copyright © 2026 Branch, Inc. All rights reserved.
+//
+//  EMT-4027: BranchRequestOpen is only ever constructed through -initWithCallback:, which
+//  hardcodes isInstall:NO, so every install-gated behaviour is unreachable in production.
+//  These tests drive the production construction path (Branch -sendOpen) rather than
+//  instantiating the request directly, because the defect is in the construction.
+//
+
+#import <XCTest/XCTest.h>
+#import <objc/runtime.h>
+#import "Branch.h"
+#import "BranchConstants.h"
+#import "BNCPreferenceHelper.h"
+#import "BNCServerRequestQueue.h"
+#import "BNCServerRequestOperation.h"
+#import "BNCServerResponse.h"
+#import "BNCSKAdNetwork.h"
+#import "BranchRequestOpen.h"
+
+@interface BNCServerRequestQueue (InstallIntrospectionTest)
+@property (strong, nonatomic) NSOperationQueue *operationQueue;
+@end
+
+// Records the SKAdNetwork calls the open response triggers instead of making them. The spy
+// adds no ivars, so it can be swapped onto the existing singleton with object_setClass and
+// swapped back in -tearDown. Recording is file-static for the same reason.
+static NSMutableArray<NSNumber *> *sPostbackFineValues = nil;
+static NSInteger sRegisterAppCallCount = 0;
+
+@interface BNCSKAdNetworkSpy : BNCSKAdNetwork
+@end
+
+@implementation BNCSKAdNetworkSpy
+
+- (void)registerAppForAdNetworkAttribution {
+    sRegisterAppCallCount++;
+}
+
+- (void)updateConversionValue:(NSInteger)conversionValue {
+    [sPostbackFineValues addObject:@(conversionValue)];
+}
+
+- (void)updatePostbackConversionValue:(NSInteger)conversionValue
+                    completionHandler:(void (^)(NSError *error))completion {
+    [sPostbackFineValues addObject:@(conversionValue)];
+}
+
+- (void)updatePostbackConversionValue:(NSInteger)fineValue
+                          coarseValue:(NSString *)coarseValue
+                           lockWindow:(BOOL)lockWindow
+                    completionHandler:(void (^)(NSError *error))completion {
+    [sPostbackFineValues addObject:@(fineValue)];
+}
+
+@end
+
+static NSString * const kInstallLinkURL = @"https://example.app.link/install-link";
+static NSString * const kClickedLinkPayloadJSON =
+    @"{\"+clicked_branch_link\":true,\"+is_first_session\":true,"
+     "\"$canonical_identifier\":\"content/12345\",\"$og_title\":\"Install Content\","
+     "\"~campaign\":\"beta launch\","
+     "\"~referring_link\":\"https://example.app.link/install-link\"}";
+
+@interface BranchRequestOpenInstallTests : XCTestCase
+@property (nonatomic, strong) Branch *branch;
+@property (nonatomic, strong) BNCServerRequestQueue *fakeQueue;
+@property (nonatomic, copy) NSString *savedBundleToken;
+@property (nonatomic, copy) NSString *savedInstallParams;
+@property (nonatomic, copy) NSString *savedSessionParams;
+@property (nonatomic, copy) NSString *savedAttributionLevel;
+@property (nonatomic, strong) NSDate *savedFirstAppLaunchTime;
+@property (nonatomic, assign) NSInteger savedSkanWindow;
+@property (nonatomic, assign) NSInteger savedHighestConversionValue;
+@property (nonatomic, assign) BOOL savedInvokeRegisterApp;
+// The stubbed open responses write real-looking session credentials. BNCServerRequestOperation
+// drops a non-init request when these are missing, so leaving them behind lets later tests
+// reach the network they would otherwise have skipped.
+@property (nonatomic, copy) NSString *savedSessionID;
+@property (nonatomic, copy) NSString *savedDeviceToken;
+@end
+
+@implementation BranchRequestOpenInstallTests
+
+- (void)setUp {
+    [super setUp];
+    self.branch = [Branch getInstance];
+
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    self.savedBundleToken = preferenceHelper.randomizedBundleToken;
+    self.savedInstallParams = preferenceHelper.installParams;
+    self.savedSessionParams = preferenceHelper.sessionParams;
+    self.savedAttributionLevel = preferenceHelper.attributionLevel;
+    self.savedFirstAppLaunchTime = preferenceHelper.firstAppLaunchTime;
+    self.savedSkanWindow = preferenceHelper.skanCurrentWindow;
+    self.savedHighestConversionValue = preferenceHelper.highestConversionValueSent;
+    self.savedInvokeRegisterApp = preferenceHelper.invokeRegisterApp;
+    self.savedSessionID = preferenceHelper.sessionID;
+    self.savedDeviceToken = preferenceHelper.randomizedDeviceToken;
+
+    // A first-ever launch: no bundle token yet, nothing attributed yet.
+    preferenceHelper.randomizedBundleToken = nil;
+    preferenceHelper.installParams = nil;
+    preferenceHelper.sessionParams = nil;
+    preferenceHelper.referringURL = nil;
+    preferenceHelper.attributionLevel = BranchAttributionLevelFull;
+
+    // Pin the SKAN window to the first window with no conversion value sent yet, so the
+    // open-only conversion path is deterministically eligible rather than incidentally
+    // suppressed by ambient install-date state.
+    preferenceHelper.firstAppLaunchTime = [NSDate date];
+    preferenceHelper.skanCurrentWindow = 0;
+    preferenceHelper.highestConversionValueSent = 0;
+    preferenceHelper.invokeRegisterApp = NO;
+
+    // BNCPreferenceHelper is a singleton backed by NSUserDefaults. installParams left over
+    // from an earlier test would satisfy getFirstReferringParams without the code under test
+    // ever writing it, so the clean slate is asserted rather than assumed.
+    XCTAssertNil(preferenceHelper.installParams,
+                 @"Precondition: installParams must be empty before the test runs.");
+    XCTAssertNil(preferenceHelper.randomizedBundleToken,
+                 @"Precondition: this must look like a first-ever launch.");
+
+    sPostbackFineValues = [NSMutableArray array];
+    sRegisterAppCallCount = 0;
+    object_setClass([BNCSKAdNetwork sharedInstance], [BNCSKAdNetworkSpy class]);
+
+    self.fakeQueue = [BNCServerRequestQueue new];
+    self.fakeQueue.operationQueue.suspended = YES;
+    [self.branch setValue:self.fakeQueue forKey:@"requestQueue"];
+}
+
+- (void)tearDown {
+    object_setClass([BNCSKAdNetwork sharedInstance], [BNCSKAdNetwork class]);
+    sPostbackFineValues = nil;
+    sRegisterAppCallCount = 0;
+
+    [self.branch setValue:[BNCServerRequestQueue getInstance] forKey:@"requestQueue"];
+    self.fakeQueue = nil;
+
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.randomizedBundleToken = self.savedBundleToken;
+    preferenceHelper.installParams = self.savedInstallParams;
+    preferenceHelper.sessionParams = self.savedSessionParams;
+    preferenceHelper.attributionLevel = self.savedAttributionLevel;
+    preferenceHelper.firstAppLaunchTime = self.savedFirstAppLaunchTime;
+    preferenceHelper.skanCurrentWindow = self.savedSkanWindow;
+    preferenceHelper.highestConversionValueSent = self.savedHighestConversionValue;
+    preferenceHelper.invokeRegisterApp = self.savedInvokeRegisterApp;
+    preferenceHelper.sessionID = self.savedSessionID;
+    preferenceHelper.randomizedDeviceToken = self.savedDeviceToken;
+    preferenceHelper.referringURL = nil;
+
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+
+    self.branch = nil;
+    [super tearDown];
+}
+
+#pragma mark - Helpers
+
+// The open request the SDK itself built for this launch. Reading it back from the queue is
+// what makes these tests characterize the production construction rather than a hand-made
+// request that could be given whatever isInstall value the test wanted.
+- (BranchRequestOpen *)openRequestEnqueuedBySDK {
+    for (NSOperation *op in self.fakeQueue.operationQueue.operations) {
+        if (![NSStringFromClass([op class]) isEqualToString:@"BNCServerRequestOperation"]) continue;
+        id request = [op valueForKey:@"request"];
+        if ([NSStringFromClass([request class]) isEqualToString:@"BranchRequestOpen"]) {
+            return (BranchRequestOpen *)request;
+        }
+    }
+    return nil;
+}
+
+- (BNCServerResponse *)openResponseWithExtras:(NSDictionary *)extras {
+    NSMutableDictionary *data = [@{
+        BRANCH_RESPONSE_KEY_SESSION_DATA: kClickedLinkPayloadJSON,
+        BRANCH_RESPONSE_KEY_SESSION_ID: @"session_id",
+        BRANCH_RESPONSE_KEY_RANDOMIZED_BUNDLE_TOKEN: @"bundle_token"
+    } mutableCopy];
+    [data addEntriesFromDictionary:extras];
+
+    BNCServerResponse *response = [BNCServerResponse new];
+    response.statusCode = @200;
+    response.data = data;
+    return response;
+}
+
+// Drives the launch the way the SDK does, then settles it with the given response.
+- (BranchRequestOpen *)settleFirstLaunchOpenWithResponse:(BNCServerResponse *)response {
+    [self.branch sendOpen];
+
+    BranchRequestOpen *openRequest = [self openRequestEnqueuedBySDK];
+    XCTAssertNotNil(openRequest, @"sendOpen must enqueue a BranchRequestOpen.");
+    [openRequest processResponse:response error:nil];
+    return openRequest;
+}
+
+#pragma mark - Tests
+
+// getFirstReferringParams is backed by installParams, which is only written when the open
+// knows it is an install. On the 4.0 path it never does, so first-referring attribution is
+// empty for the lifetime of the app.
+- (void)testFirstLaunchOpenWithClickedLinkPopulatesFirstReferringParams {
+    [self settleFirstLaunchOpenWithResponse:[self openResponseWithExtras:@{}]];
+
+    NSDictionary *firstParams = [self.branch getFirstReferringParams];
+    XCTAssertTrue([firstParams[BRANCH_RESPONSE_KEY_CLICKED_BRANCH_LINK] boolValue],
+                  @"A first-ever launch attributed to a clicked link must be readable via getFirstReferringParams.");
+    XCTAssertEqualObjects(firstParams[BRANCH_RESPONSE_KEY_BRANCH_REFERRING_LINK], kInstallLinkURL);
+    XCTAssertEqualObjects(firstParams[@"$canonical_identifier"], @"content/12345");
+    XCTAssertEqualObjects(firstParams[@"~campaign"], @"beta launch",
+                          @"The whole install payload must be persisted, not just the fields the SDK reads internally.");
+}
+
+// The install registration is gated on the same isInstall flag.
+- (void)testFirstLaunchOpenRegistersInstallWithAdNetwork {
+    [self settleFirstLaunchOpenWithResponse:
+        [self openResponseWithExtras:@{ BRANCH_RESPONSE_KEY_INVOKE_REGISTER_APP: @YES }]];
+
+    BOOL registeredInstall = sRegisterAppCallCount > 0 || [sPostbackFineValues containsObject:@0];
+    XCTAssertTrue(registeredInstall,
+                  @"A first-ever launch must register the install with SKAdNetwork. Recorded postbacks: %@, registerApp calls: %ld.",
+                  sPostbackFineValues, (long)sRegisterAppCallCount);
+}
+
+// The mirror image: the conversion-value update is explicitly gated on !isInstall, so with
+// isInstall permanently NO it also fires on a first launch, where it must be suppressed.
+- (void)testFirstLaunchOpenSuppressesTheOpenOnlyConversionValueUpdate {
+    [self settleFirstLaunchOpenWithResponse:[self openResponseWithExtras:@{
+        BRANCH_RESPONSE_KEY_INVOKE_REGISTER_APP: @YES,
+        BRANCH_RESPONSE_KEY_UPDATE_CONVERSION_VALUE: @7
+    }]];
+
+    XCTAssertFalse([sPostbackFineValues containsObject:@7],
+                   @"The open-only conversion value update must not fire on a first-ever launch. Recorded postbacks: %@.",
+                   sPostbackFineValues);
+}
+
+// A genuine second launch must keep behaving like an open: no install params written.
+- (void)testSecondLaunchOpenDoesNotOverwriteFirstReferringParams {
+    BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
+    preferenceHelper.randomizedBundleToken = @"existing_bundle_token";
+    preferenceHelper.installParams = @"{\"+clicked_branch_link\":true,\"~campaign\":\"original install\"}";
+
+    [self settleFirstLaunchOpenWithResponse:[self openResponseWithExtras:@{}]];
+
+    NSDictionary *firstParams = [self.branch getFirstReferringParams];
+    XCTAssertEqualObjects(firstParams[@"~campaign"], @"original install",
+                          @"A later open must not overwrite the install attribution.");
+}
+
+@end

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -2652,7 +2652,12 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
             }
         });
     };
-    BranchRequestOpen *openReq = [[BranchRequestOpen alloc] initWithCallback:openCallback];
+    // A launch with no randomized bundle token has never completed an open, so it is a first
+    // launch. This is the same criterion -initializeSessionAndCallCallback: uses to choose
+    // between BranchOpenRequest and BranchInstallRequest; without it no request on this path
+    // is ever an install, and every install-gated behaviour in BranchRequestOpen is unreachable.
+    BOOL isInstall = !self.preferenceHelper.randomizedBundleToken;
+    BranchRequestOpen *openReq = [[BranchRequestOpen alloc] initWithCallback:openCallback isInstall:isInstall];
     openReq.urlString = nil;
     openReq.traceCallback = bnc_tracingCallback;
 
@@ -2683,7 +2688,11 @@ static inline void BNCPerformBlockOnMainThreadSync(dispatch_block_t block) {
             }
         });
     };
-    BranchRequestOpen *openReq = [[BranchRequestOpen alloc] initWithCallback:openCallback];
+    // Same first-launch criterion as -sendOpen. An install reaches this path too: a first
+    // launch attributed to a clicked link resolves the deep link first and spawns its open here,
+    // and that is exactly the open whose payload has to be kept as the install attribution.
+    BOOL isInstall = !self.preferenceHelper.randomizedBundleToken;
+    BranchRequestOpen *openReq = [[BranchRequestOpen alloc] initWithCallback:openCallback isInstall:isInstall];
     openReq.urlString = nil;
     openReq.traceCallback = bnc_tracingCallback;
     openReq.linkData = responseData;


### PR DESCRIPTION
## Reference
[EMT-4027](https://branch.atlassian.net/browse/EMT-4027) -- detect a first launch on the 4.0 open path.

Stack 4 of 4, the tip. Base is #1634 -- review #1632, #1633 and #1634 first.

## Summary
Both `BranchRequestOpen` construction sites (`Branch.m:2604` and `:2635`) hardcoded `isInstall:NO`. They now apply the same criterion the legacy path uses in `-initializeSessionAndCallCallback:` -- a missing randomized bundle token means no open has ever completed, so this is a first launch. Applied to the resolution-spawned open as well as the organic one, since a first launch attributed to a clicked link arrives through the resolution path. No endpoint, payload or wire-format change.

It inherits that criterion's known limitation: the bundle token is written only on a completed open, so session 2 is classified as an install whenever session 1's open failed. `master` ships that behaviour today; recorded here rather than solved, since fixing it would change the shipping line too.

## Motivation
On the 4.0 surface no request was ever an install, so three install-gated behaviours were unreachable and one open-only behaviour ran when it should have been suppressed:

- `installParams` was never written, leaving `getFirstReferringParams` empty for the lifetime of the app
- `saveAppClipData` never ran
- the SKAdNetwork install registration never fired
- the open-only conversion value update fired on a first launch, where the install registration owns the postback

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
`BranchSDKTests/BranchRequestOpenInstallTests.m`, new -- `BranchRequestOpen` had no unit coverage at all, which is why this reached the beta. One test per behaviour left unreachable, plus one for the mirror image: a genuine second launch leaves the install attribution alone. The launch is driven through `-sendOpen` rather than by constructing the request, so the test exercises the construction site where the criterion is applied.

`496 tests, 0 failures` -- [run 31436336502](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/actions/runs/31436336502). That is 4 over #1634's 492 and the full 13 this stack contributes over the 483 on `4.0.0-beta.0`. The first `verify` on this branch was auto-cancelled when the stack was pushed, so this run is the one to read.

cc @BranchMetrics/saas-sdk-devs for visibility.


[EMT-4027]: https://branch.atlassian.net/browse/EMT-4027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ