### PR TITLE
Fix to BNCServerRequestOperation - freed pointer

### DIFF
--- a/Sources/BranchSDK/BNCServerRequestOperation.m
+++ b/Sources/BranchSDK/BNCServerRequestOperation.m
@@ -22,6 +22,8 @@
 
 @implementation BNCServerRequestOperation {
     BNCServerRequest *_request;
+    // One-shot gate for the terminal transition. See -finishOperation.
+    BOOL _didSignalFinish;
 }
 
 @synthesize executing = _executing;
@@ -33,6 +35,7 @@
         _request = request;
         _executing = NO;
         _finished = NO;
+        _didSignalFinish = NO;
     }
     return self;
 }
@@ -41,22 +44,40 @@
     return YES;
 }
 
+// The queue reads these from its own threads while the network callback writes them, so the flags
+// are read and written under the instance lock.
+- (BOOL)isExecuting {
+    @synchronized (self) {
+        return _executing;
+    }
+}
+
+- (BOOL)isFinished {
+    @synchronized (self) {
+        return _finished;
+    }
+}
+
 - (void)setExecuting:(BOOL)executing {
     [self willChangeValueForKey:@"isExecuting"];
-    _executing = executing;
+    @synchronized (self) {
+        _executing = executing;
+    }
     [self didChangeValueForKey:@"isExecuting"];
 }
 
 - (void)setFinished:(BOOL)finished {
     [self willChangeValueForKey:@"isFinished"];
-    _finished = finished;
+    @synchronized (self) {
+        _finished = finished;
+    }
     [self didChangeValueForKey:@"isFinished"];
 }
 
 - (void)start {
     if (self.isCancelled) {
         [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"Operation cancelled before starting: %@", self.request.requestUUID] error:nil];
-        self.finished = YES;
+        [self finishOperation];
         return;
     }
 
@@ -68,8 +89,7 @@
     if (![self.request isKindOfClass:[BranchRequestDeepLink class]]) {
         if ([preferenceHelper.attributionLevel isEqualToString:BranchAttributionLevelNone]) {
             [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"Attribution Level is 'NONE'. Skipping request: %@", self.request.requestUUID] error:nil];
-            self.executing = NO;
-            self.finished = YES;
+            [self finishOperation];
             return;
         }
     }
@@ -85,8 +105,7 @@
             BNCPerformBlockOnMainThreadSync(^{
                 [self.request processResponse:nil error:[NSError branchErrorWithCode:BNCInitError]];
             });
-            self.executing = NO;
-            self.finished = YES;
+            [self finishOperation];
             return;
         }
     }
@@ -125,20 +144,42 @@
     }];
 }
 
+// Moves the operation to its terminal state exactly once. Every path that ends the operation --
+// cancellation, the attribution gate, failed session validation and the network callback -- funnels
+// through here.
+//
+// NSOperationQueue watches isExecuting/isFinished to know when to drop its reference to an operation
+// and schedule the next one. Signalling isFinished twice makes it complete, and release, the same
+// operation twice; the freed entry is then walked on the next enqueue or completion, crashing inside
+// __NSOQSchedule far from the code that caused it. The gate below keeps that transition single.
 - (void)finishOperation {
+    @synchronized (self) {
+        if (_didSignalFinish) {
+            return;
+        }
+        _didSignalFinish = YES;
+    }
+
     [[BranchLogger shared] logVerbose:[NSString stringWithFormat:@"BNCServerRequestOperation finished for request: %@", self.request.requestUUID] error:nil];
-    self.executing = NO;
+    if (self.isExecuting) {
+        self.executing = NO;
+    }
     self.finished = YES;
 }
 
 - (void)cancel {
     [super cancel]; // Sets `isCancelled` to YES
 
-    if (!self.isExecuting) {
-        self.finished = YES;
-        [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"BNCServerRequestOperation cancelled before execution for request: %@", self.request.requestUUID] error:nil];
-    } else {
+    // Deliberately does not finish the operation. The queue still calls -start on a cancelled
+    // operation that has not begun, and -start finishes it. Note that cancelling does NOT make an
+    // operation skip its dependencies: one cancelled behind an unfinished dependency is not started
+    // until that dependency finishes, so a cancelled request may stay in the queue for a while.
+    // Signalling isFinished from here instead would complete an operation the queue has not started,
+    // corrupting the same bookkeeping described in -finishOperation.
+    if (self.isExecuting) {
         [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"BNCServerRequestOperation cancelled during execution for request: %@", self.request.requestUUID] error:nil];
+    } else {
+        [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"BNCServerRequestOperation cancelled before execution for request: %@", self.request.requestUUID] error:nil];
     }
 }
 


### PR DESCRIPTION
## Reference

## Summary
<!-- Simple summary of what was changed. -->
Introduced a fix to solve isFinish being called twice. This change ensures that, if a request was cancelled, isFinished isn't called a second time by checking if the signaledFinished was already set to yes. This prevents it from being freed prematurely leading to an EXC_BAD_ACCESS crash being called on a dead memory pointer

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
