### PR TITLE
EMT-4287 - Move Public APIs on BranchConfiguration to private class

### DIFF
--- a/BranchSDK.xcodeproj/project.pbxproj
+++ b/BranchSDK.xcodeproj/project.pbxproj
@@ -375,6 +375,9 @@
 		BB0831A12E00000000000011 /* BranchConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BB0831A12E00000000000001 /* BranchConfiguration+Private.h */; };
 		BB0831A12E00000000000012 /* BranchConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BB0831A12E00000000000001 /* BranchConfiguration+Private.h */; };
 		BB0831A12E00000000000013 /* BranchConfiguration+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = BB0831A12E00000000000001 /* BranchConfiguration+Private.h */; };
+		BB0831A22E00000000000011 /* Branch+Configuration.h in Headers */ = {isa = PBXBuildFile; fileRef = BB0831A22E00000000000001 /* Branch+Configuration.h */; };
+		BB0831A22E00000000000012 /* Branch+Configuration.h in Headers */ = {isa = PBXBuildFile; fileRef = BB0831A22E00000000000001 /* Branch+Configuration.h */; };
+		BB0831A22E00000000000013 /* Branch+Configuration.h in Headers */ = {isa = PBXBuildFile; fileRef = BB0831A22E00000000000001 /* Branch+Configuration.h */; };
 		5FCDD52E2B7AC6A300EAF29F /* Branch+Validator.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3D32B7AC6A100EAF29F /* Branch+Validator.h */; };
 		5FCDD52F2B7AC6A300EAF29F /* Branch+Validator.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3D32B7AC6A100EAF29F /* Branch+Validator.h */; };
 		5FCDD5302B7AC6A300EAF29F /* Branch+Validator.h in Headers */ = {isa = PBXBuildFile; fileRef = 5FCDD3D32B7AC6A100EAF29F /* Branch+Validator.h */; };
@@ -692,6 +695,7 @@
 		5FCDD3D12B7AC6A100EAF29F /* NSString+Branch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Branch.h"; sourceTree = "<group>"; };
 		5FCDD3D22B7AC6A100EAF29F /* BranchInstallRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BranchInstallRequest.h; sourceTree = "<group>"; };
 		BB0831A12E00000000000001 /* BranchConfiguration+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BranchConfiguration+Private.h"; sourceTree = "<group>"; };
+		BB0831A22E00000000000001 /* Branch+Configuration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Branch+Configuration.h"; sourceTree = "<group>"; };
 		5FCDD3D32B7AC6A100EAF29F /* Branch+Validator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Branch+Validator.h"; sourceTree = "<group>"; };
 		5FCDD3D42B7AC6A100EAF29F /* BNCDeepLinkViewControllerInstance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCDeepLinkViewControllerInstance.h; sourceTree = "<group>"; };
 		5FCDD3D52B7AC6A100EAF29F /* BNCContentDiscoveryManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BNCContentDiscoveryManager.h; sourceTree = "<group>"; };
@@ -1001,6 +1005,8 @@
 			children = (
 				3B2490AC2FAD18A8001CDB7F /* BNCConfig.h */,
 				3B2490AD2FAD18A8001CDB7F /* BranchConfigurationController.h */,
+
+				BB0831A22E00000000000001 /* Branch+Configuration.h */,
 				3B2268722FABEE120069F62C /* BranchRequestDeepLink.h */,
 				3B22686A2FABEDD10069F62C /* BranchRequestOpen.h */,
 				E74E43852E2F55E5000DC427 /* BNCServerRequestOperation.h */,
@@ -1094,6 +1100,7 @@
 				E7FAF6A02E26E497006C167F /* BranchConstants.h in Headers */,
 				5FCDD52E2B7AC6A300EAF29F /* Branch+Validator.h in Headers */,
 				BB0831A12E00000000000011 /* BranchConfiguration+Private.h in Headers */,
