### PR TITLE
EMT-4174: fix the beta unit build after the session-id removal

### DIFF
--- a/BranchSDKTests/BranchDeepLinkQueueDrainTests.m
+++ b/BranchSDKTests/BranchDeepLinkQueueDrainTests.m
@@ -69,7 +69,6 @@ static NSMutableArray<NSString *> *sPostedURLs = nil;
         response.data = @{ BRANCH_RESPONSE_KEY_SESSION_DATA: kResolvedLinkPayloadJSON };
     } else {
         response.data = @{
-            BRANCH_RESPONSE_KEY_SESSION_ID: @"session_id",
             BRANCH_RESPONSE_KEY_RANDOMIZED_BUNDLE_TOKEN: @"bundle_token",
             BRANCH_RESPONSE_KEY_RANDOMIZED_DEVICE_TOKEN: @"device_token"
         };
@@ -90,12 +89,8 @@ static NSMutableArray<NSString *> *sPostedURLs = nil;
 // The stubbed responses write real-looking session credentials. BNCServerRequestOperation
 // drops a non-init request when these are missing, so leaving them behind lets later tests
 // reach the network they would otherwise have skipped. Saved here, restored in -tearDown.
-@property (nonatomic, copy) NSString *savedSessionID;
 @property (nonatomic, copy) NSString *savedBundleToken;
 @property (nonatomic, copy) NSString *savedDeviceToken;
-// These tests drive the real lifecycle entry points, which move the session state machine.
-// Left armed, a later test's logEvent proceeds to the network instead of being deferred.
-@property (nonatomic, strong) id savedInitializationStatus;
 @end
 
 @implementation BranchDeepLinkQueueDrainTests
@@ -108,10 +103,8 @@ static NSMutableArray<NSString *> *sPostedURLs = nil;
     BNCPreferenceHelper *preferenceHelper = [BNCPreferenceHelper sharedInstance];
     self.savedSessionParams = preferenceHelper.sessionParams;
     self.savedAttributionLevel = preferenceHelper.attributionLevel;
-    self.savedSessionID = preferenceHelper.sessionID;
     self.savedBundleToken = preferenceHelper.randomizedBundleToken;
     self.savedDeviceToken = preferenceHelper.randomizedDeviceToken;
-    self.savedInitializationStatus = [self.branch valueForKey:@"initializationStatus"];
 
     preferenceHelper.sessionParams = nil;
     preferenceHelper.referringURL = nil;
@@ -147,10 +140,8 @@ static NSMutableArray<NSString *> *sPostedURLs = nil;
     preferenceHelper.sessionParams = self.savedSessionParams;
     preferenceHelper.referringURL = nil;
     preferenceHelper.attributionLevel = self.savedAttributionLevel;
-    preferenceHelper.sessionID = self.savedSessionID;
     preferenceHelper.randomizedBundleToken = self.savedBundleToken;
     preferenceHelper.randomizedDeviceToken = self.savedDeviceToken;
-    [self.branch setValue:self.savedInitializationStatus forKey:@"initializationStatus"];
 
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
 
@@ -198,10 +189,6 @@ static NSMutableArray<NSString *> *sPostedURLs = nil;
     dispatch_sync(isolationQueue, ^{});
 }
 
-- (NSInteger)initializationStatus {
-    return [[self.branch valueForKey:@"initializationStatus"] integerValue];
-}
-
 - (NSArray<NSString *> *)postedURLs {
     @synchronized (sPostedURLs) {
         return [sPostedURLs copy];
@@ -243,11 +230,9 @@ static NSMutableArray<NSString *> *sPostedURLs = nil;
     [self.branch applicationWillResignActive];
     [self waitForIsolationQueue];
 
-    // Precondition: the session really does read uninitialized. Attribution is set to Full in
-    // -setUp. Without both, -applicationDidBecomeActive would skip the open for a reason that
-    // has nothing to do with the in-flight resolution, and this test would pass hollow.
-    XCTAssertEqual([self initializationStatus], (NSInteger)0,
-                   @"Precondition: the session must read uninitialized (BNCInitStatusUninitialized) after resigning active.");
+    // Precondition: -applicationDidBecomeActive skips the organic open on exactly two conditions,
+    // attributionLevelNone and an init request already in the queue. The second is the behaviour
+    // under test, so attribution is the only unrelated reason left to rule out.
     XCTAssertEqualObjects([BNCPreferenceHelper sharedInstance].attributionLevel, BranchAttributionLevelFull,
                           @"Precondition: attribution must not be None, or the open is suppressed for an unrelated reason.");
 


### PR DESCRIPTION
The beta unit target has not compiled since #1632 merged. `BranchDeepLinkQueueDrainTests` references `BNCPreferenceHelper.sessionID`, `BRANCH_RESPONSE_KEY_SESSION_ID` and, through KVC by string, `Branch.initializationStatus`. None of the three exists on this line any more — they were removed in #1603, merged 2026-08-21. The test file arrived afterwards in #1632, merged 2026-08-24, having been written before the removal, so its CI had last run against an older base.

The session-id references are compile errors, so the target fails to build and nothing runs. The `initializationStatus` ones go through KVC by string, so they compile and then raise `NSUnknownKeyException` at runtime.

Every PR currently open against this line still displays a green `verify` from a run that predates the break — #1614 from 08-22, #1633 and #1631 from 08-18, #1639 from 08-19 — so the first branch to be rebased turns red.

**On the removed precondition.** The test asserted the session read uninitialized after resigning active. That state no longer decides anything: `applicationDidBecomeActive` skips the organic open on exactly two conditions, `attributionLevelNone` and an init request already in the queue, and `containsInstallOrOpen` recognises `BranchRequestDeepLink`. Attribution is the only unrelated reason left to rule out, and the test already asserts it, so the assertion is removed rather than ported.

**Proof.** On `e3a905b2` the target fails to build and zero tests run. With this change 498 tests execute and `testLiveResolutionSuppressesTheLifecycleOrganicOpen` passes. The 10 remaining local failures (`BNCKeyChainTests`, `BranchConfigurationControllerTests`, `BNCApplicationTests`) reproduce identically on `0eac1acf`, the last commit whose `verify` was green in CI, so they are environmental and unrelated to this change.

Test code only, one file. No SDK behaviour changes.