### PR TITLE
EMT-4035: keep the live-network QR tests out of the unit gate

### DIFF
--- a/BranchSDKTests/BranchSDKTests.xctestplan
+++ b/BranchSDKTests/BranchSDKTests.xctestplan
@@ -20,7 +20,12 @@
       "parallelizable" : false,
       "skippedTests" : [
         "BNCDisableAdNetworkCalloutsTests",
-        "BranchActivityItemTests"
+        "BranchActivityItemTests",
+        "BranchQRCodeTests\/testNormalQRCodeAsDataWithNoSettings",
+        "BranchQRCodeTests\/testNormalQRCodeAsImage",
+        "BranchQRCodeTests\/testNormalQRCodeDataWithAllSettings",
+        "BranchQRCodeTests\/testNormalQRCodeWithInvalidLogoURL",
+        "BranchQRCodeTests\/testQRCodeCache"
       ],
       "target" : {
         "containerPath" : "container:BranchSDK.xcodeproj",


### PR DESCRIPTION
## Reference
[EMT-4035](https://branch.atlassian.net/browse/EMT-4035) -- keep the live-network QR tests out of the unit gate.

## Summary
Skips the five `BranchQRCodeTests` cases in `BranchSDKTests.xctestplan`, the only plan `verify.yml` runs: `testNormalQRCodeAsDataWithNoSettings`, `testNormalQRCodeAsImage`, `testNormalQRCodeDataWithAllSettings`, `testNormalQRCodeWithInvalidLogoURL`, `testQRCodeCache`. Per-test entries rather than a class-level skip, so a future offline-safe test in this class runs instead of being silently skipped.

This removes the tests from the gate; it does not make them pass. EMT-4035 stays open for the real fix -- stub the transport so the cases run offline.

## Motivation
`getQRCodeAsData` and `getQRCodeAsImage` go through `BranchQRCode.m`'s own `NSURLSession` rather than the SDK request queue, so they post to the live Branch QR API and every case fails with `Code=1003 "The network request was invalid."` when the endpoint does not answer from CI.

Across the seven most recent red `verify` runs on the 4.0 line, this is the sole cause of failure on four -- #1614, #1615, #1624 and #1625, each with 14 `Code=1003` markers and zero crash restarts. #1614 is the root of the eight-PR API surface stack, so this alone keeps that chain from earning a green check on its own merits.

## Type Of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
`verify` on this branch: [run 31626960783](https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/actions/runs/31626960783) -- `Executed 478 tests, with 0 failures`, Test Succeeded. `BranchQRCodeTests` prints as a suite header with no case under it, and 478 is exactly the 483 on `4.0.0-beta.0` minus these five. Every other `verify` job on the PR is green too. No other test plan or workflow is touched.

cc @BranchMetrics/saas-sdk-devs for visibility.


[EMT-4035]: https://branch.atlassian.net/browse/EMT-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