+				BB0831A22E00000000000011 /* Branch+Configuration.h in Headers */,
 				5FCDD4A42B7AC6A200EAF29F /* BNCCallbacks.h in Headers */,
 				5FCDD4922B7AC6A100EAF29F /* BranchLinkProperties.h in Headers */,
 				5FCDD4C82B7AC6A200EAF29F /* BranchScene.h in Headers */,
@@ -1185,6 +1192,7 @@
 				E7FAF6A22E26E497006C167F /* BranchConstants.h in Headers */,
 				5FCDD52F2B7AC6A300EAF29F /* Branch+Validator.h in Headers */,
 				BB0831A12E00000000000012 /* BranchConfiguration+Private.h in Headers */,
+				BB0831A22E00000000000012 /* Branch+Configuration.h in Headers */,
 				5FCDD4A52B7AC6A200EAF29F /* BNCCallbacks.h in Headers */,
 				5FCDD4932B7AC6A100EAF29F /* BranchLinkProperties.h in Headers */,
 				5FCDD4C92B7AC6A200EAF29F /* BranchScene.h in Headers */,
@@ -1278,6 +1286,7 @@
 				5FCDD4BB2B7AC6A200EAF29F /* BranchPasteControl.h in Headers */,
 				5FCDD5302B7AC6A300EAF29F /* Branch+Validator.h in Headers */,
 				BB0831A12E00000000000013 /* BranchConfiguration+Private.h in Headers */,
+				BB0831A22E00000000000013 /* Branch+Configuration.h in Headers */,
 				5FCDD4A62B7AC6A200EAF29F /* BNCCallbacks.h in Headers */,
 				5FCDD4942B7AC6A100EAF29F /* BranchLinkProperties.h in Headers */,
 				5FCDD4CA2B7AC6A200EAF29F /* BranchScene.h in Headers */,

--- a/BranchSDKTests/BNCAPIServerTest.m
+++ b/BranchSDKTests/BNCAPIServerTest.m
@@ -12,6 +12,7 @@
 #import "BNCConfig.h"
 #import "BranchConstants.h"
 #import "Branch.h"
+#import "Branch+Configuration.h"
 
 @interface BNCAPIServerTest : XCTestCase
 

--- a/BranchSDKTests/BranchClassTests.m
+++ b/BranchSDKTests/BranchClassTests.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "Branch.h"
+#import "Branch+Configuration.h"
 #import "BranchConfiguration.h"
 #import "BranchConstants.h"
 #import "BNCPasteboard.h"

--- a/BranchSDKTests/BranchRequestDeepLinkTests.m
+++ b/BranchSDKTests/BranchRequestDeepLinkTests.m
@@ -11,6 +11,7 @@
 
 #import <XCTest/XCTest.h>
 #import "Branch.h"
+#import "Branch+Configuration.h"
 #import "BranchConfiguration.h"
 #import "BranchConstants.h"
 #import "BNCPreferenceHelper.h"

--- a/Sources/BranchSDK/Branch.m
+++ b/Sources/BranchSDK/Branch.m
@@ -168,9 +168,6 @@ void ForceCategoriesToLoad(void) {
 // Private method used internally
 - (void)clearLinkIdentifiers;
 
-+ (void)applyDeprecatedSettersFromConfiguration:(BranchConfiguration *)configuration
-                                        toBranch:(Branch *)branch;
-
 @end
 
 @implementation Branch
@@ -240,10 +237,6 @@ static BOOL bnc_didInitializeWithConfiguration = NO;
         bnc_didInitializeWithConfiguration = YES;
 
         // --- Settings that must be applied before the singleton is created ---
-        // These setters are deprecated for external callers, but +initialize: is their canonical
-        // internal application point, so suppress the deprecation warning at these call sites.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
         // Test key must be resolved before the branch key is read.
         [Branch setUseTestBranchKey:configuration.testMode];
@@ -252,8 +245,6 @@ static BOOL bnc_didInitializeWithConfiguration = NO;
         if (configuration.remoteInterface) {
             [Branch setNetworkServiceClass:configuration.remoteInterface];
         }
-
-#pragma clang diagnostic pop
 
         // Set the branch key explicitly so it takes precedence over Info.plist / branch.json.
         self.branchKey = configuration.branchKey;
@@ -290,12 +281,26 @@ static BOOL bnc_didInitializeWithConfiguration = NO;
 + (void)applyConfiguration:(BranchConfiguration *)configuration toBranch:(Branch *)branch {
     [Branch applyLoggingConfiguration:configuration];
 
-    [Branch applyDeprecatedSettersFromConfiguration:configuration toBranch:branch];
+    // Request tracing & custom endpoints
+    if (configuration.requestTracingCallback) {
+        [Branch setCallbackForTracingRequests:configuration.requestTracingCallback];
+    }
+    if (configuration.apiUrl) {
+        [Branch setAPIUrl:configuration.apiUrl];
+    }
+    if (configuration.safeTrackAPIUrl) {
+        [Branch setSafetrackAPIURL:configuration.safeTrackAPIUrl];
+    }
+
+    // Pasteboard
+    if (configuration.checkPasteboardOnInstall) {
+        [branch checkPasteboardOnInstall];
+    }
 
     // Identity & environment. These mutate the BNCServerAPI / BNCPreferenceHelper singletons, whose
     // values are read lazily at request time, so they don't need to precede singleton creation.
-    // Assigned rather than only turned on, so `euEndpoint = NO` can undo a prior -useEUEndpoints
-    // call. A configuration that never touches euEndpoint leaves the current routing alone.
+    // Assigned rather than only turned on, so `euEndpoint = NO` can undo a prior EU routing choice.
+    // A configuration that never touches euEndpoint leaves the current routing alone.
     if (configuration.euEndpointWasSet) {
         [BNCServerAPI sharedInstance].useEUServers = configuration.euEndpoint;
     }
@@ -304,16 +309,13 @@ static BOOL bnc_didInitializeWithConfiguration = NO;
     }
 
     // Network
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [branch setNetworkTimeout:configuration.networkTimeout];
-    
+
     [branch setMaxRetries:configuration.retryCount];
-    
+
     [branch setRetryInterval:configuration.retryInterval];
-    
+
     [Branch setSDKWaitTimeForThirdPartyAPIs:configuration.thirdPartyAPIsWaitTime];
-#pragma clang diagnostic pop
 
     // Privacy & attribution
     [branch disableAdNetworkCallouts:configuration.adNetworkCalloutsDisabled];
@@ -332,23 +334,18 @@ static BOOL bnc_didInitializeWithConfiguration = NO;
     }
 
     // URL collection
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (configuration.allowedSchemes.count > 0) {
         [branch setAllowedSchemes:configuration.allowedSchemes];
     }
     if (configuration.urlPatternsToIgnore.count > 0) {
         [branch setUrlPatternsToIgnore:configuration.urlPatternsToIgnore];
     }
-#pragma clang diagnostic pop
 
     // Request metadata
     for (NSString *key in configuration.requestMetadata) {
         [branch setRequestMetadataKey:key value:configuration.requestMetadata[key]];
     }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     // App Clip
     if (configuration.appClipAppGroup) {
         [branch setAppClipAppGroup:configuration.appClipAppGroup];
@@ -358,33 +355,11 @@ static BOOL bnc_didInitializeWithConfiguration = NO;
     if (configuration.deepLinkDebugParams) {
         [branch setDeepLinkDebugMode:configuration.deepLinkDebugParams];
     }
-#pragma clang diagnostic pop
 
     // Open tracking: when automatic open tracking is disabled the developer is responsible for -sendOpen.
     if (!configuration.automaticOpenEvents) {
         [Branch disableNextForegroundForTimeInterval:0];
     }
-}
-
-// Applies the setters below that are deprecated for external callers but still needed internally.
-+ (void)applyDeprecatedSettersFromConfiguration:(BranchConfiguration *)configuration
-                                        toBranch:(Branch *)branch {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    if (configuration.requestTracingCallback) {
-        [Branch setCallbackForTracingRequests:configuration.requestTracingCallback];
-    }
-    if (configuration.apiUrl) {
-        [Branch setAPIUrl:configuration.apiUrl];
-    }
-    if (configuration.safeTrackAPIUrl) {
-        [Branch setSafetrackAPIURL:configuration.safeTrackAPIUrl];
-    }
-    // Pasteboard
-    if (configuration.checkPasteboardOnInstall) {
-        [branch checkPasteboardOnInstall];
-    }
-#pragma clang diagnostic pop
 }
 
 - (id)initWithInterface:(BNCServerInterface *)interface
@@ -444,10 +419,6 @@ static BOOL bnc_didInitializeWithConfiguration = NO;
     [BranchConfigurationController sharedInstance].deferInitForPluginRuntime = self.deferInitForPluginRuntime;
 
 
-    // These setters are deprecated for external callers; the branch.json fallback path applies them
-    // internally, so suppress the deprecation warning at these call sites.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if (config.apiUrl) {
         [Branch setAPIUrl:config.apiUrl];
     }
@@ -459,7 +430,6 @@ static BOOL bnc_didInitializeWithConfiguration = NO;
     if (config.checkPasteboardOnInstall) {
         [self checkPasteboardOnInstall];
     }
-#pragma clang diagnostic pop
 
     if (config.cppLevel) {
         // Runs during singleton construction, so route through self rather than the shared accessor
@@ -628,12 +598,7 @@ static NSString *bnc_branchKey = nil;
         BranchJsonConfig *config = BranchJsonConfig.instance;
         BOOL usingTestInstance = bnc_useTestBranchKey || config.useTestInstance;
         branchKey = config.branchKey ?: usingTestInstance ? config.testKey : config.liveKey;
-        // +setUseTestBranchKey: is deprecated for external callers; this internal resolution path
-        // still needs it, so suppress the deprecation warning at this call site.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [self setUseTestBranchKey:usingTestInstance];
-#pragma clang diagnostic pop
 
         if (branchKey) {
             branchKeySource = BRANCH_KEY_SOURCE_CONFIG_JSON;
@@ -695,10 +660,6 @@ static NSString *bnc_branchKey = nil;
     if (callback) {
         logger.advancedLogCallback = callback;
     }
-}
-
-- (void)useEUEndpoints {
-    [BNCServerAPI sharedInstance].useEUServers = YES;
 }
 
 + (void)setAPIUrl:(NSString *)url {
@@ -830,12 +791,6 @@ static NSString *bnc_branchKey = nil;
     }
 }
 
-+ (void) setDMAParamsForEEA:(BOOL)eeaRegion AdPersonalizationConsent:(BOOL)adPersonalizationConsent AdUserDataUsageConsent:(BOOL)adUserDataUsageConsent{
-    [BNCPreferenceHelper sharedInstance].eeaRegion = eeaRegion;
-    [BNCPreferenceHelper sharedInstance].adPersonalizationConsent = adPersonalizationConsent;
-    [BNCPreferenceHelper sharedInstance].adUserDataUsageConsent = adUserDataUsageConsent;
-}
-
 + (void)setODMInfo:(NSString *)odmInfo andFirstOpenTimestamp:(NSDate *) firstOpenTimestamp {
 #if !TARGET_OS_TV
     @synchronized (self) {
@@ -901,10 +856,6 @@ static NSString *bnc_branchKey = nil;
 
 - (void)setAllowedSchemes:(NSArray *)schemes {
     self.allowedSchemeList = [schemes mutableCopy];
-}
-
-- (void)addAllowedScheme:(NSString *)scheme {
-    [self.allowedSchemeList addObject:scheme];
 }
 
 - (void)setUrlPatternsToIgnore:(NSArray<NSString*>*)urlsToIgnore {

--- a/Sources/BranchSDK/Private/BNCPasteboard.h
+++ b/Sources/BranchSDK/Private/BNCPasteboard.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  Indicates if the client wishes to check for Branch links on install. By default, this is NO.
  
- Set via Branch.checkPasteboardOnInstall
+ Set via BranchConfiguration.checkPasteboardOnInstall
  Checked by BranchInstallRequest.makeRequest before checking the pasteboard for a Branch link.
  */
 @property (nonatomic, assign) BOOL checkOnInstall;

--- a/Sources/BranchSDK/Private/Branch+Configuration.h
+++ b/Sources/BranchSDK/Private/Branch+Configuration.h
@@ -2,6 +2,8 @@
 //  Branch+Configuration.h
 //  BranchSDK
 //
+//  Created by Brandon Boothe on 9/9/26.
+//
 //  Copyright © 2026 Branch, Inc. All rights reserved.
 //
 

--- a/Sources/BranchSDK/Private/Branch+Configuration.h
+++ b/Sources/BranchSDK/Private/Branch+Configuration.h
@@ -1,0 +1,75 @@
+//
+//  Branch+Configuration.h
+//  BranchSDK
+//
+//  Copyright © 2026 Branch, Inc. All rights reserved.
+//
+
+#import "Branch.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Settings that are applied from a `BranchConfiguration` by `+[Branch initialize:]`.
+
+ The implementations live in the main `@implementation Branch` in `Branch.m`. They are declared
+ here rather than in `Branch.h` so they are reachable from inside the SDK and its tests without
+ being part of the public API.
+ */
+@interface Branch (Configuration)
+
+/**
+ Sets a custom base URL for all calls to the Branch API.
+
+ @param url  Base URL that the Branch API will use.
+ */
++ (void)setAPIUrl:(NSString *)url;
+
+/**
+ Sets a custom base safetrack URL for non-linking calls to the Branch API.
+
+ @param url  Base safetrack URL that the Branch API will use.
+ */
++ (void)setSafetrackAPIURL:(NSString *)url;
+
+/**
+ Sets an array of regex patterns that match URLs for Branch to ignore.
+
+ These are ICU standard regular expressions.
+
+ @param urlsToIgnore  Regex patterns matching URLs that must not be transmitted to Branch.
+ */
+- (void)setUrlPatternsToIgnore:(NSArray<NSString *> *)urlsToIgnore;
+
+/**
+ Checks the pasteboard (clipboard) for a Branch Link on App Install. If found, the Branch Link is
+ used to provide deferred deeplink data.
+
+ Note, this may display a toast message to the end user.
+ */
+- (void)checkPasteboardOnInstall;
+
+/**
+ Sets the AppGroup used to share data between the App Clip and the Full App.
+
+ @param appGroup  The app group identifier shared by the App Clip and the full app.
+ */
+- (void)setAppClipAppGroup:(NSString *)appGroup;
+
+/**
+ Sets the time to wait in seconds between retries in the case of a Branch server error.
+
+ @param retryInterval  Number of seconds to wait between retries.
+ */
+- (void)setRetryInterval:(NSTimeInterval)retryInterval;
+
+/**
+ Sets the amount of time before a request should be considered "timed out".
+
+ @param timeout  Number of seconds before a request is considered timed out.
+ */
+- (void)setNetworkTimeout:(NSTimeInterval)timeout;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/BranchSDK/Private/BranchConfiguration+Private.h
+++ b/Sources/BranchSDK/Private/BranchConfiguration+Private.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  `+[Branch initialize:]` uses this so that `euEndpoint = NO` reads as "route to the default
  endpoints" rather than "no opinion". Without it a configuration could only ever turn EU routing on,
- leaving no way to undo a prior `-[Branch useEUEndpoints]` call. A configuration that never touches
+ leaving no way to undo a prior EU routing choice. A configuration that never touches
  `euEndpoint` leaves `BNCServerAPI.useEUServers` alone.
  */
 @property (nonatomic, assign, readonly) BOOL euEndpointWasSet;

--- a/Sources/BranchSDK/Public/BNCNetworkServiceProtocol.h
+++ b/Sources/BranchSDK/Public/BNCNetworkServiceProtocol.h
@@ -37,9 +37,8 @@
     The `start` method is required, as are all the getters for request, response, error, and date
     data items.
 
- 3. In your app delegate, set your network class by calling `[Branch setNetworkServiceClass:]` with
-    your network class as a parameter. This method must be called before initializing the Branch 
-    shared object.
+ 3. In your app delegate, set `remoteInterface` on your `BranchConfiguration` to your network class
+    and pass that configuration to `+[Branch initialize:]`.
 
 */
 @protocol BNCNetworkOperationProtocol <NSObject>

--- a/Sources/BranchSDK/Public/Branch.h
+++ b/Sources/BranchSDK/Public/Branch.h
@@ -209,33 +209,11 @@ extern NSString * __nonnull const BNCSpotlightFeature;
 + (nullable instancetype)sharedInstance;
 
 /**
- Set the network service class.
-
- The class must conform to the `BNCNetworkServiceProtocol` and be a drop in replacement for the
- standard Branch SDK networking.
-
- This allows the use of Branch SDK with your own apps network service.
-
- The NetworkServiceClass can be set only once, before the Branch SDK initialization.
-
- @param networkServiceClass     The class to use as the network service class.
-*/
-+ (void)setNetworkServiceClass:(Class)networkServiceClass __attribute__((deprecated("This API is deprecated. Please set config.remoteInterface on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
  Return the Branch SDK network service class.
 
  @return Returns the network service class.
  */
 + (Class)networkServiceClass;
-
-/**
-    Sets Branch to use the test `key_test_...` Branch key found in the Info.plist.
-    This can only be set before `[Branch initialize:]` is called.
-
- @param useTestKey If YES then Branch to use the Branch test found in your app's Info.plist.
-*/
-+ (void)setUseTestBranchKey:(BOOL)useTestKey __attribute__((deprecated("This API is deprecated. Please set config.testMode = YES on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
 
 /// @return Returns true if the Branch test key should be used.
 + (BOOL)useTestBranchKey;
@@ -631,28 +609,6 @@ extern NSString * __nonnull const BNCSpotlightFeature;
 - (void)enableLoggingAtLevel:(BranchLogLevel)logLevel withCallback:(nullable BranchLogCallback)callback __attribute__((deprecated(("This API is deprecated. Please use the static version."))));
 
 /**
- Send requests to EU endpoints.
-
- This feature must also be enabled on the server side, otherwise the server will drop requests. Contact your account manager for details.
- */
-- (void)useEUEndpoints __attribute__((deprecated("This API is deprecated. Please set config.euEndpoint = YES on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
-Sets a custom base URL for all calls to the Branch API.
-@param url  Base URL that the Branch API will use.
-*/
-+ (void)setAPIUrl:(NSString *)url __attribute__((deprecated("This API is deprecated. Please set config.apiUrl on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
-Sets a custom base safetrack URL for non-linking calls to the Branch API.
-@param url  Base safetrack URL that the Branch API will use.
- */
-
-+ (void)setSafetrackAPIURL:(NSString *)url __attribute__((deprecated("This API is deprecated. Please set config.safeTrackAPIUrl on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-+ (void)setCallbackForTracingRequests: (callbackForTracingRequests) callback __attribute__((deprecated("This API is deprecated. Please set config.requestTracingCallback on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
   @brief        Use the `validateSDKIntegration` method as a debugging aid to assure that you've
                 integrated the Branch SDK correctly.
 
@@ -679,52 +635,6 @@ Sets a custom base safetrack URL for non-linking calls to the Branch API.
 - (void)validateSDKIntegration;
 
 /**
- Specify additional constant parameters to be included in the response
-
- @param debugParams dictionary of keystrings/valuestrings that will be added to response
- */
--(void)setDeepLinkDebugMode:(nullable NSDictionary *)debugParams __attribute__((deprecated("This API is deprecated. Please set config.deepLinkDebugParams on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
- Allow a URI scheme to be tracked by Branch. Default to all schemes.
-
- @param scheme URI scheme allowed to track, i.e. @"http", @"https" or @"myapp"
- */
--(void)addAllowedScheme:(nullable NSString *)scheme __attribute__((deprecated("This API is deprecated. Please use -[BranchConfiguration addAllowedScheme:] and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
- Allow an array of URI schemes to be tracked by Branch. Default to all schemes.
-
- @param schemes An array of URI schemes allowed to track, i.e. @[@"http", @"https", @"myapp"]
- */
--(void)setAllowedSchemes:(nullable NSArray *)schemes __attribute__((deprecated("This API is deprecated. Please use -[BranchConfiguration addAllowedScheme:] and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
- @brief     Sets an array of regex patterns that match URLs for Branch to ignore.
-
- @discusion Set this property to prevent URLs containing sensitive data such as oauth tokens,
-            passwords, login credentials, and other URLs from being transmitted to Branch.
-
-            The Branch SDK already ignores login URLs for Facebook, Twitter, Google, and many oauth
-            security URLs, so it's usually unnecessary to set this parameter yourself.
-
-            Set this parameter with any additional URLs that should be ignored by Branch.
-
-            These are ICU standard regular expressions.
-*/
-- (void)setUrlPatternsToIgnore:(NSArray<NSString *> *)urlsToIgnore __attribute__((deprecated("This API is deprecated. Please set config.urlPatternsToIgnore on BranchConfiguration and call +[Branch initialize:] instead.")));
-
-/**
- Checks the pasteboard (clipboard) for a Branch Link on App Install.
- If found, the Branch Link is used to provide deferred deeplink data.
- 
- This should be called before `+[Branch initialize:]`
-
- Note, this may display a toast message to the end user.
- */
-- (void)checkPasteboardOnInstall __attribute__((deprecated("This API is deprecated. Please set config.checkPasteboardOnInstall = YES on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
  Let's client know if the Branch SDK will trigger a pasteboard toast to the end user.
 
  All of the following conditions must be true.
@@ -734,13 +644,6 @@ Sets a custom base safetrack URL for non-linking calls to the Branch API.
  3. First time app is run with Branch SDK
  */
 - (BOOL)willShowPasteboardToast;
-
-/**
- Set the AppGroup used to share data between the App Clip and the Full App.
- 
- This must be set before `+[Branch initialize:]` is called.
- */
-- (void)setAppClipAppGroup:(NSString *)appGroup __attribute__((deprecated("This API is deprecated. Please set config.appClipAppGroup on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
 
 /**
  Pass the AppTrackingTransparency authorization status to Branch to measure ATT prompt performance.
@@ -780,35 +683,6 @@ Sets a custom base safetrack URL for non-linking calls to the Branch API.
  Clears all Partner Parameters
  */
 - (void)clearPartnerParameters;
-
-/**
- Specify the time to wait in seconds between retries in the case of a Branch server error
-
- @param retryInterval Number of seconds to wait between retries.
- */
-- (void)setRetryInterval:(NSTimeInterval)retryInterval __attribute__((deprecated("This API is deprecated. Please set config.retryInterval on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
- Specify the max number of times to retry in the case of a Branch server error
-
- @param maxRetries Number of retries to make.
- */
-- (void)setMaxRetries:(NSInteger)maxRetries __attribute__((deprecated("This API is deprecated. Please set config.retryCount on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
- Specify the amount of time before a request should be considered "timed out"
-
- @param timeout Number of seconds to before a request is considered timed out.
- */
-- (void)setNetworkTimeout:(NSTimeInterval)timeout __attribute__((deprecated("This API is deprecated. Please set config.networkTimeout on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
-
-/**
- Set the SDK wait time for third party APIs (for fetching ODM info and Apple Attribution Token) to finish
- This timeout should be > 0 and <= 10 seconds.
-
- @param waitTime Number of seconds before third party API calls are considered timed out. Default is 0.5 seconds (500ms).
- */
-+ (void)setSDKWaitTimeForThirdPartyAPIs:(NSTimeInterval)waitTime __attribute__((deprecated("This API is deprecated. Please set config.thirdPartyAPIsWaitTime on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
 
 /**
  Disable callouts to ad networks for all events for a user; by default Branch sends callouts to ad networks.
@@ -886,16 +760,6 @@ Sets a custom base safetrack URL for non-linking calls to the Branch API.
  @param validityWindow -(NSTimeInterval) number of seconds for which referrer_gbraid will be valid starting from now.
  */
 + (void) setReferrerGbraidValidityWindow:(NSTimeInterval) validityWindow;
-
-/*
-
- Sets the value of parameters required by Google Conversion APIs for DMA Compliance in EEA region.
-
- @param eeaRegion -(BOOL) If European regulations, including the DMA, apply to this user and conversion.
- @param adPersonalizationConsent - (BOOL) If End user has granted/denied ads personalization consent.
- @param adUserDataUsageConsent - (BOOL) If User has granted/denied consent for 3P transmission of user level data for ads
- */
-+ (void) setDMAParamsForEEA:(BOOL) eeaRegion AdPersonalizationConsent:(BOOL) adPersonalizationConsent AdUserDataUsageConsent:(BOOL) adUserDataUsageConsent __attribute__((deprecated("This API is deprecated. Please set config.dmaParameters on BranchConfiguration and call +[Branch initialize:config] instead. This function will be made non-public in a future release.")));
 
 /**
  Sets the ODM ( Fetched using Google framework - AppAdsOnDeviceConversion:fetchAggregateConversionInfoForInteraction ) info in SDK.

--- a/Sources/BranchSDK/Public/BranchConfiguration.h
+++ b/Sources/BranchSDK/Public/BranchConfiguration.h
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSString *apiUrl;
 
 /// Optional custom base URL for non-linking ("safe track") calls to the Branch API. Must start with
-/// `http://` or `https://`. Maps to `+[Branch setSafetrackAPIURL:]`.
+/// `http://` or `https://`.
 @property (nonatomic, copy, nullable) NSString *safeTrackAPIUrl;
 
 /// Optional custom base URL used for the CDN pattern list.
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) Class remoteInterface;
 
 /// SDK wait time in seconds for third-party APIs (ODM info, Apple Attribution Token). Must be > 0 and <= 10.
-/// Default matches the SDK default (0.5s). Maps to `+[Branch setSDKWaitTimeForThirdPartyAPIs:]`.
+/// Default matches the SDK default (0.5s).
 @property (nonatomic, assign) NSTimeInterval thirdPartyAPIsWaitTime;
 
 #pragma mark - Privacy & attribution
@@ -126,20 +126,19 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Pasteboard
 
 /// When YES, Branch checks the pasteboard (clipboard) for a Branch Link on app install, which may present
-/// the system paste-permission toast to the user. Equivalent to calling `-[Branch checkPasteboardOnInstall]`
-/// before init. Default NO.
+/// the system paste-permission toast to the user. Default NO.
 @property (nonatomic, assign) BOOL checkPasteboardOnInstall;
 
 #pragma mark - App Clip
 
-/// Optional App Group identifier used to share data between an App Clip and the full app. Maps to
-/// `-[Branch setAppClipAppGroup:]`, which must be set before the first session begins.
+/// Optional App Group identifier used to share data between an App Clip and the full app. Must be
+/// set before the first session begins.
 @property (nonatomic, copy, nullable) NSString *appClipAppGroup;
 
 #pragma mark - Debugging
 
-/// Optional constant parameters merged into every deep-link response, for debugging. Maps to
-/// `-[Branch setDeepLinkDebugMode:]`. Not for production use.
+/// Optional constant parameters merged into every deep-link response, for debugging.
+/// Not for production use.
 @property (nonatomic, copy, nullable) NSDictionary *deepLinkDebugParams;
 
 #pragma mark - Initialization


### PR DESCRIPTION
## Reference
EMT-4287 - Move Public APIs on BranchConfiguration to private class.

## Summary
<!-- Simple summary of what was changed. -->
Moving the previously deprecated APIs now used in BranchConfiguration to private files.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Type Of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
- Verify BranchConfiguration example in appDelegate still works by running app.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
